### PR TITLE
feat: implement fixes for architecture audit items 1-3

### DIFF
--- a/docs/technical-architecture-audit.md
+++ b/docs/technical-architecture-audit.md
@@ -1,0 +1,255 @@
+# Technical Architecture & Pattern Audit (2026-02-14)
+
+## Executive Summary
+
+The site is in a good state for a personal content platform: modern stack (Next.js App Router + TypeScript), sensible static-export deployment, solid SEO/structured-data foundations, and CI checks for lint/test/build.
+
+The highest-leverage improvements are:
+
+1. **Strengthen content typing and validation** in the blog data layer to reduce runtime risk and improve maintainability.
+2. **Tighten build/runtime consistency** between local and production static export behavior.
+3. **Improve performance architecture** (image strategy, font loading, and route-level payload discipline).
+4. **Expand quality gates** (type-check step, E2E smoke checks, and architecture guardrails).
+5. **Reduce coupling between content/config and rendering** for cleaner long-term evolution.
+
+## Current Architecture Snapshot
+
+### Platform & Deployment
+
+- Next.js 16 App Router with React 19 and TypeScript.
+- Static export for production/GitHub Pages via `output: 'export'` and trailing slashes.
+- CI runs lint, tests, and build on PRs and main pushes.
+
+### App Structure
+
+- Route-centric layout under `src/app/`.
+- Shared components in `src/components/`.
+- Content constants in `src/constants/`.
+- Markdown posts in `content/posts/` parsed at build time.
+
+### Data & Content Flow
+
+- Blog post metadata/content is loaded from the filesystem.
+- Markdown is converted to HTML and injected into article pages.
+- Sitemap generation derives blog URLs from post metadata.
+
+## What Is Working Well
+
+1. **Static architecture is deployment-appropriate** for a content-first site and keeps operational complexity very low.
+2. **SEO baseline is strong** with metadata + JSON-LD + sitemap in place.
+3. **Codebase is clean and approachable** for a solo-maintained portfolio.
+4. **Component modularity is generally good**, with route-specific and shared component separation.
+5. **Testing culture exists** (unit/component tests and coverage threshold).
+
+## Holistic Findings & Recommended Improvements
+
+## 1) Reliability & Type Safety
+
+### Finding
+
+The blog data API uses loose types (`[key: string]: string`) and implicit assumptions around front matter values and date formats.
+
+### Why this matters
+
+- Runtime issues are more likely when metadata evolves (new fields, missing fields, malformed dates).
+- Weak types make refactoring and feature expansion (tags, reading time, related posts) slower.
+
+### Recommendation
+
+- Introduce a strict post schema type (e.g., `PostFrontMatter`, `PostSummary`, `PostDetail`).
+- Validate front matter with a schema library (e.g., Zod) during build.
+- Parse and normalize dates once in the data layer.
+
+### Priority
+
+**High**
+
+---
+
+## 2) Build Environment Consistency
+
+### Finding
+
+`next.config.js` conditionally enables static export only in production mode.
+
+### Why this matters
+
+- Local `yarn build` behavior can diverge depending on environment variables.
+- Subtle deployment regressions are easier to miss when local build semantics differ.
+
+### Recommendation
+
+- Prefer explicit, deterministic behavior for build outputs in all build contexts.
+- Consider always setting `output: 'export'` (if no server-only features are needed).
+- Add a CI assertion that `out/` generation contains expected critical routes.
+
+### Priority
+
+**High**
+
+---
+
+## 3) Performance Architecture (Core Web Vitals)
+
+### Finding
+
+- Blog and page images are rendered with raw `<img>` and limited intrinsic sizing strategy.
+- Global font is imported via CSS `@import` from Google Fonts.
+
+### Why this matters
+
+- Can increase CLS/LCP risk and reduce caching/perf efficiency.
+- CSS `@import` for fonts can delay font discovery and adds a third-party dependency on first paint.
+
+### Recommendation
+
+- Migrate to `next/image` where static-export-compatible, or enforce width/height and lazy-loading consistently for `<img>`.
+- Move font loading to `next/font` for better preload/subsetting and privacy/perf gains.
+- Add a lightweight Lighthouse budget in CI (at least for homepage + one blog post).
+
+### Priority
+
+**High**
+
+---
+
+## 4) Security Posture for Markdown Rendering
+
+### Finding
+
+Markdown is rendered into HTML and injected via `dangerouslySetInnerHTML`.
+
+### Why this matters
+
+- Even if source content is trusted today, future contributors or copied content can introduce unsafe HTML patterns.
+- Defense-in-depth is useful for long-lived content pipelines.
+
+### Recommendation
+
+- Add explicit sanitation policy (`rehype-sanitize`) in the markdown pipeline.
+- Define an allowlist for tags/attributes needed for code blocks, links, and typography.
+- Add regression tests for script/style/event-handler stripping.
+
+### Priority
+
+**Medium-High**
+
+---
+
+## 5) Lint/Formatting Guardrail Coverage
+
+### Finding
+
+Prettier glob patterns in scripts target `{src,app,components}/...`, but `app` and `components` live under `src/`.
+
+### Why this matters
+
+- Intended files outside the matched set (if any) may not be checked/formatted consistently.
+- Guardrails become less trustworthy over time.
+
+### Recommendation
+
+- Simplify to `prettier --check .` with explicit ignore file, or correct globs to match actual structure.
+- Add dedicated `yarn typecheck` script and run it in CI.
+
+### Priority
+
+**Medium**
+
+---
+
+## 6) Content Model Evolution Readiness
+
+### Finding
+
+Post model is minimal (title/date/excerpt/cover/slug/content) and not yet structured for taxonomy-driven growth.
+
+### Why this matters
+
+- Upcoming features (tags, related posts, series pages, RSS enhancements) benefit from a richer normalized content schema.
+
+### Recommendation
+
+- Add optional front matter fields now: `updated`, `tags`, `readingTime`, `draft`, `canonicalUrl`.
+- Centralize content transformations into one module that emits typed view models.
+- Consider generating a build-time content index JSON for faster page generation.
+
+### Priority
+
+**Medium**
+
+---
+
+## 7) UI Architecture & Accessibility Patterns
+
+### Finding
+
+UI composition is mostly clean, but some behaviors (mobile menu, route hash scroll) are imperative and spread across components.
+
+### Why this matters
+
+- Harder to reason about interaction state as features grow.
+- A11y regressions can creep in without centralized patterns.
+
+### Recommendation
+
+- Extract reusable hooks/utilities for common browser effects (`useLockBodyScroll`, `useSmoothHashScroll`).
+- Add an accessibility check pass in CI (axe-based test for primary routes).
+- Standardize semantic landmarks/headings checklist for each page template.
+
+### Priority
+
+**Medium**
+
+---
+
+## 8) Observability & Runtime Feedback
+
+### Finding
+
+Current architecture has strong build checks but little production telemetry.
+
+### Why this matters
+
+- Hard to prioritize improvements without real user/performance data.
+
+### Recommendation
+
+- Add privacy-friendly analytics and Web Vitals collection.
+- Track simple KPIs: top pages, referrers, outbound clicks, 404s.
+- Review monthly to guide content and performance investments.
+
+### Priority
+
+**Medium**
+
+## Suggested Roadmap
+
+### Phase 1 (Quick Wins: 1-2 days)
+
+1. Fix lint/Prettier glob strategy and add `yarn typecheck`.
+2. Define strict TypeScript types for blog front matter and returned post objects.
+3. Add/standardize `updated` in post metadata and date normalization.
+
+### Phase 2 (Hardening: 2-4 days)
+
+1. Add markdown sanitization and tests.
+2. Move fonts to `next/font`.
+3. Improve image rendering strategy (intrinsic sizes/lazy-loading or `next/image`).
+
+### Phase 3 (Scale Readiness: 1 week, incremental)
+
+1. Introduce tags/series/related-post architecture.
+2. Add E2E smoke tests for core routes.
+3. Add lightweight analytics + Web Vitals pipeline.
+
+## Architecture Principles to Preserve
+
+- Keep static-first deployment and low-ops simplicity.
+- Keep route-level ownership clear (App Router structure is good).
+- Keep SEO/entity modeling as a first-class concern.
+- Keep writing/content throughput high; avoid over-engineering.
+
+## Final Assessment
+
+Overall maturity is **strong for a personal publishing platform**: clear structure, modern stack, and good baseline quality practices. With targeted improvements to typing, performance, and guardrails, the project can become notably more resilient and easier to evolve without increasing operational burden.

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: process.env.NODE_ENV === "production" ? "export" : undefined,
+  output: "export",
   trailingSlash: true,
   images: {
     unoptimized: true,
+  },
+  experimental: {
+    turbopackUseSystemTlsCerts: true,
   },
 };
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { JsonLd } from "react-schemaorg";
 
 import { Metadata } from "next";
+import Image from "next/image";
 import { notFound } from "next/navigation";
 
 import { format } from "date-fns";
@@ -144,9 +145,12 @@ export default async function Post({ params }: Props) {
             </div>
             {post.coverImage && (
               <div className="mb-6 sm:mx-0 md:mb-10">
-                <img
+                <Image
                   src={post.coverImage}
                   alt={`Cover for ${post.title}`}
+                  width={1200}
+                  height={630}
+                  sizes="(min-width: 1024px) 896px, 100vw"
                   className="aspect-[21/9] w-full rounded-lg object-cover shadow-sm"
                 />
               </div>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import { JsonLd } from "react-schemaorg";
 
 import { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 
 import { format } from "date-fns";
@@ -104,12 +105,14 @@ export default function BlogIndex() {
                 aria-label={post.title}
               >
                 <div className="mb-5">
-                  {/* Placeholder for cover image if I decide to add next/image later */}
                   {post.coverImage && (
                     <div className="mb-4 h-48 w-full overflow-hidden rounded-lg bg-gray-800">
-                      <img
+                      <Image
                         src={post.coverImage}
                         alt={`Cover for ${post.title}`}
+                        width={1200}
+                        height={630}
+                        sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
                         className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
                       />
                     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -21,7 +20,7 @@
   }
 
   body {
-    @apply relative bg-transparent font-lato leading-normal text-white;
+    @apply relative bg-transparent leading-normal text-white;
   }
 
   /* Background image overlay for better text readability */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from "react";
 import { JsonLd } from "react-schemaorg";
 
 import type { Metadata, Viewport } from "next";
+import { Lato } from "next/font/google";
 
 import * as schemadts from "schema-dts";
 
@@ -15,6 +16,12 @@ import "./globals.css";
 const title = "Alex Leung | Syntropy Engineer and Programmer, P.Eng.";
 const description =
   "Personal website of Alex Leung, a Syntropy Engineer and Programmer, featuring writing on software, systems, and learning in public.";
+
+const lato = Lato({
+  subsets: ["latin"],
+  weight: ["400", "900"],
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: title,
@@ -199,7 +206,7 @@ function buildWebSiteSchema(): schemadts.WithContext<schemadts.WebSite> {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
-      <body className="flex min-h-screen flex-col">
+      <body className={`${lato.className} flex min-h-screen flex-col`}>
         <JsonLd item={buildPersonSchema()} />
         <JsonLd item={buildWebSiteSchema()} />
         <div className="fixed inset-0 -z-10 h-screen bg-[url('/assets/background.webp')] bg-cover bg-center bg-no-repeat after:absolute after:inset-0 after:bg-black/50"></div>

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -4,15 +4,58 @@ import { join } from "path";
 
 const postsDirectory = join(process.cwd(), "content/posts");
 
-export function getPostSlugs() {
-  return fs.readdirSync(postsDirectory);
-}
+const POST_FIELDS = [
+  "slug",
+  "title",
+  "date",
+  "updated",
+  "excerpt",
+  "coverImage",
+  "content",
+] as const;
 
-type Items = {
-  [key: string]: string;
+type PostField = (typeof POST_FIELDS)[number];
+
+export type Post = {
+  slug: string;
+  title: string;
+  date: string;
+  updated?: string;
+  excerpt?: string;
+  coverImage?: string;
+  content: string;
 };
 
-export function getPostBySlug(slug: string, fields: string[] = []) {
+function isPostField(value: string): value is PostField {
+  return POST_FIELDS.includes(value as PostField);
+}
+
+function assertValidDate(date: string, slug: string, key: "date" | "updated") {
+  if (Number.isNaN(Date.parse(date))) {
+    throw new Error(`Invalid ${key} in post "${slug}": ${date}`);
+  }
+}
+
+function readString(
+  data: Record<string, unknown>,
+  key: string,
+  slug: string,
+  required = false
+): string | undefined {
+  const value = data[key];
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (required) {
+    throw new Error(`Missing required front matter key "${key}" in ${slug}.md`);
+  }
+
+  return undefined;
+}
+
+function parsePostBySlug(slug: string): Post | null {
   const realSlug = slug.replace(/\.md$/, "");
   const fullPath = join(postsDirectory, `${realSlug}.md`);
 
@@ -22,32 +65,99 @@ export function getPostBySlug(slug: string, fields: string[] = []) {
 
   const fileContents = fs.readFileSync(fullPath, "utf8");
   const { data, content } = matter(fileContents);
+  const frontMatter = data as Record<string, unknown>;
 
-  const items: Items = {};
+  const title = readString(frontMatter, "title", realSlug, true);
+  const date = readString(frontMatter, "date", realSlug, true);
+  const updated = readString(frontMatter, "updated", realSlug);
+  const excerpt = readString(frontMatter, "excerpt", realSlug);
+  const coverImage = readString(frontMatter, "coverImage", realSlug);
 
-  // Ensure only the minimal needed data is exposed
-  fields.forEach((field) => {
-    if (field === "slug") {
-      items[field] = realSlug;
-    }
-    if (field === "content") {
-      items[field] = content;
-    }
+  assertValidDate(date!, realSlug, "date");
 
-    if (typeof data[field] !== "undefined") {
-      items[field] = data[field];
-    }
-  });
+  if (updated) {
+    assertValidDate(updated, realSlug, "updated");
+  }
 
-  return items;
+  return {
+    slug: realSlug,
+    title: title!,
+    date: new Date(date!).toISOString(),
+    updated: updated ? new Date(updated).toISOString() : undefined,
+    excerpt,
+    coverImage,
+    content,
+  };
 }
 
-export function getAllPosts(fields: string[] = []) {
-  const slugs = getPostSlugs();
-  const posts = slugs
-    .map((slug) => getPostBySlug(slug, fields))
-    .filter((post): post is Items => post !== null)
-    // sort posts by date in descending order
-    .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
-  return posts;
+function pickPostFields<T extends PostField>(
+  post: Post,
+  fields: readonly T[]
+): Pick<Post, T> {
+  return fields.reduce(
+    (acc, field) => {
+      acc[field] = post[field] as Pick<Post, T>[T];
+
+      return acc;
+    },
+    {} as Pick<Post, T>
+  );
+}
+
+export function getPostSlugs() {
+  return fs.readdirSync(postsDirectory);
+}
+
+export function getPostBySlug(slug: string): Post | null;
+export function getPostBySlug<T extends PostField>(
+  slug: string,
+  fields: readonly T[]
+): Pick<Post, T> | null;
+export function getPostBySlug<T extends PostField>(
+  slug: string,
+  fields?: readonly T[]
+) {
+  const post = parsePostBySlug(slug);
+
+  if (!post) {
+    return null;
+  }
+
+  if (!fields || fields.length === 0) {
+    return post;
+  }
+
+  const invalidField = fields.find((field) => !isPostField(field));
+
+  if (invalidField) {
+    throw new Error(`Unsupported post field requested: ${invalidField}`);
+  }
+
+  return pickPostFields(post, fields);
+}
+
+export function getAllPosts(): Post[];
+export function getAllPosts<T extends PostField>(
+  fields: readonly T[]
+): Array<Pick<Post, T>>;
+export function getAllPosts<T extends PostField>(fields?: readonly T[]) {
+  const posts = getPostSlugs()
+    .map((slug) => parsePostBySlug(slug))
+    .filter((post): post is Post => post !== null)
+    .sort(
+      (post1, post2) =>
+        new Date(post2.date).getTime() - new Date(post1.date).getTime()
+    );
+
+  if (!fields || fields.length === 0) {
+    return posts;
+  }
+
+  const invalidField = fields.find((field) => !isPostField(field));
+
+  if (invalidField) {
+    throw new Error(`Unsupported post field requested: ${invalidField}`);
+  }
+
+  return posts.map((post) => pickPostFields(post, fields));
 }


### PR DESCRIPTION
### Motivation
- Address the top three findings from the technical architecture audit: strengthen blog content typing/validation, make static builds deterministic across environments, and improve font/image loading for performance.
- Reduce runtime risk from malformed front-matter and inconsistent date handling by centralizing parsing and validation in the content layer.
- Eliminate build flakiness related to remote Google Font fetches during Turbopack builds and enable a deterministic static export for GitHub Pages.

### Description
- Refactored `src/lib/blogApi.ts` to introduce a typed `Post`/`PostField` model, add front-matter validation helpers (`readString`, `assertValidDate`), normalize dates to ISO, and provide typed overloads for `getPostBySlug` and `getAllPosts` using a `pickPostFields` helper.
- Updated `next.config.js` to always use `output: "export"` and enabled `experimental.turbopackUseSystemTlsCerts` to stabilize font fetching in Turbopack/CI environments.
- Migrated font loading from a CSS `@import` to `next/font/google` (`Lato`) in `src/app/layout.tsx` and removed the remote `@import` from `src/app/globals.css`, applying the font via `lato.className` on the root `<body>`.
- Replaced raw `<img>` elements for blog cover images with `next/image` on both the blog index and individual post pages, adding explicit `width`/`height` and responsive `sizes` attributes to improve LCP/CLS behavior.
- Applied Prettier/ESLint fixes where required to satisfy linting rules and keep formatting consistent.

### Testing
- Ran `corepack enable && corepack install && yarn lint` and fixes were applied where necessary, after which `yarn lint` reported success.
- Ran `yarn test --runInBand` and all unit/component tests passed (13 suites, 49 tests).
- Ran `yarn build` and a production build completed successfully with Turbopack after enabling system TLS certs.
- Started `yarn dev` and validated the blog page rendering; a headless screenshot was captured as an automated smoke check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990dc25a7dc8323a3301dfff9104d7c)