### PR TITLE
Add Open Graph/Twitter cover image support for blog pages

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -33,7 +33,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const description =
     post.excerpt || `Read ${post.title} on Alex Leung's blog.`;
   const url = `${BASE_URL}/blog/${params_awaited.slug}`;
-  const images = post.coverImage ? [post.coverImage] : [];
+  const coverImageUrl = post.coverImage
+    ? new URL(post.coverImage, BASE_URL).toString()
+    : undefined;
+  const images = coverImageUrl ? [coverImageUrl] : undefined;
   const publishedTime = new Date(post.date).toISOString();
   const modifiedTime = new Date(post.updated || post.date).toISOString();
 
@@ -50,7 +53,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       modifiedTime,
     },
     twitter: {
-      card: "summary_large_image",
+      card: coverImageUrl ? "summary_large_image" : "summary",
       title,
       description,
       images,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -17,26 +17,37 @@ const description =
   "Thoughts on software engineering, product development, and life as a developer.";
 const url = `${BASE_URL}/blog/`;
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
+export function generateMetadata(): Metadata {
+  const posts = getAllPosts(["coverImage"]);
+  const firstCoverImage = posts.find((post) => post.coverImage)?.coverImage;
+  const image = firstCoverImage
+    ? new URL(firstCoverImage, BASE_URL).toString()
+    : undefined;
+  const images = image ? [image] : undefined;
+
+  return {
     title: title,
     description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-  },
-};
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      title: title,
+      description: description,
+      type: "website",
+      url: url,
+      siteName: "Alex Leung",
+      locale: "en_CA",
+      images,
+    },
+    twitter: {
+      card: image ? "summary_large_image" : "summary",
+      title: title,
+      description: description,
+      images,
+    },
+  };
+}
 
 export default function BlogIndex() {
   const allPosts = getAllPosts([


### PR DESCRIPTION
### Motivation
- Ensure blog post and index pages include proper Open Graph and Twitter metadata and use a post's `coverImage` when available for richer social previews.
- Make the Twitter card type conditional so pages without a cover fall back to a standard `summary` card while pages with a cover use `summary_large_image`.

### Description
- Resolve per-post `coverImage` to an absolute URL and include it in Open Graph and Twitter `images` when present in `src/app/blog/[slug]/page.tsx`.
- Make the Twitter `card` value conditional on the presence of a cover image in `src/app/blog/[slug]/page.tsx`.
- Convert the `/blog` index metadata from a static `metadata` export to a `generateMetadata()` function that selects the first available post cover (if any) and populates Open Graph/Twitter `images` and the `card` type in `src/app/blog/page.tsx`.
- Use `new URL(..., BASE_URL).toString()` to build absolute image URLs and ensure metadata fields fall back gracefully when no image exists.

### Testing
- Ran `corepack enable && corepack install` and `yarn install` to prepare the environment, and both completed successfully.
- Ran `yarn lint` after installing dependencies and it passed successfully.
- Ran `yarn test` and all test suites passed (`13` test suites, `49` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f01bc53c83239c4827b091ede638)