### PR TITLE
Centralize SEO metadata and JSON-LD builders; migrate route metadata

### DIFF
--- a/docs/technical-architecture-audit.md
+++ b/docs/technical-architecture-audit.md
@@ -93,7 +93,8 @@ Metadata and JSON-LD are robust, but they are currently authored across route fi
   - `src/lib/seo/url.ts` for canonical and absolute URL derivation
   - `src/lib/seo/metadata.ts` for standardized `Metadata` generation
   - tests added for URL normalization and metadata defaults/overrides
-- 🔄 **Remaining work**: apply these utilities route-by-route and extract shared JSON-LD helper builders.
+- ✅ **Phase 2 (part 1) complete**: route-level metadata builders now power `about`, `contact`, `now`, `blog`, and `blog/[slug]`.
+- ✅ **Phase 2 (part 2) complete**: shared JSON-LD helper builders and stable schema IDs are centralized under `src/lib/seo/jsonLd.ts` and consumed by core routes.
 
 ### E) Performance Budget Not Yet Explicit (Medium)
 
@@ -142,3 +143,5 @@ The site has good baseline choices, but no explicit performance budget or regres
 ## Progress Log
 
 - **2026-02-16**: Recommendation D has completed foundational work (Phase 0 + Phase 1 utilities and tests). Remaining scope is route migration + JSON-LD extraction under Phase 2.
+
+- **2026-02-16**: Recommendation D Phase 2 route migration + JSON-LD helper extraction completed for primary content routes (`about`, `contact`, `now`, `blog`, `blog/[slug]`).

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,6 @@
 import { JsonLd } from "react-schemaorg";
 
-import { Metadata } from "next";
+import type { Metadata } from "next";
 
 import * as schemadts from "schema-dts";
 
@@ -8,49 +8,26 @@ import { Credentials } from "@/app/about/_components/Credentials";
 import { Journey } from "@/app/about/_components/MyBackground";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
-import { BASE_URL } from "@/constants";
+import { buildBasicPageSchema, buildPageMetadata } from "@/lib/seo";
 
 import { Skills } from "./_components/TechnicalInterests";
 
 const title = "About Me | Alex Leung";
 const description =
   "Learn about Alex Leung's journey - from University of Waterloo and Georgia Tech to end-to-end product development.";
-const url = `${BASE_URL}/about/`;
-
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-    images: [
-      {
-        url: "/assets/about_portrait.webp",
-        width: 5712,
-        height: 4284,
-        alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-    images: [
-      {
-        url: "/assets/about_portrait.webp",
-        alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
-      },
-    ],
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path: "/about",
+  images: [
+    {
+      url: "/assets/about_portrait.webp",
+      width: 5712,
+      height: 4284,
+      alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
+    },
+  ],
+});
 
 export default function AboutPage() {
   return (
@@ -62,23 +39,12 @@ export default function AboutPage() {
         ]}
       />
       <JsonLd<schemadts.ProfilePage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ProfilePage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildBasicPageSchema({
+          type: "ProfilePage",
+          path: "/about",
+          title,
+          description,
+        })}
       />
 
       <div className="py-[var(--header-height)]">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { JsonLd } from "react-schemaorg";
 
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 
@@ -12,6 +12,7 @@ import { Title } from "@/components/Title";
 import { BASE_URL } from "@/constants";
 import { getAllPosts, getPostBySlug } from "@/lib/blogApi";
 import markdownToHtml from "@/lib/markdownToHtml";
+import { buildPageMetadata, getBlogId, getPersonId } from "@/lib/seo";
 
 export const dynamicParams = false;
 
@@ -33,35 +34,27 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const title = `${post.title} | Alex Leung`;
   const description =
     post.excerpt || `Read ${post.title} on Alex Leung's blog.`;
-  const url = `${BASE_URL}/blog/${params_awaited.slug}`;
   const coverImageUrl = post.coverImage
     ? new URL(post.coverImage, BASE_URL).toString()
     : undefined;
-  const images = coverImageUrl ? [coverImageUrl] : undefined;
   const publishedTime = new Date(post.date).toISOString();
   const modifiedTime = new Date(post.updated || post.date).toISOString();
 
-  return {
+  const metadata = buildPageMetadata({
     title,
     description,
+    path: `/blog/${params_awaited.slug}`,
+    type: "article",
+    images: coverImageUrl ? [{ url: coverImageUrl }] : undefined,
+    keywords: post.tags.length > 0 ? post.tags : undefined,
+  });
+
+  return {
+    ...metadata,
     openGraph: {
-      title,
-      description,
-      type: "article",
-      url,
-      images,
+      ...metadata.openGraph,
       publishedTime,
       modifiedTime,
-    },
-    twitter: {
-      card: coverImageUrl ? "summary_large_image" : "summary",
-      title,
-      description,
-      images,
-    },
-    keywords: post.tags.length > 0 ? post.tags : undefined,
-    alternates: {
-      canonical: url,
     },
   };
 }
@@ -124,12 +117,12 @@ export default async function Post({ params }: Props) {
           dateModified: new Date(post.updated || post.date).toISOString(),
           author: {
             "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
+            "@id": getPersonId(),
             name: "Alex Leung",
           },
           publisher: {
             "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
+            "@id": getPersonId(),
           },
           inLanguage: "en-CA",
           mainEntityOfPage: {
@@ -138,7 +131,7 @@ export default async function Post({ params }: Props) {
           },
           isPartOf: {
             "@type": "Blog",
-            "@id": `${BASE_URL}/blog/#blog`,
+            "@id": getBlogId(),
             name: "Blog | Alex Leung",
           },
         }}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -12,7 +12,12 @@ import { Title } from "@/components/Title";
 import { BASE_URL } from "@/constants";
 import { getAllPosts, getPostBySlug } from "@/lib/blogApi";
 import markdownToHtml from "@/lib/markdownToHtml";
-import { buildPageMetadata, getBlogId, getPersonId } from "@/lib/seo";
+import {
+  buildPageMetadata,
+  getBlogId,
+  getPersonId,
+  toCanonical,
+} from "@/lib/seo";
 
 export const dynamicParams = false;
 
@@ -91,6 +96,7 @@ export default async function Post({ params }: Props) {
   }
 
   const content = await markdownToHtml(post.content || "");
+  const canonicalPostUrl = toCanonical(`/blog/${post.slug}`);
 
   return (
     <>
@@ -105,8 +111,8 @@ export default async function Post({ params }: Props) {
         item={{
           "@context": "https://schema.org",
           "@type": "BlogPosting",
-          "@id": `${BASE_URL}/blog/${post.slug}#blogposting`,
-          url: `${BASE_URL}/blog/${post.slug}`,
+          "@id": `${canonicalPostUrl}#blogposting`,
+          url: canonicalPostUrl,
           headline: post.title,
           description: post.excerpt,
           keywords: post.tags.length > 0 ? post.tags.join(", ") : undefined,
@@ -127,7 +133,7 @@ export default async function Post({ params }: Props) {
           inLanguage: "en-CA",
           mainEntityOfPage: {
             "@type": "WebPage",
-            "@id": `${BASE_URL}/blog/${post.slug}`,
+            "@id": canonicalPostUrl,
           },
           isPartOf: {
             "@type": "Blog",

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,6 @@
 import { JsonLd } from "react-schemaorg";
 
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -11,11 +11,17 @@ import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
 import { BASE_URL } from "@/constants";
 import { getAllPosts } from "@/lib/blogApi";
+import {
+  buildPageMetadata,
+  getBlogId,
+  getPersonId,
+  getWebsiteId,
+} from "@/lib/seo";
 
 const title = "Blog | Alex Leung";
 const description =
   "Thoughts on software engineering, product development, and life as a developer.";
-const url = `${BASE_URL}/blog/`;
+const blogUrl = `${BASE_URL}/blog/`;
 
 export function generateMetadata(): Metadata {
   const posts = getAllPosts(["coverImage"]);
@@ -23,30 +29,12 @@ export function generateMetadata(): Metadata {
   const image = firstCoverImage
     ? new URL(firstCoverImage, BASE_URL).toString()
     : undefined;
-  const images = image ? [image] : undefined;
-
-  return {
-    title: title,
-    description: description,
-    alternates: {
-      canonical: url,
-    },
-    openGraph: {
-      title: title,
-      description: description,
-      type: "website",
-      url: url,
-      siteName: "Alex Leung",
-      locale: "en_CA",
-      images,
-    },
-    twitter: {
-      card: image ? "summary_large_image" : "summary",
-      title: title,
-      description: description,
-      images,
-    },
-  };
+  return buildPageMetadata({
+    title,
+    description,
+    path: "/blog",
+    images: image ? [{ url: image }] : undefined,
+  });
 }
 
 export default function BlogIndex() {
@@ -71,22 +59,22 @@ export default function BlogIndex() {
         item={{
           "@context": "https://schema.org",
           "@type": "CollectionPage",
-          "@id": url,
-          url: url,
+          "@id": blogUrl,
+          url: blogUrl,
           name: title,
           description: description,
           inLanguage: "en-CA",
           isPartOf: {
             "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
+            "@id": getWebsiteId(),
           },
           mainEntity: {
             "@type": "Blog",
-            "@id": `${BASE_URL}/blog/#blog`,
+            "@id": getBlogId(),
             name: "Alex Leung's Blog",
             description: description,
             publisher: {
-              "@id": `${BASE_URL}/#person`,
+              "@id": getPersonId(),
             },
           },
         }}
@@ -95,7 +83,7 @@ export default function BlogIndex() {
         item={{
           "@context": "https://schema.org",
           "@type": "ItemList",
-          "@id": `${BASE_URL}/blog/#itemlist`,
+          "@id": `${blogUrl}#itemlist`,
           itemListElement: allPosts.map((post, index) => ({
             "@type": "ListItem",
             position: index + 1,

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,12 +1,12 @@
 import { JsonLd } from "react-schemaorg";
 
-import { Metadata } from "next";
+import type { Metadata } from "next";
 
 import * as schemadts from "schema-dts";
 
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
-import { BASE_URL } from "@/constants";
+import { buildBasicPageSchema, buildPageMetadata } from "@/lib/seo";
 
 import { EmailMe } from "./_components/EmailMe";
 import { SocialMediaList } from "./_components/SocialMediaList";
@@ -14,28 +14,12 @@ import { SocialMediaList } from "./_components/SocialMediaList";
 const title = "Contact | Alex Leung";
 const description =
   "Get in touch with Alex Leung - Syntropy Engineer and Programmer. Available for collaboration, consulting, and professional inquiries.";
-const url = `${BASE_URL}/contact/`;
-
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path: "/contact",
+  twitterCard: "summary_large_image",
+});
 
 export default function ContactPage() {
   return (
@@ -47,23 +31,12 @@ export default function ContactPage() {
         ]}
       />
       <JsonLd<schemadts.ContactPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ContactPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildBasicPageSchema({
+          type: "ContactPage",
+          path: "/contact",
+          title,
+          description,
+        })}
       />
 
       <div className="py-[var(--header-height)]">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,7 @@
 
 @layer components {
   .section-center {
-    @apply max-w-content mx-auto w-[90vw];
+    @apply mx-auto w-[90vw] max-w-content;
   }
 
   @media screen and (min-width: 992px) {
@@ -52,7 +52,7 @@
   }
 
   .toggle-button {
-    @apply absolute top-4 right-4;
+    @apply absolute right-4 top-4;
   }
 
   /* Section Spacing Utilities */
@@ -146,6 +146,6 @@
   .surface-interactive {
     @apply rounded-lg border border-white/10 bg-white/5 backdrop-blur-sm transition-all duration-200;
     @apply cursor-pointer hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 hover:shadow-lg;
-    @apply focus-visible:ring-accent-link focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none;
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-link focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950;
   }
 }

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -1,39 +1,23 @@
 import { JsonLd } from "react-schemaorg";
 
-import { Metadata } from "next";
+import type { Metadata } from "next";
 
 import { WebPage } from "schema-dts";
 
 import ExternalLink from "@/components/ExternalLink";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
-import { BASE_URL } from "@/constants";
+import { buildBasicPageSchema, buildPageMetadata } from "@/lib/seo";
 
 const title = "What I'm Doing Now | Alex Leung";
 const description =
   "Current projects, books, and goals - a snapshot of what Alex Leung is focused on right now.";
-const url = `${BASE_URL}/now/`;
-
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path: "/now",
+  twitterCard: "summary_large_image",
+});
 
 export default function NowPage() {
   return (
@@ -45,23 +29,12 @@ export default function NowPage() {
         ]}
       />
       <JsonLd<WebPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "WebPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildBasicPageSchema({
+          type: "WebPage",
+          path: "/now",
+          title,
+          description,
+        })}
       />
 
       <div className="py-[var(--header-height)]">

--- a/src/lib/seo/__tests__/jsonLd.test.ts
+++ b/src/lib/seo/__tests__/jsonLd.test.ts
@@ -1,0 +1,35 @@
+import {
+  buildBasicPageSchema,
+  getBlogId,
+  getPersonId,
+  getWebsiteId,
+} from "@/lib/seo/jsonLd";
+
+describe("seo json-ld helpers", () => {
+  it("returns stable schema identifiers", () => {
+    expect(getPersonId()).toBe("https://alexleung.ca/#person");
+    expect(getWebsiteId()).toBe("https://alexleung.ca/#website");
+    expect(getBlogId()).toBe("https://alexleung.ca/blog/#blog");
+  });
+
+  it("builds canonical page schema with shared references", () => {
+    const schema = buildBasicPageSchema({
+      type: "ContactPage",
+      path: "/contact?utm_source=test#top",
+      title: "Contact | Alex Leung",
+      description: "Get in touch with Alex Leung.",
+    });
+
+    expect(schema["@type"]).toBe("ContactPage");
+    expect(schema["@id"]).toBe("https://alexleung.ca/contact/");
+    expect(schema.url).toBe("https://alexleung.ca/contact/");
+    expect(schema.mainEntity).toEqual({
+      "@type": "Person",
+      "@id": "https://alexleung.ca/#person",
+    });
+    expect(schema.isPartOf).toEqual({
+      "@type": "WebSite",
+      "@id": "https://alexleung.ca/#website",
+    });
+  });
+});

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -1,3 +1,9 @@
 export { buildPageMetadata } from "./metadata";
+export {
+  buildBasicPageSchema,
+  getBlogId,
+  getPersonId,
+  getWebsiteId,
+} from "./jsonLd";
 export { toAbsoluteUrl, toCanonical } from "./url";
 export type { SeoImage, SeoInput } from "./types";

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -1,0 +1,43 @@
+import { BASE_URL } from "@/constants";
+import { toCanonical } from "@/lib/seo/url";
+
+type BasicPageSchemaInput = {
+  description: string;
+  path: string;
+  title: string;
+  type: string;
+};
+
+export function getPersonId(): string {
+  return `${BASE_URL}/#person`;
+}
+
+export function getWebsiteId(): string {
+  return `${BASE_URL}/#website`;
+}
+
+export function getBlogId(): string {
+  return `${BASE_URL}/blog/#blog`;
+}
+
+export function buildBasicPageSchema(input: BasicPageSchemaInput) {
+  const canonicalUrl = toCanonical(input.path);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": input.type,
+    "@id": canonicalUrl,
+    url: canonicalUrl,
+    name: input.title,
+    description: input.description,
+    mainEntity: {
+      "@type": "Person",
+      "@id": getPersonId(),
+    },
+    inLanguage: "en-CA",
+    isPartOf: {
+      "@type": "WebSite",
+      "@id": getWebsiteId(),
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication and drift in per-route metadata/JSON-LD by centralizing canonical URL and metadata builders under `src/lib/seo` as recommended in the architecture audit (Recommendation D). 
- Provide stable schema identifiers and a minimal shared JSON-LD builder so routes can emit consistent structured data without repeating site constants.

### Description
- Add a new JSON-LD helper module `src/lib/seo/jsonLd.ts` that exposes stable IDs (`getPersonId`, `getWebsiteId`, `getBlogId`) and a basic page schema builder `buildBasicPageSchema` that canonicalizes paths via `toCanonical`.
- Re-export the new helpers from the SEO barrel file (`src/lib/seo/index.ts`) and add unit tests in `src/lib/seo/__tests__/jsonLd.test.ts` to validate canonicalization and stable IDs.
- Migrate route-level metadata composition to use `buildPageMetadata` and consume `buildBasicPageSchema` for JSON-LD on the primary pages: `about`, `contact`, `now`, `blog`, and `blog/[slug]`, and update blog JSON-LD to use `getPersonId`/`getBlogId`/`getWebsiteId` to remove duplicated literals.
- Update `docs/technical-architecture-audit.md` to mark Recommendation D Phase 2 route migration and JSON-LD extraction as completed.

### Testing
- Ran `yarn lint` (and `yarn lint:fix`) to enforce formatting and code style; linter passed after fixes. 
- Ran `yarn test`; all unit tests passed (`17` test suites, `61` tests passed).
- Attempted `yarn build`; build fails in this environment due to a missing PostCSS plugin (`@tailwindcss/postcss`) during Next/Turbopack PostCSS evaluation, not due to the SEO changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a01099cc832386efc59a3ce64db9)