### PR TITLE
Improve readability rhythm on About and Now pages

### DIFF
--- a/src/app/about/_components/Background.tsx
+++ b/src/app/about/_components/Background.tsx
@@ -19,41 +19,73 @@ export function Journey() {
 
           <div className="mb-6 flex items-start gap-3">
             <span className="mt-1 flex-shrink-0 text-xl">💼</span>
-            <p className="leading-relaxed">
-              Currently, I&apos;m at{" "}
-              <ExternalLink href="https://jetsonhome.com">Jetson</ExternalLink>,
-              electrifying North American homes with vertically integrated
-              energy solutions. My previous experience includes developing AR/AI
-              Glasses at{" "}
-              <ExternalLink href="https://arvr.google.com/">
-                Google
-              </ExternalLink>{" "}
-              and driving product engineering initiatives at{" "}
-              <ExternalLink href="https://cash.app/">Cash App</ExternalLink>.
-            </p>
+            <div>
+              <h3 className="text-heading-sm mb-2 font-semibold">What I Do</h3>
+              <div className="space-y-3 leading-relaxed">
+                <p>
+                  Currently, I&apos;m at{" "}
+                  <ExternalLink href="https://jetsonhome.com">
+                    Jetson
+                  </ExternalLink>
+                  , electrifying North American homes with vertically integrated
+                  energy solutions.
+                </p>
+                <p>
+                  Before that, I worked on AR/AI Glasses at{" "}
+                  <ExternalLink href="https://arvr.google.com/">
+                    Google
+                  </ExternalLink>{" "}
+                  and drove product engineering initiatives at{" "}
+                  <ExternalLink href="https://cash.app/">Cash App</ExternalLink>
+                  .
+                </p>
+              </div>
+            </div>
           </div>
 
           <div className="mb-6 flex items-start gap-3">
             <span className="mt-1 flex-shrink-0 text-xl">🚀</span>
-            <p className="leading-relaxed">
-              I build products from 0-1 and scale them from 1-100. My background
-              spans distributed systems, embedded systems, and AI. My approach
-              is simple:{" "}
-              <strong>Prioritize momentum, then optimize for scale.</strong>I
-              lean into ambiguity, decomposing large-scale challenges into
-              actionable technical roadmaps that keep teams aligned and moving
-              fast.
-            </p>
+            <div>
+              <h3 className="text-heading-sm mb-2 font-semibold">How I Work</h3>
+              <div className="space-y-3 leading-relaxed">
+                <p>
+                  I build products from 0-1 and help teams scale them from
+                  1-100.
+                </p>
+                <p>
+                  My background spans distributed systems, embedded systems, and
+                  AI. My approach is simple:
+                  <strong>
+                    {" "}
+                    prioritize momentum first, then optimize for scale.
+                  </strong>
+                </p>
+                <p>
+                  I lean into ambiguity and decompose complex problems into
+                  actionable technical roadmaps that keep teams aligned and
+                  moving fast.
+                </p>
+              </div>
+            </div>
           </div>
 
           <div className="mb-6 flex items-start gap-3">
             <span className="mt-1 flex-shrink-0 text-xl">❤️</span>
-            <p className="leading-relaxed">
-              What drives me is building things people love, getting stuff done,
-              and continuously learning. In my spare time, I enjoy playing
-              tennis 🎾, reading 📚, hiking 🏔️, rock climbing 🧗, and spending
-              time with furmily 🐱.
-            </p>
+            <div>
+              <h3 className="text-heading-sm mb-2 font-semibold">
+                Outside of Work
+              </h3>
+              <p className="mb-3 leading-relaxed">
+                What drives me is building things people love, getting stuff
+                done, and continuously learning.
+              </p>
+              <ul className="list-inside list-disc space-y-1 leading-relaxed">
+                <li>Tennis 🎾</li>
+                <li>Reading 📚</li>
+                <li>Hiking 🏔️ and rock climbing 🧗</li>
+                <li>Spending time with furmily 🐱</li>
+              </ul>
+            </div>
           </div>
         </div>
 

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -83,12 +83,12 @@ export default function NowPage() {
                 </h3>
                 <div className="space-y-3 leading-relaxed">
                   <p>
-                    I recently launched the blog section of this site! It's been
-                    a fun project to build a "boring" but effective static
-                    architecture to share my technical thoughts.
+                    I recently launched the blog section of this site. Building
+                    a "boring" but effective static architecture has been a fun
+                    way to share my technical thoughts.
                   </p>
                   <p>
-                    I'm also deeply intrigued by the recent viral rise of{" "}
+                    I&apos;m also deeply intrigued by the recent viral rise of{" "}
                     <ExternalLink href="https://moltbook.com">
                       Moltbook
                     </ExternalLink>{" "}
@@ -96,10 +96,18 @@ export default function NowPage() {
                     <ExternalLink href="https://github.com/openclaw/moltbot">
                       Moltbot
                     </ExternalLink>{" "}
-                    framework. The idea of autonomous agents having their own
-                    social network is both fascinating and a bit terrifying. I'm
-                    not willing to give it a try just yet.
+                    framework.
                   </p>
+                  <ul className="list-inside list-disc space-y-2 pl-1">
+                    <li>
+                      The idea of autonomous agents having their own social
+                      network is fascinating.
+                    </li>
+                    <li>
+                      It&apos;s also a little terrifying, so I&apos;m still
+                      observing from the sidelines.
+                    </li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -113,21 +121,26 @@ export default function NowPage() {
                 <h3 className="text-heading-sm mb-2 font-semibold">
                   Currently Reading
                 </h3>
-                <p className="leading-relaxed">
-                  I&apos;m almost done with Part 1 of the{" "}
-                  <ExternalLink href="https://www.deeplearningbook.org/">
-                    <em>Deep Learning</em>
-                  </ExternalLink>{" "}
-                  book by Goodfellow, Bengio, and Courville. It&apos;s been
-                  refreshing to touch on many math concepts I haven&apos;t used
-                  in years, and I&apos;m thinking of writing a blog post about
-                  my experience soon.{" "}
-                  <ExternalLink href="https://www.domainlanguage.com/ddd/">
-                    <em>Domain Driven Design</em>
-                  </ExternalLink>{" "}
-                  has been put on hold indefinitely—I&apos;m too enthralled by
-                  AI these days.
-                </p>
+                <div className="space-y-3 leading-relaxed">
+                  <p>
+                    I&apos;m almost done with Part 1 of{" "}
+                    <ExternalLink href="https://www.deeplearningbook.org/">
+                      <em>Deep Learning</em>
+                    </ExternalLink>{" "}
+                    by Goodfellow, Bengio, and Courville.
+                  </p>
+                  <p>
+                    It&apos;s been refreshing to revisit math concepts I
+                    haven&apos;t used in years. I&apos;m considering writing a
+                    blog post about the experience.
+                  </p>
+                  <p>
+                    <ExternalLink href="https://www.domainlanguage.com/ddd/">
+                      <em>Domain Driven Design</em>
+                    </ExternalLink>{" "}
+                    is on hold for now—I&apos;m too enthralled by AI these days.
+                  </p>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
### Motivation

- Improve scannability and reading rhythm on the About and Now pages to follow the C1 recommendation of shortening paragraphs, adding subheadings, and making key points easier to skim.
- Preserve existing content while surfacing high-level signals (what I do, how I work, interests) in a concise, non-sensitive format that supports a blog-first site.

### Description

- Reworked `src/app/about/_components/Background.tsx` to split dense narrative blocks into three scannable sections with subheadings: `What I Do`, `How I Work`, and `Outside of Work`, and converted hobbies into a short bullet list.
- Updated `src/app/now/page.tsx` to shorten long paragraphs in the `Top of Mind` and `Currently Reading` sections and added a compact bullet list to highlight key takeaways.
- Changes are purely presentational text/markup adjustments with no behavioral or routing changes.

### Testing

- Ran `yarn lint` (after `corepack enable && corepack install` and `yarn install`) and formatting checks passed successfully.
- Ran `yarn lint:fix` to apply automated formatting fixes and re-checked formatting successfully.
- Ran `yarn test --runInBand` which failed due to an existing Jest configuration/module resolution issue (`Cannot find module 'next/jest'`), unrelated to these copy/markup changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ad1897648323821a90555f715244)