### PR TITLE
Clean up Top of Mind section on Now page

### DIFF
--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -105,11 +105,11 @@ export default function NowPage() {
                     social network is fascinating (and a little terrifying).
                     I&apos;m observing for now instead of jumping in.
                   </p>
-                  <ul className="list-inside list-disc space-y-1">
-                    <li>Ship consistently on the blog</li>
-                    <li>Use tooling pragmatically to move faster</li>
-                    <li>Stay curious about emerging AI-native products</li>
-                  </ul>
+                  <p>
+                    Right now my priorities are simple: ship consistently on the
+                    blog, use tooling pragmatically to move faster, and stay
+                    curious about emerging AI-native products.
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Remove an out-of-place three-item bullet list in the Top of Mind section so the copy matches the surrounding narrative and preserves the same priorities.

### Description
- Replaced the three-item bulleted list with a single cohesive sentence in `src/app/now/page.tsx` under the "Top of Mind" section.

### Testing
- Ran `corepack enable && corepack install && yarn lint` and `yarn lint:fix`, which resulted in no remaining lint errors, and captured a Playwright screenshot of `/now/` for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bd64e1848323ad7cbf46f53286dd)