### PR TITLE
Add PR checks workflow for lint, tests, and build

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,41 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify Build, Lint, and Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: 🧰 Enable Corepack (Yarn v4)
+        run: |
+          corepack enable
+          corepack install
+
+      - name: 🏗️ Install Dependencies
+        run: yarn install --immutable
+
+      - name: ✅ Lint
+        run: yarn lint
+
+      - name: 🧪 Test
+        run: yarn test
+
+      - name: 🏗️ Build
+        run: yarn build


### PR DESCRIPTION
### Motivation

- Ensure every pull request targeting `main` verifies that the codebase still builds, passes lint, and runs unit tests before merging.
- Use the pinned Yarn v4 workflow via Corepack and enable concurrency cancellation so repeated updates to the same PR do not queue redundant runs.

### Description

- Add a new GitHub Actions workflow at `.github/workflows/pr-checks.yml` that runs on `pull_request` events for the `main` branch.
- The workflow performs `actions/checkout@v4`, sets up Node from the repository ` .nvmrc` via `actions/setup-node@v4`, enables Corepack and installs the pinned Yarn with `corepack enable` / `corepack install`, then installs dependencies with `yarn install --immutable`.
- The job runs the repository checks in sequence using `yarn lint`, `yarn test`, and `yarn build` and is configured to cancel in-progress runs for the same PR.

### Testing

- `corepack enable` + `corepack install` and `yarn install --immutable` were executed successfully in the environment and returned success.
- `yarn lint` ran successfully and reported formatted files matched Prettier.
- `yarn test` failed due to Jest configuration loading error: `Cannot find module '/workspace/.../node_modules/next/jest'` imported from `jest.config.ts` (test runner error), causing test step to fail.
- `yarn build` completed successfully and produced a compiled static export.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa59a60e08323978f1334fbb5d584)