### PR TITLE
Fix mobile home hero top spacing below fixed header

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,7 +7,7 @@ export function Hero() {
   return (
     <section
       id="home"
-      className="flex flex-grow items-center justify-center py-12"
+      className="flex flex-grow items-center justify-center pb-12 pt-[calc(var(--header-height)+1rem)] md:py-12"
     >
       <div className="section-center">
         <div>


### PR DESCRIPTION
### Motivation
- The home hero was partially covered by the fixed header on small screens after a recent change, so the hero needs header-aware top spacing on mobile to avoid overlap.

### Description
- Adjusted `src/components/Hero.tsx` to replace the global `py-12` with `pt-[calc(var(--header-height)+1rem)] pb-12 md:py-12` so mobile uses header-aware top padding while preserving desktop spacing.

### Testing
- Ran unit tests with `yarn test src/components/__tests__/Hero.test.tsx` which passed, ran `yarn lint` which passed, and verified the fix by launching the dev server and capturing a mobile viewport screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ba9cae6883239c8258cacf27a0b8)