### PR TITLE
Fix landscape side-edge background color fallback

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,10 @@
     --header-height: 4.5rem;
   }
 
+  html {
+    @apply bg-slate-950;
+  }
+
   * {
     @apply m-0 box-border p-0;
   }
@@ -17,7 +21,7 @@
   }
 
   body {
-    @apply relative font-lato leading-normal text-white;
+    @apply relative bg-transparent font-lato leading-normal text-white;
   }
 
   /* Background image overlay for better text readability */


### PR DESCRIPTION
### Motivation
- Landscape orientation on some browsers can reveal viewport gutters that showed a light/white background, breaking the intended dark background behind the fixed full-bleed background image.

### Description
- Add a dark fallback background to the `html` root (`@apply bg-slate-950`) and make `body` explicitly `bg-transparent` so the existing fixed background image layer continues to render as designed.

### Testing
- Ran `corepack enable && corepack install`, `yarn lint`, and captured a Playwright screenshot of `/about/` in a landscape viewport to validate the visual fix, and all steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d7a923048323ab52f7dbcf89a1f3)