### PR TITLE
Increase homepage hero spacing below fixed header

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,7 +7,7 @@ export function Hero() {
   return (
     <section
       id="home"
-      className="flex flex-grow items-center justify-center pb-12 pt-[calc(var(--header-height)+1rem)] md:py-12"
+      className="flex flex-grow items-center justify-center pb-12 pt-[calc(var(--header-height)+1.5rem)] md:pb-12 md:pt-[calc(var(--header-height)+3rem)]"
     >
       <div className="section-center">
         <div>


### PR DESCRIPTION
### Motivation
- The hero content was sitting too close below the fixed header, so increase the top offset to improve visual separation on page load.

### Description
- Updated `src/components/Hero.tsx` to increase the hero top padding from `pt-[calc(var(--header-height)+1rem)]` to `pt-[calc(var(--header-height)+1.5rem)]` and replaced `md:py-12` with explicit `md:pb-12` and `md:pt-[calc(var(--header-height)+3rem)]` to preserve header offset at desktop breakpoints.

### Testing
- Ran `yarn lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69912ad5f7f083239164ba4ed762a641)