### PR TITLE
Fix home hero overlap with fixed header on wide/short viewports

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,7 +7,7 @@ export function Hero() {
   return (
     <section
       id="home"
-      className="flex flex-grow items-center justify-center pb-12 pt-[calc(var(--header-height)+1rem)] md:py-12"
+      className="flex flex-grow items-center justify-center pb-12 pt-[calc(var(--header-height)+1rem)] md:pb-12"
     >
       <div className="section-center">
         <div>


### PR DESCRIPTION
### Motivation
- Prevent the fixed header from overlapping the Hero content on wide-but-short viewports by keeping the header-offset top padding applied at all breakpoints.

### Description
- Preserve `pt-[calc(var(--header-height)+1rem)]` on the Hero section and replace the previous `md:py-12` override with `md:pb-12` so medium+ screens only adjust bottom padding.

### Testing
- Ran `yarn lint` and `yarn test --runInBand`, and all checks and test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913110b59c8323809566b401b393cf)