### PR TITLE
Refine About page credentials to be concise and contextual

### DIFF
--- a/src/app/about/_components/Credentials.tsx
+++ b/src/app/about/_components/Credentials.tsx
@@ -7,6 +7,11 @@ export function Credentials() {
     <section className="section-center">
       <Subtitle title="Credentials" id="credentials" />
 
+      <p className="mb-6 leading-relaxed text-gray-300">
+        My credentials ground how I think about technology: rigorous systems
+        design, accountable decision-making, and practical execution at scale.
+      </p>
+
       <div className="flex flex-col gap-6">
         {/* P.Eng. Credential */}
         <Card>
@@ -22,15 +27,14 @@ export function Credentials() {
                 </ExternalLink>
               </p>
               <p className="leading-relaxed text-gray-300">
-                Licensed Professional Engineer bringing engineering discipline,
-                ethics, and accountability to software development and AI
-                systems.
+                Licensed in Ontario. I apply engineering discipline and ethics
+                to software and AI systems.
               </p>
             </div>
           </div>
         </Card>
 
-        {/* Education Grid */}
+        {/* Education */}
         <div className="grid gap-8 md:grid-cols-2">
           {/* Georgia Tech */}
           <Card>
@@ -44,11 +48,6 @@ export function Credentials() {
                 MSECE, Electrical & Computer Engineering
               </p>
               <p className="text-gray-300">2013 - 2016</p>
-            </div>
-            <div className="mb-3">
-              <p className="text-lg font-medium text-gray-300">
-                4.0 / 4.0 CGPA
-              </p>
             </div>
             <div>
               <p className="text-sm text-gray-300">
@@ -70,13 +69,6 @@ export function Credentials() {
                 BASc, Electrical Engineering & Pure Mathematics
               </p>
               <p className="text-gray-300">2008 - 2013</p>
-            </div>
-            <div className="mb-3">
-              <p className="text-lg font-medium text-gray-300">92.3% CGPA</p>
-              <div className="text-sm text-accent-info">
-                <p>• With Distinction</p>
-                <p>• Dean&apos;s Honours List</p>
-              </div>
             </div>
             <div>
               <p className="text-sm text-gray-300">


### PR DESCRIPTION
### Motivation
- Implement recommendation B2 to keep credentials as concise, contextual trust signals that explain how they inform perspective without over-sharing details.

### Description
- Add a short contextual intro paragraph under the `Credentials` heading explaining how credentials shape thinking and decision-making.
- Shorten the P.Eng. copy to a compact, location-qualified trust statement and retain the external link to PEO in `src/app/about/_components/Credentials.tsx`.
- Remove GPA and honours detail from the education cards so each entry shows only institution, degree, years, and concentrations for faster scanning.

### Testing
- Ran environment setup and linting with `corepack enable`, `corepack install`, and `yarn lint`, which completed successfully.
- Exercised the running site and captured an automated screenshot using Playwright; Chromium launch in the container failed with a SIGSEGV, then the script was retried using Firefox and succeeded in producing the `about-credentials` screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990acc2e01883239a9a6a4158c1fdfe)