### PR TITLE
Add blog-post-tone skill and smooth opening for orchestrator post

### DIFF
--- a/content/posts/from-coder-to-orchestrator.md
+++ b/content/posts/from-coder-to-orchestrator.md
@@ -6,11 +6,9 @@ excerpt: "How my AI workflow changed from quick snippets to a practical plan/imp
 coverImage: "/assets/blog/from-coder-to-orchestrator/cover.webp"
 ---
 
-I haven’t hand-written a `for` loop for my day job in months.
+Over the past two years, my day-to-day work has shifted from direct implementation toward orchestration and verification. In early 2024, I used AI mostly for autocomplete-level tasks such as snippets, error explanations, and small refactors. By 2026, I still write code when needed, but far more of my time goes to defining tasks clearly, checking outputs, and fixing edge cases the agents miss.
 
-In early 2024, I used AI mostly for autocomplete-level tasks: snippets, error explanations, and small refactors. In 2026, I still write code when needed, but most of my time goes to defining tasks, checking outputs, and fixing edge cases the agents miss.
-
-This post is a practical summary of what changed and what still doesn’t work well.
+This post summarizes what changed, what improved, and what remains unreliable in that transition.
 
 ![Timeline diagram comparing software development workflow in 2024 versus 2026](/assets/blog/from-coder-to-orchestrator/swe-workflow-evolution.webp)
 

--- a/skills/blog-post-tone/SKILL.md
+++ b/skills/blog-post-tone/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: blog-post-tone
+description: Use when drafting or revising blog posts to match Alex Leung's preferred tone: analytical and executive, warm but concise, and explicitly not LinkedIn-style one-sentence paragraph cadence.
+---
+
+# Blog Post Tone Skill
+
+Use this skill whenever the user asks to write or edit blog content in Alex's house style.
+
+## Target Voice
+
+- Analytical, structured, and practical.
+- Warm but understated: confident, relationship-aware, forward-looking.
+- Professional prose with emotional intelligence.
+- Avoid theatrics, hype language, and performative emphasis.
+
+## Hard Constraints
+
+1. Do **not** use repeated one-sentence paragraphs as the dominant cadence.
+2. Default to cohesive paragraphs that carry one clear claim with supporting detail.
+3. Prefer specific trade-offs, mechanisms, and implications over slogans.
+4. Keep the writing concise: remove filler, throat-clearing, and redundant qualifiers.
+
+## Drafting Workflow
+
+1. **Frame the thesis** in 1–2 sentences (problem, point of view, scope).
+2. **Organize by reasoning** (context → decision/process → trade-offs → takeaway).
+3. **Merge choppy lines** into coherent paragraphs unless a list genuinely improves clarity.
+4. **Add grounded detail** (examples, constraints, outcomes, caveats).
+5. **Tone pass**: replace punchy social-post phrasing with measured professional language.
+6. **Cadence pass**: ensure paragraph lengths vary naturally but are mostly multi-sentence.
+
+## Self-Review Checklist
+
+Before finalizing, confirm:
+
+- The piece reads as a cohesive argument, not a thread.
+- Paragraphs are mostly multi-sentence and logically connected.
+- Claims are backed by context, not just assertion.
+- Trade-offs and limitations are explicit.
+- The close is forward-looking and concrete.
+
+## Quick Rewrite Patterns
+
+- Convert hook-only opening lines into a thesis + context paragraph.
+- Combine adjacent short paragraphs that express one idea.
+- Replace broad praise/critique with specific criteria.
+- Turn "hot take" phrasing into "observation + evidence + implication."


### PR DESCRIPTION
### Motivation

- Codify a consistent house style for blog posts so generated or edited content follows an analytical, warm, and concise voice rather than short, punchy social-post cadence. 
- Improve the lead of the existing post to replace choppy one-line paragraphs with a cohesive introduction that better frames the thesis and scope.

### Description

- Add a new Codex skill at `skills/blog-post-tone/SKILL.md` that documents the target voice, hard constraints, a drafting workflow, a self-review checklist, and quick rewrite patterns. 
- Revise the opening of `content/posts/from-coder-to-orchestrator.md` to merge the short, punchy lines into a clear 1–2 sentence thesis and a single follow-up summary sentence while preserving the original meaning. 
- No other content or site configuration changes were made.

### Testing

- Ran `corepack enable && corepack install` to ensure the pinned Yarn version was available and the command completed successfully. 
- Ran `yarn lint` and confirmed formatting/lint checks passed. 
- Launched the dev server with `yarn dev` and observed the site start successfully for local verification. 
- Executed a Playwright screenshot script against the updated post page and produced a visual artifact for confirmation. 
- Ran `curl -I https://example.com` as a basic connectivity check which returned `200 OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69911252a6688323817764da2cf6006f)