### PR TITLE
Refine humble framing in About credentials section

### DIFF
--- a/src/app/about/_components/Credentials.tsx
+++ b/src/app/about/_components/Credentials.tsx
@@ -8,8 +8,8 @@ export function Credentials() {
       <Subtitle title="Credentials" id="credentials" />
 
       <p className="mb-6 leading-relaxed text-gray-300">
-        My credentials ground how I think about technology: rigorous systems
-        design, accountable decision-making, and practical execution at scale.
+        I try to bring rigor, accountability, and pragmatism to technology work,
+        shaped by my training and experience.
       </p>
 
       <div className="flex flex-col gap-6">


### PR DESCRIPTION
### Motivation
- Make the About > Credentials intro copy more humble and grounded in tone while preserving the intent that training and experience inform the author's approach to technology.

### Description
- Replace the original intro sentence in `src/app/about/_components/Credentials.tsx` with: `I try to bring rigor, accountability, and pragmatism to technology work, shaped by my training and experience.`

### Testing
- Ran `yarn lint:fix` which applied formatting fixes and completed successfully.
- Ran `yarn lint` which verifies Prettier/ESLint formatting and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991df5bd6cc83239a04d791a0bbd468)