### PR TITLE
Improve mobile navigation active-state clarity

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -92,11 +92,11 @@
   }
 
   .mobile-nav-link {
-    @apply block px-8 py-4 text-xl transition-all hover:bg-white/5;
+    @apply block border-l-2 border-transparent px-8 py-4 text-xl transition-all hover:bg-white/5;
   }
 
   .mobile-nav-link--active {
-    @apply bg-white/10 font-semibold text-white;
+    @apply border-l-cyan-300 bg-white/15 font-semibold text-white;
   }
 
   .mobile-nav-link--inactive {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -69,20 +69,23 @@ export default function Header() {
 
           {/* Desktop Navigation */}
           <ul className="hidden gap-8 md:flex">
-            {navLinks.map((link) => (
-              <li key={link.href}>
-                <Link
-                  href={link.href}
-                  className={`nav-link ${
-                    isActive(link.href)
-                      ? "nav-link--active"
-                      : "nav-link--inactive"
-                  }`}
-                >
-                  {link.label}
-                </Link>
-              </li>
-            ))}
+            {navLinks.map((link) => {
+              const active = isActive(link.href);
+
+              return (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    aria-current={active ? "page" : undefined}
+                    className={`nav-link ${
+                      active ? "nav-link--active" : "nav-link--inactive"
+                    }`}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
 
           {/* Mobile Menu Button */}
@@ -124,32 +127,37 @@ export default function Header() {
         aria-hidden={!isMenuOpen}
       >
         <ul className="flex flex-col py-8">
-          {navLinks.map((link, index) => (
-            <li
-              key={link.href}
-              className={`transition-all duration-300 ${
-                isMenuOpen
-                  ? "translate-x-0 opacity-100"
-                  : "-translate-x-4 opacity-0"
-              }`}
-              style={{
-                transitionDelay: isMenuOpen ? `${index * 50}ms` : "0ms",
-              }}
-            >
-              <Link
-                href={link.href}
-                onClick={closeMenu}
-                className={`mobile-nav-link ${
-                  isActive(link.href)
-                    ? "mobile-nav-link--active"
-                    : "mobile-nav-link--inactive"
+          {navLinks.map((link, index) => {
+            const active = isActive(link.href);
+
+            return (
+              <li
+                key={link.href}
+                className={`transition-all duration-300 ${
+                  isMenuOpen
+                    ? "translate-x-0 opacity-100"
+                    : "-translate-x-4 opacity-0"
                 }`}
-                tabIndex={isMenuOpen ? 0 : -1}
+                style={{
+                  transitionDelay: isMenuOpen ? `${index * 50}ms` : "0ms",
+                }}
               >
-                {link.label}
-              </Link>
-            </li>
-          ))}
+                <Link
+                  href={link.href}
+                  onClick={closeMenu}
+                  aria-current={active ? "page" : undefined}
+                  className={`mobile-nav-link ${
+                    active
+                      ? "mobile-nav-link--active"
+                      : "mobile-nav-link--inactive"
+                  }`}
+                  tabIndex={isMenuOpen ? 0 : -1}
+                >
+                  {link.label}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       </div>
     </>

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -110,6 +110,19 @@ describe("Header", () => {
       const homeLinks = screen.getAllByText("Home");
       expect(homeLinks[0].closest("a")).toHaveClass("nav-link--active");
     });
+
+    it("should set aria-current on active links across desktop and mobile nav", () => {
+      (usePathname as jest.Mock).mockReturnValue("/about/");
+      render(<Header />);
+
+      const aboutLinks = screen.getAllByText("About");
+      expect(aboutLinks[0]).toHaveAttribute("aria-current", "page");
+      expect(aboutLinks[1]).toHaveAttribute("aria-current", "page");
+
+      const homeLinks = screen.getAllByText("Home");
+      expect(homeLinks[0]).not.toHaveAttribute("aria-current");
+      expect(homeLinks[1]).not.toHaveAttribute("aria-current");
+    });
   });
 
   describe("Accessibility", () => {


### PR DESCRIPTION
### Motivation

- Make the mobile navigation "you are here" state more visually obvious so visitors can tell which page is active on small screens. 
- Improve accessibility semantics by exposing the active link role to assistive tech via ARIA. 
- Keep behavior identical while reducing repeated work by computing each link's active state once during render.

### Description

- Add `aria-current="page"` to active navigation links in both desktop and mobile menus and compute `isActive` once per link in `src/components/Header.tsx` to avoid repeated checks. 
- Update mobile CSS in `src/app/globals.css` to add a subtle left accent border and slightly stronger active background (`border-l-2`/`border-l-cyan-300` + `bg-white/15`) for clearer visual indication. 
- Add a unit test in `src/components/__tests__/Header.test.tsx` that asserts `aria-current` appears only on active links (covers desktop and mobile instances). 
- Minor test formatting and lint fixes applied to keep repository style consistent.

### Testing

- Ran `yarn lint` (and `yarn lint:fix`) and confirmed formatting/linting passed successfully. 
- Built the site with `yarn build` and observed a successful static build of all routes. 
- Launched the dev server and captured a Playwright screenshot of the mobile menu to validate the visual active-state indicator. 
- Running `yarn test src/components/__tests__/Header.test.tsx` currently fails due to a repository Jest configuration/module resolution issue (`next/jest` import in `jest.config.ts`), not due to the new test assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ace1dd5083238694d2ca980654be)