### PR TITLE
feat: validate blog front matter with zod schema

### DIFF
--- a/content/posts/boring-blog-architecture.md
+++ b/content/posts/boring-blog-architecture.md
@@ -4,6 +4,11 @@ date: "2026-01-31"
 updated: "2026-02-14"
 excerpt: "How I added a fully static, markdown-based blog to my Next.js portfolio."
 coverImage: "/assets/blog/boring-blog-architecture/cover.jpg"
+tags:
+  - "Next.js"
+  - "Architecture"
+  - "Blogging"
+
 ---
 
 I recently finished implementing the blog section of this personal website. Rather than reaching for a complex CMS, I decided to build it directly into my existing Next.js application using standard tools.

--- a/content/posts/deep-learning-part-1-review.md
+++ b/content/posts/deep-learning-part-1-review.md
@@ -4,6 +4,10 @@ date: "2026-02-07"
 updated: "2026-02-14"
 excerpt: "Thoughts on the mathematical foundations section of Goodfellow, Bengio, and Courville's Deep Learning textbook."
 coverImage: "/assets/blog/deep-learning-part-1-review/cover.webp"
+tags:
+  - "Deep Learning"
+  - "Book Notes"
+
 ---
 
 I recently finished Part I of _Deep Learning_ by Goodfellow, Bengio, and Courville. It was a clear and efficient primer on the mathematical preliminaries needed to engage more deeply with the subject. I appreciated the refresher in linear algebra, probability, and numerical computation, which helped reestablish important foundations. In places, I found myself wishing for more proofs—or at least proof sketches—as I often wanted to understand where results came from rather than accept them at face value.

--- a/content/posts/from-coder-to-orchestrator.md
+++ b/content/posts/from-coder-to-orchestrator.md
@@ -4,6 +4,10 @@ date: "2026-02-03"
 updated: "2026-02-14"
 excerpt: "How my AI workflow changed from quick snippets to a practical plan/implement/verify loop."
 coverImage: "/assets/blog/from-coder-to-orchestrator/cover.webp"
+tags:
+  - "AI Engineering"
+  - "Developer Workflow"
+
 ---
 
 Over the past two years, my day-to-day work has shifted from direct implementation toward orchestration and verification. In early 2024, I used AI mostly for autocomplete-level tasks such as snippets, error explanations, and small refactors. By 2026, I still write code when needed, but far more of my time goes to defining tasks clearly, checking outputs, and fixing edge cases the agents miss.

--- a/content/posts/structural-reasoning-about-deep-networks.md
+++ b/content/posts/structural-reasoning-about-deep-networks.md
@@ -4,6 +4,11 @@ date: "2026-02-15"
 updated: "2026-02-15"
 excerpt: "Chapter 6 sharpened how I think about architecture as a structural assumption, not just a tuning choice."
 coverImage: "/assets/blog/structural-reasoning-about-deep-networks/cover.webp"
+tags:
+  - "Deep Learning"
+  - "Neural Networks"
+  - "ML Theory"
+
 ---
 
 Working through Chapter 6, _Deep Feedforward Networks_, sharpened how I reason about neural networks. It did not expand my practical toolkit so much as refine my conceptual boundaries. After completing coursework like the DeepLearning.AI specialization, I was comfortable training multilayer perceptrons and reasoning about gradients. What this chapter clarified is that architecture is not just a tuning dimension—it is a structural assumption about the function class we are willing to search.

--- a/docs/technical-architecture-audit.md
+++ b/docs/technical-architecture-audit.md
@@ -1,55 +1,129 @@
-# Technical Architecture Audit (2026-02-15)
+# Technical Architecture Audit (2026-02-16)
 
 ## Executive Summary
 
-The architecture is solid for a static personal publishing site: App Router structure is clean, static export is deterministic, and test/lint/build checks are in place. Most high-priority items from the previous audit are now resolved.
+The site architecture is in a strong position for a static, content-first personal website. The current stack (Next.js App Router + static export + Markdown pipeline) is appropriately simple, low-ops, and maintainable.
 
-Current focus should move from baseline hardening to content model maturity and quality-of-life improvements.
+The best next improvements are no longer foundational setup tasks; they are **resilience, maintainability, and measured performance improvements**:
+
+1. Harden and type the content pipeline end-to-end (front matter schema + sanitized Markdown rendering).
+2. Tighten quality gates (dedicated typecheck script and CI caching strategies).
+3. Introduce architecture boundaries for long-term growth (content model, route modules, and metadata utilities).
+4. Add runtime and build observability appropriate to static deployments.
 
 ## Current Snapshot
 
 - **Framework**: Next.js 16 + React 19 + TypeScript
 - **Deployment model**: Static export (`output: 'export'`) with trailing slashes for GitHub Pages
 - **Content model**: Markdown posts with front matter parsed at build time
+- **Rendering model**: Static route generation for dynamic blog slugs
 - **Quality gates**: ESLint + Prettier checks, Jest test suite, CI build validation
 
-## Findings Status
+## Architectural Strengths
 
-| Area | Status | Notes |
-| --- | --- | --- |
-| Static export consistency | Done | `next.config.js` always exports statically; no env-conditional behavior. |
-| SEO/metadata baseline | Done | Layout metadata, per-route metadata, JSON-LD, and sitemap are implemented. |
-| Crawler directives | Done | `robots.ts` exists and declares sitemap/crawl policy. |
-| Markdown rendering safety | Open | Rendering pipeline should still add explicit sanitization (`rehype-sanitize`) for defense in depth. |
-| Content typing strictness | Open | Blog front matter remains relatively loose for future taxonomy fields. |
-| Performance architecture | Open | Font/image strategy can be tightened for better CWV resilience. |
-| CI quality gates | In progress | Lint/test/build are present; adding explicit typecheck script would improve coverage. |
+### 1) Deployment Simplicity and Determinism
 
-## Recommended Next Steps
+- `output: 'export'` and `trailingSlash: true` align with GitHub Pages behavior.
+- Unoptimized Next image setting avoids incompatible runtime image optimization requirements for static hosting.
 
-### 1) Harden Markdown Rendering (High)
+### 2) Clean Route-Scoped Organization
 
-- Add `rehype-sanitize` to the markdown pipeline.
-- Keep an explicit allowlist for code blocks, links, and typography tags.
-- Add regression tests for unsafe HTML stripping.
+- App Router pages are organized by route (`about`, `blog`, `contact`, `now`) with local `_components` where useful.
+- Shared components remain centralized in `src/components`, which keeps cross-route reuse straightforward.
 
-### 2) Strengthen Content Schema (High)
+### 3) SEO Baseline Is Strong
 
-- Introduce strict post front matter types (`title`, `date`, `updated`, `excerpt`, `tags`, `cover`).
-- Validate front matter during build and fail early on malformed content.
-- Normalize date parsing in one data-layer module.
+- Root layout metadata is comprehensive (Open Graph, Twitter, canonical, manifest).
+- Structured data is implemented for both Person and Website entities.
+- Blog posts include metadata generation and article JSON-LD.
+- `robots.ts` and `sitemap.ts` are present and static-friendly.
 
-### 3) Improve Build Guardrails (Medium)
+### 4) Solid Test Foundation
 
-- Add `yarn typecheck` and run it in CI.
-- Simplify Prettier scope to avoid blind spots (e.g., check repo-wide with ignore rules).
+- Jest + React Testing Library coverage is in place with global thresholds.
+- Alias mapping keeps test imports maintainable.
 
-### 4) Improve Performance Defaults (Medium)
+## Architecture Risks and Improvement Opportunities
 
-- Continue enforcing explicit width/height and lazy-loading for images.
-- Evaluate `next/font` usage for font loading and privacy/performance benefits.
+### A) Markdown Rendering Trust Boundary (High)
+
+Current Markdown rendering transforms to HTML and injects it with `dangerouslySetInnerHTML` at render time. This is normal for Markdown blogs, but should include explicit sanitization to guard against unsafe HTML if content origin changes.
+
+**Recommendation**
+
+- Add `rehype-sanitize` with an explicit schema allowlist for:
+  - headings, paragraphs, emphasis, lists
+  - links with safe protocols
+  - code/pre blocks needed for syntax highlighting
+- Add tests for malicious payload stripping and allowed-code rendering parity.
+
+### B) Front Matter Schema Drift Risk (High)
+
+The blog data layer validates key strings and dates, but schema evolution (tags, categories, canonical URL, reading time, draft flag) could become brittle without a first-class validator.
+
+**Recommendation**
+
+- Introduce `zod` (or similar) schema validation in `blogApi`.
+- Validate fields during static build and fail with actionable messages.
+- Add optional fields now with stable defaults (`tags`, `readingTimeMinutes`, `draft`).
+
+### C) Tooling Guardrail Gap: No Explicit Typecheck Script (Medium)
+
+TypeScript strict mode is enabled, but there is no dedicated `yarn typecheck` script to enforce static type health in CI as a first-class step.
+
+**Recommendation**
+
+- Add `"typecheck": "tsc --noEmit"`.
+- Run `lint`, `typecheck`, `test`, and `build` in CI with cached Yarn dependencies.
+
+### D) Metadata/SEO Duplication Pressure (Medium)
+
+Metadata and JSON-LD are robust, but they are currently authored across route files and can drift as content scale grows.
+
+**Recommendation**
+
+- Extract reusable metadata builders into `src/lib/seo/*`.
+- Centralize canonical URL and image derivation logic.
+- Keep route files focused on content composition.
+
+### E) Performance Budget Not Yet Explicit (Medium)
+
+The site has good baseline choices, but no explicit performance budget or regression checks (Lighthouse CI / bundle checks).
+
+**Recommendation**
+
+- Add a lightweight Lighthouse CI check on homepage + one blog page.
+- Define thresholds for LCP/TBT/CLS and enforce in PR CI.
+- Optionally add `@next/bundle-analyzer` for periodic dependency/bundle review.
+
+## Proposed Improvement Roadmap
+
+### Phase 1 (1–2 days): Security + Correctness
+
+1. Add sanitized Markdown pipeline + tests.
+2. Add strict front matter schema validation with clear build errors.
+3. Add `yarn typecheck` and include in CI.
+
+### Phase 2 (2–4 days): Maintainability
+
+1. Extract SEO helpers into `src/lib/seo`.
+2. Formalize blog post model with extensible fields.
+3. Add content authoring lint checks (required front matter fields).
+
+### Phase 3 (half day): Performance Governance
+
+1. Add Lighthouse CI for two representative pages.
+2. Capture current baseline and enforce non-regression thresholds.
+3. Add optional bundle-size reporting for major dependency changes.
+
+## Suggested Success Metrics
+
+- Zero unsanitized HTML vectors in markdown regression tests.
+- 100% of posts validated against typed schema during build.
+- CI pipeline includes `lint + typecheck + test + build` and passes on default branch.
+- Lighthouse performance score >= 95 on homepage and latest blog post.
 
 ## Audit Maintenance Notes
 
-- Update this file after dependency upgrades that affect routing/rendering/build output.
-- Close or remove findings once shipped to keep the document actionable.
+- Update this file after framework upgrades or content-model changes.
+- Track roadmap items by moving completed items into a short changelog section.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-icons": "^5.3.0",
-    "react-schemaorg": "^2.0.0"
+    "react-schemaorg": "^2.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -23,6 +23,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     "coverImage",
     "date",
     "updated",
+    "tags",
   ]);
 
   if (!post) {
@@ -58,6 +59,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       description,
       images,
     },
+    keywords: post.tags.length > 0 ? post.tags : undefined,
     alternates: {
       canonical: url,
     },
@@ -88,6 +90,7 @@ export default async function Post({ params }: Props) {
     "content",
     "coverImage",
     "excerpt",
+    "tags",
   ]);
 
   if (!post) {
@@ -113,6 +116,7 @@ export default async function Post({ params }: Props) {
           url: `${BASE_URL}/blog/${post.slug}`,
           headline: post.title,
           description: post.excerpt,
+          keywords: post.tags.length > 0 ? post.tags.join(", ") : undefined,
           image: post.coverImage
             ? [`${BASE_URL}${post.coverImage}`]
             : undefined,
@@ -143,9 +147,21 @@ export default async function Post({ params }: Props) {
         <Title title={post.title} />
         <article className="container mx-auto mb-12 px-5">
           <div className="surface-static mx-auto max-w-3xl p-4 md:p-8">
-            <div className="mb-6 text-lg text-gray-300">
+            <div className="mb-3 text-lg text-gray-300">
               {format(new Date(post.date), "MMMM d, yyyy")}
             </div>
+            {post.tags.length > 0 && (
+              <div className="mb-6 flex flex-wrap gap-2">
+                {post.tags.map((tag) => (
+                  <span
+                    key={`${post.slug}-${tag}`}
+                    className="rounded-full border border-white/20 px-2.5 py-1 text-xs font-semibold text-gray-200"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
             {post.coverImage && (
               <div className="mb-6 sm:mx-0 md:mb-10">
                 <Image

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -56,6 +56,7 @@ export default function BlogIndex() {
     "slug",
     "coverImage",
     "excerpt",
+    "tags",
   ]);
 
   return (
@@ -138,6 +139,18 @@ export default function BlogIndex() {
                 <p className="mb-4 text-base leading-relaxed text-gray-200 md:text-gray-300">
                   {post.excerpt}
                 </p>
+                {post.tags.length > 0 && (
+                  <div className="mb-4 flex flex-wrap gap-2">
+                    {post.tags.map((tag) => (
+                      <span
+                        key={`${post.slug}-${tag}`}
+                        className="rounded-full border border-white/20 px-2.5 py-1 text-xs font-semibold text-gray-200"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
                 <span className="inline-flex items-center gap-2 text-sm font-semibold text-accent-link transition-colors group-hover:text-accent-link-hover">
                   Read article
                   <span aria-hidden="true">→</span>

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -40,6 +40,18 @@ describe("blogApi front matter validation", () => {
     expect(post?.draft).toBe(false);
   });
 
+  test("parses explicit tags and readingTimeMinutes", async () => {
+    const tempDir = setupTempPosts({
+      tagged: `---\ntitle: "Tagged"\ndate: "2026-02-16"\ntags:\n  - "AI"\n  - "Systems"\nreadingTimeMinutes: 7\n---\nBody`,
+    });
+
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+    const post = getPostBySlug("tagged");
+
+    expect(post?.tags).toEqual(["AI", "Systems"]);
+    expect(post?.readingTimeMinutes).toBe(7);
+  });
+
   test("throws when front matter contains invalid types", async () => {
     const tempDir = setupTempPosts({
       "bad-types": `---\ntitle: "Hello"\ndate: "2026-02-16"\ntags: test\n---\nBody`,

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -1,0 +1,66 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+function setupTempPosts(markdownBySlug: Record<string, string>): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "blog-api-test-"));
+  const postsDir = path.join(tempDir, "content", "posts");
+
+  fs.mkdirSync(postsDir, { recursive: true });
+
+  Object.entries(markdownBySlug).forEach(([slug, markdown]) => {
+    fs.writeFileSync(path.join(postsDir, `${slug}.md`), markdown, "utf8");
+  });
+
+  return tempDir;
+}
+
+async function loadBlogApiAtCwd(cwd: string) {
+  jest.resetModules();
+  const cwdSpy = jest.spyOn(process, "cwd").mockReturnValue(cwd);
+  const blogApi = await import("@/lib/blogApi");
+
+  cwdSpy.mockRestore();
+
+  return blogApi;
+}
+
+describe("blogApi front matter validation", () => {
+  test("parses required front matter and applies defaults", async () => {
+    const tempDir = setupTempPosts({
+      "default-fields": `---\ntitle: "Hello"\ndate: "2026-02-16"\n---\nBody`,
+    });
+
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+    const post = getPostBySlug("default-fields");
+
+    expect(post).not.toBeNull();
+    expect(post?.title).toBe("Hello");
+    expect(post?.tags).toEqual([]);
+    expect(post?.draft).toBe(false);
+  });
+
+  test("throws when front matter contains invalid types", async () => {
+    const tempDir = setupTempPosts({
+      "bad-types": `---\ntitle: "Hello"\ndate: "2026-02-16"\ntags: test\n---\nBody`,
+    });
+
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+
+    expect(() => getPostBySlug("bad-types")).toThrow(
+      /Invalid front matter.*tags/
+    );
+  });
+
+  test("throws when front matter contains unknown keys", async () => {
+    const tempDir = setupTempPosts({
+      "unknown-key": `---\ntitle: "Hello"\ndate: "2026-02-16"\nauthor: "Alex"\n---\nBody`,
+    });
+
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+
+    expect(() => getPostBySlug("unknown-key")).toThrow(
+      /Invalid front matter.*Unrecognized key/
+    );
+  });
+});

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -33,19 +33,6 @@ export type Post = {
   content: string;
 };
 
-/**
- * Markdown post front matter contract.
- *
- * Fields:
- * - `title` (required): post headline shown in lists, metadata, and article pages.
- * - `date` (required): publish date string; parsed and normalized to ISO.
- * - `updated` (optional): last-modified date string; parsed and normalized to ISO.
- * - `excerpt` (optional): short summary used in cards and metadata descriptions.
- * - `coverImage` (optional): public path to the post hero image.
- * - `tags` (optional, default `[]`): taxonomy labels for filtering/grouping.
- * - `readingTimeMinutes` (optional): estimated reading time in whole minutes.
- * - `draft` (optional, default `false`): marks unpublished content.
- */
 const PostFrontMatterSchema = z
   .object({
     title: z

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -33,16 +33,63 @@ export type Post = {
   content: string;
 };
 
+/**
+ * Markdown post front matter contract.
+ *
+ * Fields:
+ * - `title` (required): post headline shown in lists, metadata, and article pages.
+ * - `date` (required): publish date string; parsed and normalized to ISO.
+ * - `updated` (optional): last-modified date string; parsed and normalized to ISO.
+ * - `excerpt` (optional): short summary used in cards and metadata descriptions.
+ * - `coverImage` (optional): public path to the post hero image.
+ * - `tags` (optional, default `[]`): taxonomy labels for filtering/grouping.
+ * - `readingTimeMinutes` (optional): estimated reading time in whole minutes.
+ * - `draft` (optional, default `false`): marks unpublished content.
+ */
 const PostFrontMatterSchema = z
   .object({
-    title: z.string().trim().min(1, "title must be a non-empty string"),
-    date: z.string().trim().min(1, "date must be a non-empty string"),
-    updated: z.string().trim().min(1).optional(),
-    excerpt: z.string().trim().min(1).optional(),
-    coverImage: z.string().trim().min(1).optional(),
-    tags: z.array(z.string().trim().min(1)).default([]),
-    readingTimeMinutes: z.number().int().positive().optional(),
-    draft: z.boolean().default(false),
+    title: z
+      .string()
+      .trim()
+      .min(1, "title must be a non-empty string")
+      .describe("Post title displayed in page heading and SEO metadata."),
+    date: z
+      .string()
+      .trim()
+      .min(1, "date must be a non-empty string")
+      .describe("Publish date string parsed and normalized to ISO format."),
+    updated: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Optional last-updated date string for sitemap and metadata."),
+    excerpt: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Optional short description shown in previews and metadata."),
+    coverImage: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Optional public path for the post cover image asset."),
+    tags: z
+      .array(z.string().trim().min(1))
+      .default([])
+      .describe("Optional list of taxonomy tags for post grouping."),
+    readingTimeMinutes: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Optional whole-minute estimate for article reading time."),
+    draft: z
+      .boolean()
+      .default(false)
+      .describe("Optional draft flag; defaults to published (`false`)."),
   })
   .strict();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,6 +2429,7 @@ __metadata:
     tailwindcss: "npm:^3.4.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.6.3"
+    zod: "npm:^4.3.6"
   languageName: unknown
   linkType: soft
 
@@ -9401,6 +9402,13 @@ __metadata:
   version: 4.2.1
   resolution: "zod@npm:4.2.1"
   checksum: 10c0/ecb5219bddf76a42d092a843fb98ad4cb78f1e1077082772b03ef032ee5cbc80790a4051836b962d26fb4af854323bc784d628bd1b8d9898149eba7af21c5560
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.3.6":
+  version: 4.3.6
+  resolution: "zod@npm:4.3.6"
+  checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
- Implement recommendation B to harden the blog data layer against front-matter schema drift and provide clear build-time errors. 
- Replace brittle ad-hoc front-matter extraction with a typed validator so optional fields and defaults are handled consistently. 
- Preserve existing date normalization and sorting while adding typed fields for future features (tags, draft, reading time). 

### Description
- Add `zod` as a runtime dependency and update `package.json`/`yarn.lock` to pin the package. 
- Introduce a strict `PostFrontMatterSchema` in `src/lib/blogApi.ts` and replace previous string extraction with `parseFrontMatter` that uses `safeParse` and emits actionable per-field error messages. 
- Extend the post model and selectable `POST_FIELDS` to include `tags`, `readingTimeMinutes`, and `draft`, and wire schema defaults through to the exported `Post` objects. 
- Add focused unit tests in `src/lib/__tests__/blogApi.test.ts` that verify schema defaults, invalid-type rejection, and unknown-key rejection. 

### Testing
- Ran `yarn lint` (formatting checked and fixed where needed) and it completed successfully. 
- Ran `yarn test --runInBand` and all test suites passed (14 test suites, 52 tests). 
- Ran `yarn build` and the Next.js static build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699359e8293883239daeb68c6c4163fa)