### PR TITLE
Refine interactive card affordances and shared surface styles

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -100,7 +100,7 @@ export default function BlogIndex() {
               <Link
                 key={post.slug}
                 href={`/blog/${post.slug}`}
-                className="group mb-8 block rounded-xl border border-white/10 bg-black/40 p-6 backdrop-blur-sm transition-all hover:border-white/30"
+                className="surface-interactive group mb-8 block rounded-xl bg-black/40 p-6"
                 aria-label={post.title}
               >
                 <div className="mb-5">
@@ -118,12 +118,16 @@ export default function BlogIndex() {
                 <h3 className="mb-3 text-2xl font-bold leading-snug text-white transition-colors group-hover:text-accent-link">
                   {post.title}
                 </h3>
-                <div className="mb-4 text-sm text-gray-400">
+                <div className="mb-4 text-sm text-gray-300">
                   {format(new Date(post.date), "MMMM d, yyyy")}
                 </div>
-                <p className="mb-4 text-base leading-relaxed text-gray-300">
+                <p className="mb-4 text-base leading-relaxed text-gray-200 md:text-gray-300">
                   {post.excerpt}
                 </p>
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-accent-link transition-colors group-hover:text-accent-link-hover">
+                  Read article
+                  <span aria-hidden="true">→</span>
+                </span>
               </Link>
             ))}
           </div>

--- a/src/app/contact/_components/SocialMediaList.tsx
+++ b/src/app/contact/_components/SocialMediaList.tsx
@@ -13,7 +13,7 @@ export function SocialMediaList() {
             target="_blank"
             rel="noopener noreferrer me"
             aria-label={link.label}
-            className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 px-6 py-4 transition-all hover:border-white/30 hover:bg-white/10"
+            className="surface-interactive flex items-center gap-3 px-6 py-4"
           >
             <span className="text-2xl">{link.icon}</span>
             <span className="text-body">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,7 +17,7 @@
   }
 
   img {
-    @apply w-full;
+    @apply h-auto max-w-full;
   }
 
   body {
@@ -138,5 +138,16 @@
 
   .text-hero-description {
     @apply text-lg md:text-2xl;
+  }
+
+  /* Surface primitives */
+  .surface-static {
+    @apply rounded-lg border border-white/10 bg-white/5 backdrop-blur-sm;
+  }
+
+  .surface-interactive {
+    @apply rounded-lg border border-white/10 bg-white/5 backdrop-blur-sm transition-all duration-200;
+    @apply cursor-pointer hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 hover:shadow-lg;
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-link focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950;
   }
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -10,8 +10,7 @@ export interface CardProps {
  * @param className - Additional custom classes to apply
  */
 export function Card({ children, className = "" }: CardProps) {
-  const baseStyles =
-    "p-6 rounded-lg backdrop-blur-sm border bg-white/5 border-white/10";
+  const baseStyles = "surface-static p-6";
 
   return <div className={`${baseStyles} ${className}`}>{children}</div>;
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -47,7 +47,7 @@ export function Hero() {
           </div>
           <section
             aria-labelledby="positioning-heading"
-            className="mt-10 max-w-3xl animate-showTopText rounded-xl border border-white/10 bg-black/20 p-6 opacity-0 backdrop-blur-sm md:p-8"
+            className="surface-static mt-10 max-w-3xl animate-showTopText rounded-xl bg-black/20 p-6 opacity-0 md:p-8"
             style={{ animationDelay: "0.8s", animationFillMode: "forwards" }}
           >
             <h2 id="positioning-heading" className="text-heading font-semibold">

--- a/src/components/__tests__/Card.test.tsx
+++ b/src/components/__tests__/Card.test.tsx
@@ -7,7 +7,7 @@ describe("Card", () => {
     const { container } = render(<Card>Test content</Card>);
 
     expect(screen.getByText("Test content")).toBeInTheDocument();
-    expect(container.firstChild).toHaveClass("p-6", "rounded-lg", "border");
+    expect(container.firstChild).toHaveClass("surface-static", "p-6");
   });
 
   it("should merge custom className with base styles", () => {


### PR DESCRIPTION
### Motivation
- Reduce interaction ambiguity across the site by distinguishing static surfaces from fully interactive card surfaces as recommended in the UX audit. 
- Prevent unintended visual side-effects from a global `img { width: 100% }` rule that can stretch images in rich content.

### Description
- Introduced CSS surface primitives `surface-static` and `surface-interactive` in `src/app/globals.css` to centralize visual semantics for static vs interactive containers. 
- Updated the reusable `Card` component to use `surface-static` for non-interactive content in `src/components/Card.tsx`. 
- Converted blog cards and social media links to use `surface-interactive`, increased metadata/excerpt contrast, and added an explicit `Read article →` action cue in `src/app/blog/page.tsx` and `src/app/contact/_components/SocialMediaList.tsx`. 
- Replaced the global `img` reset with `max-width: 100%` and `height: auto` to avoid unintended stretching, and updated the hero info panel to use the static surface in `src/components/Hero.tsx`. 
- Updated the `Card` unit test expectation to reflect the new base class contract in `src/components/__tests__/Card.test.tsx`.

### Testing
- Ran `corepack enable && corepack install` successfully to ensure the pinned Yarn version was available. 
- Ran `yarn lint` which reported formatting checks passed. 
- Ran `yarn test` and all test suites completed successfully (`13` test suites, `49` tests passed). 
- Started the dev server and performed a manual visual check of `/blog/`, capturing a screenshot artifact to validate the interactive affordances visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69911dfc30b883239a046ae5c7dc69ec)