### PR TITLE
Refine now page footer copy

### DIFF
--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -171,12 +171,10 @@ export default function NowPage() {
               <ExternalLink href="https://nownownow.com/about">
                 now page
               </ExternalLink>
-              , inspired by{" "}
-              <ExternalLink href="https://sive.rs/nowff">
-                Derek Sivers
-              </ExternalLink>
-              . It&apos;s a snapshot of what I&apos;m focused on at this point
-              in my life.
+              . You can read more about the format{" "}
+              <ExternalLink href="https://sive.rs/nowff">here</ExternalLink>.
+              It&apos;s a snapshot of what I&apos;m focused on at this point in
+              my life.
             </p>
           </div>
         </section>


### PR DESCRIPTION
### Motivation
- Remove the direct mention of Derek Sivers from the Now page footer copy while keeping the existing reference link, and keep the copy focused on the author.

### Description
- Updated the footer copy in `src/app/now/page.tsx` to remove ", inspired by Derek Sivers" and instead link to the same `https://sive.rs/nowff` URL with the anchor text `here`.
- Preserved the `nownownow.com` and `sive.rs` links and the original intent that the section is a snapshot of current focus.
- Ran automatic formatting fixes to satisfy Prettier/ESLint rules.

### Testing
- `corepack enable && corepack install && yarn lint` initially reported Prettier formatting errors (failed). 
- `yarn lint:fix` was run and fixed formatting issues successfully.
- `yarn lint` passed after fixes, and `yarn dev` started the app and a Playwright screenshot of `/now/` was captured to validate the change (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699873f028e883238ce6ed0083684e6e)