### PR TITLE
Implement shared SEO utilities and update audit (Recommendation D Phase 0/1)

### DIFF
--- a/docs/technical-architecture-audit.md
+++ b/docs/technical-architecture-audit.md
@@ -86,6 +86,15 @@ Metadata and JSON-LD are robust, but they are currently authored across route fi
 - Centralize canonical URL and image derivation logic.
 - Keep route files focused on content composition.
 
+**Status (2026-02-16 update)**
+
+- ✅ **Phase 0 complete**: shared SEO model contract (`SeoInput`, `SeoImage`) is defined in `src/lib/seo/types.ts`.
+- ✅ **Phase 1 complete**: reusable URL + metadata builders are in place:
+  - `src/lib/seo/url.ts` for canonical and absolute URL derivation
+  - `src/lib/seo/metadata.ts` for standardized `Metadata` generation
+  - tests added for URL normalization and metadata defaults/overrides
+- 🔄 **Remaining work**: apply these utilities route-by-route and extract shared JSON-LD helper builders.
+
 ### E) Performance Budget Not Yet Explicit (Medium)
 
 The site has good baseline choices, but no explicit performance budget or regression checks (Lighthouse CI / bundle checks).
@@ -106,9 +115,10 @@ The site has good baseline choices, but no explicit performance budget or regres
 
 ### Phase 2 (2–4 days): Maintainability
 
-1. Extract SEO helpers into `src/lib/seo`.
-2. Formalize blog post model with extensible fields.
-3. Add content authoring lint checks (required front matter fields).
+1. Migrate route-level metadata to use `src/lib/seo` helpers (`about`, `contact`, `now`, `blog`, and `blog/[slug]`).
+2. Extract shared JSON-LD builders so route files retain only page-specific schema fields.
+3. Formalize blog post model with extensible fields.
+4. Add content authoring lint checks (required front matter fields).
 
 ### Phase 3 (half day): Performance Governance
 
@@ -127,3 +137,8 @@ The site has good baseline choices, but no explicit performance budget or regres
 
 - Update this file after framework upgrades or content-model changes.
 - Track roadmap items by moving completed items into a short changelog section.
+
+
+## Progress Log
+
+- **2026-02-16**: Recommendation D has completed foundational work (Phase 0 + Phase 1 utilities and tests). Remaining scope is route migration + JSON-LD extraction under Phase 2.

--- a/src/lib/seo/__tests__/metadata.test.ts
+++ b/src/lib/seo/__tests__/metadata.test.ts
@@ -1,0 +1,64 @@
+import { buildPageMetadata } from "@/lib/seo/metadata";
+
+describe("buildPageMetadata", () => {
+  it("builds canonical, Open Graph, and Twitter metadata with defaults", () => {
+    const metadata = buildPageMetadata({
+      title: "About Me | Alex Leung",
+      description: "Learn more about Alex Leung.",
+      path: "/about",
+    });
+
+    expect(metadata.alternates?.canonical).toBe("https://alexleung.ca/about/");
+    expect(metadata.openGraph?.url).toBe("https://alexleung.ca/about/");
+    expect(metadata.openGraph?.type).toBe("website");
+    expect(metadata.openGraph?.siteName).toBe("Alex Leung");
+    expect(metadata.twitter?.card).toBe("summary");
+  });
+
+  it("normalizes image URLs and uses large-image twitter card when images exist", () => {
+    const metadata = buildPageMetadata({
+      title: "Blog | Alex Leung",
+      description: "Latest writing.",
+      path: "/blog",
+      images: [
+        {
+          url: "/assets/screenshot.png",
+          alt: "Blog screenshot",
+          width: 1200,
+          height: 630,
+        },
+      ],
+    });
+
+    expect(metadata.openGraph?.images).toEqual([
+      {
+        url: "https://alexleung.ca/assets/screenshot.png",
+        alt: "Blog screenshot",
+        width: 1200,
+        height: 630,
+      },
+    ]);
+    expect(metadata.twitter?.images).toEqual([
+      {
+        url: "https://alexleung.ca/assets/screenshot.png",
+        alt: "Blog screenshot",
+        width: 1200,
+        height: 630,
+      },
+    ]);
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+  });
+
+  it("supports overriding metadata type and twitter card", () => {
+    const metadata = buildPageMetadata({
+      title: "A post | Alex Leung",
+      description: "A deep dive post.",
+      path: "/blog/deep-dive",
+      type: "article",
+      twitterCard: "summary",
+    });
+
+    expect(metadata.openGraph?.type).toBe("article");
+    expect(metadata.twitter?.card).toBe("summary");
+  });
+});

--- a/src/lib/seo/__tests__/url.test.ts
+++ b/src/lib/seo/__tests__/url.test.ts
@@ -1,0 +1,25 @@
+import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
+
+describe("seo url helpers", () => {
+  it("builds absolute URLs from relative paths", () => {
+    expect(toAbsoluteUrl("/blog/my-post")).toBe(
+      "https://alexleung.ca/blog/my-post"
+    );
+    expect(toAbsoluteUrl("blog/my-post")).toBe(
+      "https://alexleung.ca/blog/my-post"
+    );
+  });
+
+  it("preserves absolute URLs", () => {
+    expect(toAbsoluteUrl("https://example.com/docs/")).toBe(
+      "https://example.com/docs/"
+    );
+  });
+
+  it("normalizes canonical URLs to trailing-slash and strips query/hash", () => {
+    expect(toCanonical("/contact")).toBe("https://alexleung.ca/contact/");
+    expect(
+      toCanonical("https://alexleung.ca/blog?utm_source=test#section")
+    ).toBe("https://alexleung.ca/blog/");
+  });
+});

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -1,0 +1,3 @@
+export { buildPageMetadata } from "./metadata";
+export { toAbsoluteUrl, toCanonical } from "./url";
+export type { SeoImage, SeoInput } from "./types";

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+
+import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
+
+import type { SeoImage, SeoInput } from "./types";
+
+const SITE_NAME = "Alex Leung";
+const DEFAULT_LOCALE = "en_CA";
+
+function normalizeImages(images: SeoImage[] | undefined): SeoImage[] {
+  if (!images || images.length === 0) {
+    return [];
+  }
+
+  return images.map((image) => ({
+    ...image,
+    url: toAbsoluteUrl(image.url),
+  }));
+}
+
+export function buildPageMetadata(input: SeoInput): Metadata {
+  const canonicalUrl = toCanonical(input.path);
+  const normalizedImages = normalizeImages(input.images);
+  const hasImages = normalizedImages.length > 0;
+  const twitterCard =
+    input.twitterCard || (hasImages ? "summary_large_image" : "summary");
+
+  return {
+    title: input.title,
+    description: input.description,
+    keywords: input.keywords,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      title: input.title,
+      description: input.description,
+      type: input.type || "website",
+      url: canonicalUrl,
+      siteName: SITE_NAME,
+      locale: DEFAULT_LOCALE,
+      images: hasImages ? normalizedImages : undefined,
+    },
+    twitter: {
+      card: twitterCard,
+      title: input.title,
+      description: input.description,
+      images: hasImages ? normalizedImages : undefined,
+    },
+  };
+}

--- a/src/lib/seo/types.ts
+++ b/src/lib/seo/types.ts
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export type SeoImage = {
+  alt?: string;
+  height?: number;
+  url: string;
+  width?: number;
+};
+
+export type SeoInput = {
+  description: string;
+  images?: SeoImage[];
+  keywords?: Metadata["keywords"];
+  path: string;
+  title: string;
+  type?: "article" | "website";
+  twitterCard?: "summary" | "summary_large_image";
+};

--- a/src/lib/seo/url.ts
+++ b/src/lib/seo/url.ts
@@ -1,0 +1,35 @@
+import { BASE_URL } from "@/constants";
+
+function ensureLeadingSlash(path: string): string {
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function ensureTrailingSlash(path: string): string {
+  if (path === "/") {
+    return path;
+  }
+
+  return path.endsWith("/") ? path : `${path}/`;
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^https?:\/\//.test(value);
+}
+
+export function toAbsoluteUrl(pathOrUrl: string): string {
+  if (isAbsoluteUrl(pathOrUrl)) {
+    return new URL(pathOrUrl).toString();
+  }
+
+  return new URL(ensureLeadingSlash(pathOrUrl), BASE_URL).toString();
+}
+
+export function toCanonical(pathOrUrl: string): string {
+  const url = new URL(toAbsoluteUrl(pathOrUrl));
+
+  url.hash = "";
+  url.search = "";
+  url.pathname = ensureTrailingSlash(url.pathname);
+
+  return url.toString();
+}


### PR DESCRIPTION
### Motivation

- Reduce duplication and drift in route-level metadata and JSON-LD by centralizing canonical URL / metadata generation into a small reusable library.

### Description

- Add `src/lib/seo/types.ts` to define a shared `SeoInput` / `SeoImage` contract for route metadata inputs.
- Add `src/lib/seo/url.ts` with `toAbsoluteUrl` and `toCanonical` helpers to normalize absolute/canonical URLs and trailing-slash behavior.
- Add `src/lib/seo/metadata.ts` with `buildPageMetadata` to produce standardized Next.js `Metadata` (Open Graph, Twitter, canonical) and image normalization.
- Add `src/lib/seo/index.ts` barrel and tests under `src/lib/seo/__tests__` for URL and metadata behavior, and update `docs/technical-architecture-audit.md` to record Phase 0/Phase 1 completion and remaining Phase 2 work.

### Testing

- Ran targeted tests with `yarn test src/lib/seo/__tests__/url.test.ts src/lib/seo/__tests__/metadata.test.ts` and both suites passed.
- Ran full test suite with `yarn test` and all test suites passed (16 suites, 59 tests) successfully.
- Fixed initial formatting warnings with `yarn lint:fix` and verified formatting and linting with `yarn lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993982eaea48323907363cd93fe3d43)