### PR TITLE
Fix Jest config import path to next/jest.js

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'jest';
-import nextJest from 'next/jest';
+import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment


### PR DESCRIPTION
### Motivation
- Jest failed to start because `next/jest` could not be resolved in the project environment, preventing `yarn test` from running.

### Description
- Update `jest.config.ts` to import `nextJest` from `next/jest.js` instead of `next/jest`.

### Testing
- Ran `yarn test` which passed all test suites (13 suites, 49 tests); `yarn lint` reports a Prettier formatting issue in `src/components/__tests__/Hero.test.tsx` that is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b35e021483239dff4457628ddd9f)