### PR TITLE
ci: enable Yarn cache in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -16,19 +16,16 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v4
 
+      - name: 🧰 Enable Corepack shims
+        run: corepack enable
+
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - name: ♻️ Cache Yarn Berry cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.yarn/berry/cache
-          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn4-
-
           cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: 🧰 Activate pinned Yarn (Corepack)
           cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -20,6 +20,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+      - name: ♻️ Cache Yarn Berry cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.yarn/berry/cache
+          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
+
           cache: yarn
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,6 +22,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+      - name: ♻️ Cache Yarn Berry cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.yarn/berry/cache
+          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
+
           cache: yarn
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,19 +18,16 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v4
 
+      - name: 🧰 Enable Corepack shims
+        run: corepack enable
+
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - name: ♻️ Cache Yarn Berry cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.yarn/berry/cache
-          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn4-
-
           cache: yarn
+          cache-dependency-path: yarn.lock
+      - name: 🧰 Activate pinned Yarn (Corepack)
           cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)


### PR DESCRIPTION
### Motivation
- Speed up CI dependency installs by enabling Yarn caching in GitHub Actions and keep cache correctness tied to the lockfile for the repo's pinned `yarn@4.12.0` + Corepack flow.

### Description
- Added `cache: yarn` and `cache-dependency-path: yarn.lock` to the `actions/setup-node` `with:` block in both `.github/workflows/pr-checks.yml` and `.github/workflows/build-deploy.yml`.

### Testing
- Executed `corepack enable && corepack install && yarn --version` which returned `4.12.0`, and verified the workflow changes with `git diff` and `git status`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa7c738c88323b11b8e13b7ddce6f)