### PR TITLE
Tune responsive typography scales across breakpoints

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,11 +58,11 @@
 
   /* Section Spacing Utilities */
   .section-title {
-    @apply mx-auto my-12 flex justify-center text-2xl md:text-4xl;
+    @apply mx-auto my-12 flex justify-center text-2xl md:text-3xl lg:text-4xl;
   }
 
   .section-subtitle {
-    @apply mx-auto my-8 flex justify-center text-xl md:text-2xl;
+    @apply mx-auto my-8 flex justify-center text-xl md:text-xl lg:text-2xl;
   }
 
   /* Subtitle Divider Lines */
@@ -108,11 +108,11 @@
 
   /* Responsive Text Sizing Utilities */
   .text-body-sm {
-    @apply text-sm lg:text-base;
+    @apply text-sm md:text-base;
   }
 
   .text-body {
-    @apply text-base lg:text-lg;
+    @apply text-base;
   }
 
   .text-body-lg {
@@ -120,23 +120,23 @@
   }
 
   .text-heading-sm {
-    @apply text-lg lg:text-xl;
+    @apply text-lg;
   }
 
   .text-heading {
-    @apply text-xl lg:text-2xl;
+    @apply text-xl;
   }
 
   .text-hero-subtitle {
-    @apply text-lg md:text-xl;
+    @apply text-lg md:text-lg lg:text-xl;
   }
 
   .text-hero-title {
-    @apply text-4xl md:text-8xl;
+    @apply text-4xl md:text-7xl lg:text-8xl;
   }
 
   .text-hero-description {
-    @apply text-lg md:text-2xl;
+    @apply text-lg md:text-xl lg:text-2xl;
   }
 
   /* Surface primitives */


### PR DESCRIPTION
### Motivation
- Desktop and tablet typography felt oversized compared to mobile due to abrupt large-screen upsizing in global utilities, particularly the hero title and section headings.
- Smooth responsive scaling was needed so mobile retains its current rhythm while larger screens scale more gradually.

### Description
- Adjusted responsive typography in `src/app/globals.css` to soften large-screen jumps for core utilities and headings by changing several Tailwind `@apply` steps (e.g. `section-title`, `section-subtitle`, `text-body-*`, `text-heading-*`, `text-hero-*`).
- Specifically, `section-title` now uses `text-2xl md:text-3xl lg:text-4xl`, `section-subtitle` uses `text-xl md:text-xl lg:text-2xl`, `text-hero-title` uses `text-4xl md:text-7xl lg:text-8xl`, and body/heading utilities removed aggressive `lg:`/`xl:` upscales.
- The changes keep mobile sizes unchanged while making tablet→desktop transitions smoother and less heavy.

### Testing
- Ran dependency setup with `corepack enable && corepack install` and `yarn install` which completed successfully.
- Ran linting with `yarn lint` which passed with Prettier formatting OK.
- Ran the test suite with `yarn test --runInBand` and all test suites passed (`13` suites, `49` tests).
- Used Playwright scripts to sample computed `font-size`/`line-height` at mobile/tablet/desktop breakpoints and confirmed the hero/title jumps were reduced and tablet sizing is more balanced (measurements validated visually with screenshots).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699127f9fa688323b9f163368b019d30)