### PR TITLE
Refine About page visuals: static surface, bullets, and photo

### DIFF
--- a/src/app/about/_components/Background.tsx
+++ b/src/app/about/_components/Background.tsx
@@ -83,15 +83,6 @@ export function Journey() {
 
         <div className="flex flex-col gap-4 md:gap-6">
           <Image
-            src="/assets/about_portrait_mountain.webp"
-            alt="Alex Leung on a scenic mountain overlook, enjoying the outdoors and mountain views during a hiking adventure"
-            width={400}
-            height={267}
-            loading="lazy"
-            placeholder="blur"
-            blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAhEAACAQMDBQAAAAAAAAAAAAABAgMABAUGIWGRkqGx0f/EABUBAQEAAAAAAAAAAAAAAAAAAAMF/8QAGhEAAgIDAAAAAAAAAAAAAAAAAAECEgMRkf/aAAwDAQACEQMRAD8AltJagyeH0AthI5xdrLcNM91BF5pX2HaH9bcfaSXWGaRmknyLDSEsAy2kZTNL4a4VNPgABNVMm1kEhQXEmQr/AMHkABFxXjQW0iyRwwq"
-          />
-          <Image
             src="/assets/about_portrait.webp"
             alt="Alex Leung standing on a mountain trail during a hiking adventure, wearing outdoor gear and smiling at the camera"
             width={400}

--- a/src/app/about/_components/TechnicalInterests.tsx
+++ b/src/app/about/_components/TechnicalInterests.tsx
@@ -7,12 +7,9 @@ export function Skills({ className }: { className?: string }) {
       <Subtitle title="Technical Interests" id="technicalinterests" />
       <div className={`text-md flex flex-col lg:text-lg ${className}`}>
         Here are a few technical areas that I enjoy working in:
-        <ul className="mt-4 grid list-none grid-cols-1 gap-x-4 p-0 lg:grid-cols-4">
+        <ul className="mt-4 grid list-inside list-disc grid-cols-1 gap-x-4 lg:grid-cols-4">
           {skills.map(({ skill }) => (
-            <li
-              key={skill}
-              className="relative mb-3 pl-6 leading-6 before:absolute before:left-0 before:top-0 before:text-base before:content-['■']"
-            >
+            <li key={skill} className="mb-3 leading-6">
               {skill}
             </li>
           ))}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,7 +141,7 @@
 
   /* Surface primitives */
   .surface-static {
-    @apply rounded-lg border border-white/10 bg-white/5 backdrop-blur-sm;
+    @apply rounded-lg border border-white/15 bg-slate-900/65 shadow-sm;
   }
 
   .surface-interactive {


### PR DESCRIPTION
### Motivation
- Make non-clickable surfaces visually distinct from interactive CTAs so users can more easily tell what is clickable. 
- Ensure list markers are consistent across the About page by using standard circular bullets. 
- Simplify the About page layout by keeping only one portrait image to reduce visual clutter.

### Description
- Adjusted the non-interactive surface style by changing `.surface-static` in `src/app/globals.css` to use `bg-slate-900/65`, a lighter border (`border-white/15`), and a small shadow (`shadow-sm`) to create a subtler, higher-contrast matte look. 
- Replaced the custom square glyph list in `src/app/about/_components/TechnicalInterests.tsx` with a standard `list-disc`/`list-inside` layout and removed the `before:content` square glyph to restore circular bullets. 
- Removed the first portrait image from `src/app/about/_components/Background.tsx` so only the second portrait (`/assets/about_portrait.webp`) remains on the About page. 

### Testing
- Ran `yarn lint` and the lint/Prettier checks completed successfully. 
- Ran `yarn test --runInBand` and all test suites passed (`13` suites, `49` tests). 
- Ran `yarn build` and the Next.js static build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991360d6b208323af301a0f5c8a9e5a)