### PR TITLE
Extract shared SEO builders and migrate route metadata (Recommendation D)

### DIFF
--- a/docs/technical-architecture-audit.md
+++ b/docs/technical-architecture-audit.md
@@ -142,3 +142,4 @@ The site has good baseline choices, but no explicit performance budget or regres
 ## Progress Log
 
 - **2026-02-16**: Recommendation D has completed foundational work (Phase 0 + Phase 1 utilities and tests). Remaining scope is route migration + JSON-LD extraction under Phase 2.
+- **2026-02-20**: Recommendation D route migration completed for `about`, `contact`, `now`, `blog`, and `blog/[slug]` using shared SEO helpers. Shared JSON-LD builders were added to reduce schema duplication across routes.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -8,49 +8,28 @@ import { Credentials } from "@/app/about/_components/Credentials";
 import { Journey } from "@/app/about/_components/MyBackground";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
-import { BASE_URL } from "@/constants";
+import { buildPageMetadata, buildProfilePageJsonLd } from "@/lib/seo";
 
 import { Skills } from "./_components/TechnicalInterests";
 
 const title = "About Me | Alex Leung";
 const description =
   "Learn about Alex Leung's journey - from University of Waterloo and Georgia Tech to end-to-end product development.";
-const url = `${BASE_URL}/about/`;
+const path = "/about";
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-    images: [
-      {
-        url: "/assets/about_portrait.webp",
-        width: 5712,
-        height: 4284,
-        alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-    images: [
-      {
-        url: "/assets/about_portrait.webp",
-        alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
-      },
-    ],
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+  images: [
+    {
+      url: "/assets/about_portrait.webp",
+      width: 5712,
+      height: 4284,
+      alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
+    },
+  ],
+});
 
 export default function AboutPage() {
   return (
@@ -62,23 +41,7 @@ export default function AboutPage() {
         ]}
       />
       <JsonLd<schemadts.ProfilePage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ProfilePage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildProfilePageJsonLd({ path, title, description })}
       />
 
       <div className="py-[var(--header-height)]">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -19,6 +19,10 @@ import {
 
 export const dynamicParams = false;
 
+const BLOG_PATH = "/blog";
+const BLOG_NAME = "Blog | Alex Leung";
+const AUTHOR_NAME = "Alex Leung";
+
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params_awaited = await props.params;
   const post = getPostBySlug(params_awaited.slug, [
@@ -107,7 +111,10 @@ export default async function Post({ params }: Props) {
       />
       <JsonLd<BlogPosting>
         item={buildBlogPostingJsonLd({
-          slug: post.slug,
+          path: `/blog/${post.slug}`,
+          blogPath: BLOG_PATH,
+          blogName: BLOG_NAME,
+          authorName: AUTHOR_NAME,
           title: post.title,
           description: post.excerpt,
           coverImage: post.coverImage,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -9,44 +9,28 @@ import { CollectionPage, ItemList } from "schema-dts";
 
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
-import { BASE_URL } from "@/constants";
 import { getAllPosts } from "@/lib/blogApi";
+import {
+  buildBlogCollectionPageJsonLd,
+  buildBlogItemListJsonLd,
+  buildPageMetadata,
+} from "@/lib/seo";
 
 const title = "Blog | Alex Leung";
 const description =
   "Thoughts on software engineering, product development, and life as a developer.";
-const url = `${BASE_URL}/blog/`;
+const path = "/blog";
 
 export function generateMetadata(): Metadata {
   const posts = getAllPosts(["coverImage"]);
   const firstCoverImage = posts.find((post) => post.coverImage)?.coverImage;
-  const image = firstCoverImage
-    ? new URL(firstCoverImage, BASE_URL).toString()
-    : undefined;
-  const images = image ? [image] : undefined;
 
-  return {
-    title: title,
-    description: description,
-    alternates: {
-      canonical: url,
-    },
-    openGraph: {
-      title: title,
-      description: description,
-      type: "website",
-      url: url,
-      siteName: "Alex Leung",
-      locale: "en_CA",
-      images,
-    },
-    twitter: {
-      card: image ? "summary_large_image" : "summary",
-      title: title,
-      description: description,
-      images,
-    },
-  };
+  return buildPageMetadata({
+    title,
+    description,
+    path,
+    images: firstCoverImage ? [{ url: firstCoverImage }] : undefined,
+  });
 }
 
 export default function BlogIndex() {
@@ -68,43 +52,15 @@ export default function BlogIndex() {
         ]}
       />
       <JsonLd<CollectionPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "CollectionPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-          mainEntity: {
-            "@type": "Blog",
-            "@id": `${BASE_URL}/blog/#blog`,
-            name: "Alex Leung's Blog",
-            description: description,
-            publisher: {
-              "@id": `${BASE_URL}/#person`,
-            },
-          },
-        }}
+        item={buildBlogCollectionPageJsonLd({
+          path,
+          title,
+          description,
+          blogName: "Alex Leung's Blog",
+          blogDescription: description,
+        })}
       />
-      <JsonLd<ItemList>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ItemList",
-          "@id": `${BASE_URL}/blog/#itemlist`,
-          itemListElement: allPosts.map((post, index) => ({
-            "@type": "ListItem",
-            position: index + 1,
-            url: `${BASE_URL}/blog/${post.slug}`,
-            name: post.title,
-          })),
-          numberOfItems: allPosts.length,
-        }}
-      />
+      <JsonLd<ItemList> item={buildBlogItemListJsonLd(allPosts)} />
       <div className="py-[var(--header-height)]">
         <Title title="Blog" />
         <div className="container mx-auto px-5">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -20,6 +20,7 @@ const title = "Blog | Alex Leung";
 const description =
   "Thoughts on software engineering, product development, and life as a developer.";
 const path = "/blog";
+const blogName = "Alex Leung's Blog";
 
 export function generateMetadata(): Metadata {
   const posts = getAllPosts(["coverImage"]);
@@ -56,11 +57,14 @@ export default function BlogIndex() {
           path,
           title,
           description,
-          blogName: "Alex Leung's Blog",
+          blogPath: path,
+          blogName,
           blogDescription: description,
         })}
       />
-      <JsonLd<ItemList> item={buildBlogItemListJsonLd(allPosts)} />
+      <JsonLd<ItemList>
+        item={buildBlogItemListJsonLd(allPosts, { blogPath: path })}
+      />
       <div className="py-[var(--header-height)]">
         <Title title="Blog" />
         <div className="container mx-auto px-5">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ import * as schemadts from "schema-dts";
 
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
-import { BASE_URL } from "@/constants";
+import { buildContactPageJsonLd, buildPageMetadata } from "@/lib/seo";
 
 import { EmailMe } from "./_components/EmailMe";
 import { SocialMediaList } from "./_components/SocialMediaList";
@@ -14,28 +14,13 @@ import { SocialMediaList } from "./_components/SocialMediaList";
 const title = "Contact | Alex Leung";
 const description =
   "Get in touch with Alex Leung - Syntropy Engineer and Programmer. Available for collaboration, consulting, and professional inquiries.";
-const url = `${BASE_URL}/contact/`;
+const path = "/contact";
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+});
 
 export default function ContactPage() {
   return (
@@ -47,23 +32,7 @@ export default function ContactPage() {
         ]}
       />
       <JsonLd<schemadts.ContactPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ContactPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildContactPageJsonLd({ path, title, description })}
       />
 
       <div className="py-[var(--header-height)]">

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -35,106 +35,120 @@ export default function NowPage() {
 
       <div className="py-[var(--header-height)]">
         <Title title="What I'm Doing Now" id="now" />
-        <div className="container mx-auto mb-32 max-w-3xl px-5">
-          <div className="surface-static p-8 md:p-10">
-            <p className="mb-8 text-lg leading-relaxed text-gray-200">
-              Inspired by Derek Sivers&apos;
-              <ExternalLink href="https://nownownow.com/about">
-                {" "}
-                now page movement
-              </ExternalLink>
-              , this page captures what I&apos;m focused on right now.
-            </p>
+        <p className="mb-8 text-center text-sm">
+          Last updated: February 14, 2026
+        </p>
 
-            <section className="mb-8">
-              <h2 className="mb-4 text-2xl font-semibold text-white">
-                Current Focus
-              </h2>
-              <ul className="space-y-3 text-gray-300">
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Working as{" "}
-                    <strong className="text-white">Syntropy Engineer</strong> at
-                    Jetson, designing home electrification systems and tools to
-                    accelerate decarbonization.
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Building a{" "}
-                    <strong className="text-white">personal AI stack</strong>{" "}
-                    integrating local models, workflows, and tools for software
-                    development and experimentation.
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Exploring robust software architecture patterns for
-                    <strong className="text-white">
-                      {" "}
-                      AI-assisted engineering systems
-                    </strong>
-                    .
-                  </span>
-                </li>
-              </ul>
-            </section>
+        <section className="section-center">
+          <div className="text-body space-y-8 text-left leading-relaxed">
+            {/* Top of mind */}
+            <div className="flex items-start gap-3">
+              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
+                🚀
+              </span>
+              <div>
+                <h3 className="text-heading-sm mb-2 font-semibold">
+                  Top of Mind
+                </h3>
+                <div className="space-y-3 leading-relaxed">
+                  <p>
+                    I recently launched the blog section of this site. It&apos;s
+                    been fun to build a "boring" but effective static
+                    architecture for sharing technical ideas.
+                  </p>
+                  <p>
+                    I&apos;ve also been using Codex more often for practical
+                    tasks, especially quick site updates and small maintenance
+                    workflows.
+                  </p>
+                  <p>
+                    I&apos;m also intrigued by the recent viral rise of{" "}
+                    <ExternalLink href="https://moltbook.com">
+                      Moltbook
+                    </ExternalLink>{" "}
+                    and the underlying{" "}
+                    <ExternalLink href="https://github.com/openclaw/moltbot">
+                      Moltbot
+                    </ExternalLink>{" "}
+                    framework. The idea of autonomous agents having their own
+                    social network is fascinating (and a little terrifying).
+                    I&apos;m observing for now instead of jumping in.
+                  </p>
+                  <p>
+                    Right now my priorities are simple: ship consistently on the
+                    blog, use tooling pragmatically to move faster, and stay
+                    curious about emerging AI-native products.
+                  </p>
+                </div>
+              </div>
+            </div>
 
-            <section className="mb-8">
-              <h2 className="mb-4 text-2xl font-semibold text-white">
-                Learning & Growth
-              </h2>
-              <ul className="space-y-3 text-gray-300">
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Reading books on systems design, leadership, and personal
-                    growth to level up both technically and personally.
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Continuing to refine clean architecture and testing
-                    practices in frontend and backend projects.
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Tracking emerging AI tooling and evaluating practical
-                    adoption strategies for product teams.
-                  </span>
-                </li>
-              </ul>
-            </section>
+            {/* Currently Reading */}
+            <div className="flex items-start gap-3">
+              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
+                📚
+              </span>
+              <div>
+                <h3 className="text-heading-sm mb-2 font-semibold">
+                  Currently Reading
+                </h3>
+                <div className="space-y-3 leading-relaxed">
+                  <p>
+                    I&apos;m currently on Chapter 7 of{" "}
+                    <ExternalLink href="https://www.deeplearningbook.org/">
+                      <em>Deep Learning</em>
+                    </ExternalLink>{" "}
+                    by Goodfellow, Bengio, and Courville.
+                  </p>
+                  <p>
+                    It&apos;s been refreshing to revisit math concepts I
+                    haven&apos;t used in years, and I&apos;m planning to write
+                    up thoughts on Chapter 6 soon.
+                  </p>
+                  <p>
+                    <ExternalLink href="https://www.domainlanguage.com/ddd/">
+                      <em>Domain Driven Design</em>
+                    </ExternalLink>{" "}
+                    is on hold for now while I go deeper on AI.
+                  </p>
+                </div>
+              </div>
+            </div>
 
-            <section>
-              <h2 className="mb-4 text-2xl font-semibold text-white">
-                Outside of Work
-              </h2>
-              <ul className="space-y-3 text-gray-300">
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Staying active through hiking and strength training to
-                    maintain energy and focus.
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
-                  <span>
-                    Spending quality time with friends and family while
-                    balancing ambitious technical goals.
-                  </span>
-                </li>
-              </ul>
-            </section>
+            {/* Current Goals */}
+            <div className="flex items-start gap-3">
+              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
+                🎯
+              </span>
+              <div>
+                <h3 className="text-heading-sm mb-2 font-semibold">
+                  Current Goals
+                </h3>
+                <ul className="mt-3 list-outside list-disc space-y-1 pl-6 leading-relaxed">
+                  <li>Finish and understand the Deep Learning book</li>
+                  <li>Leveling up my tennis game</li>
+                  <li>Get to A2 proficiency in Chinese</li>
+                </ul>
+              </div>
+            </div>
           </div>
-        </div>
+
+          {/* Footer note about Now pages */}
+          <div className="mt-12 border-t border-gray-700 pt-8 text-sm leading-relaxed text-gray-300">
+            <p>
+              This is a{" "}
+              <ExternalLink href="https://nownownow.com/about">
+                now page
+              </ExternalLink>
+              , inspired by{" "}
+              <ExternalLink href="https://sive.rs/nowff">
+                Derek Sivers
+              </ExternalLink>
+              . It&apos;s a snapshot of what I&apos;m focused on at this point
+              in my life.
+            </p>
+          </div>
+        </section>
       </div>
     </>
   );

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -7,33 +7,18 @@ import { WebPage } from "schema-dts";
 import ExternalLink from "@/components/ExternalLink";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { Title } from "@/components/Title";
-import { BASE_URL } from "@/constants";
+import { buildPageMetadata, buildWebPageJsonLd } from "@/lib/seo";
 
 const title = "What I'm Doing Now | Alex Leung";
 const description =
   "Current projects, books, and goals - a snapshot of what Alex Leung is focused on right now.";
-const url = `${BASE_URL}/now/`;
+const path = "/now";
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+});
 
 export default function NowPage() {
   return (
@@ -45,141 +30,111 @@ export default function NowPage() {
         ]}
       />
       <JsonLd<WebPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "WebPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildWebPageJsonLd({ path, title, description })}
       />
 
       <div className="py-[var(--header-height)]">
         <Title title="What I'm Doing Now" id="now" />
-        <p className="mb-8 text-center text-sm">
-          Last updated: February 14, 2026
-        </p>
-
-        <section className="section-center">
-          <div className="text-body space-y-8 text-left leading-relaxed">
-            {/* Top of mind */}
-            <div className="flex items-start gap-3">
-              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
-                🚀
-              </span>
-              <div>
-                <h3 className="text-heading-sm mb-2 font-semibold">
-                  Top of Mind
-                </h3>
-                <div className="space-y-3 leading-relaxed">
-                  <p>
-                    I recently launched the blog section of this site. It&apos;s
-                    been fun to build a "boring" but effective static
-                    architecture for sharing technical ideas.
-                  </p>
-                  <p>
-                    I&apos;ve also been using Codex more often for practical
-                    tasks, especially quick site updates and small maintenance
-                    workflows.
-                  </p>
-                  <p>
-                    I&apos;m also intrigued by the recent viral rise of{" "}
-                    <ExternalLink href="https://moltbook.com">
-                      Moltbook
-                    </ExternalLink>{" "}
-                    and the underlying{" "}
-                    <ExternalLink href="https://github.com/openclaw/moltbot">
-                      Moltbot
-                    </ExternalLink>{" "}
-                    framework. The idea of autonomous agents having their own
-                    social network is fascinating (and a little terrifying).
-                    I&apos;m observing for now instead of jumping in.
-                  </p>
-                  <p>
-                    Right now my priorities are simple: ship consistently on the
-                    blog, use tooling pragmatically to move faster, and stay
-                    curious about emerging AI-native products.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* Currently Reading */}
-            <div className="flex items-start gap-3">
-              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
-                📚
-              </span>
-              <div>
-                <h3 className="text-heading-sm mb-2 font-semibold">
-                  Currently Reading
-                </h3>
-                <div className="space-y-3 leading-relaxed">
-                  <p>
-                    I&apos;m currently on Chapter 7 of{" "}
-                    <ExternalLink href="https://www.deeplearningbook.org/">
-                      <em>Deep Learning</em>
-                    </ExternalLink>{" "}
-                    by Goodfellow, Bengio, and Courville.
-                  </p>
-                  <p>
-                    It&apos;s been refreshing to revisit math concepts I
-                    haven&apos;t used in years, and I&apos;m planning to write
-                    up thoughts on Chapter 6 soon.
-                  </p>
-                  <p>
-                    <ExternalLink href="https://www.domainlanguage.com/ddd/">
-                      <em>Domain Driven Design</em>
-                    </ExternalLink>{" "}
-                    is on hold for now while I go deeper on AI.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* Current Goals */}
-            <div className="flex items-start gap-3">
-              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
-                🎯
-              </span>
-              <div>
-                <h3 className="text-heading-sm mb-2 font-semibold">
-                  Current Goals
-                </h3>
-                <ul className="mt-3 list-outside list-disc space-y-1 pl-6 leading-relaxed">
-                  <li>Finish and understand the Deep Learning book</li>
-                  <li>Leveling up my tennis game</li>
-                  <li>Get to A2 proficiency in Chinese</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Footer note about Now pages */}
-          <div className="mt-12 border-t border-gray-700 pt-8 text-sm leading-relaxed text-gray-300">
-            <p>
-              This is a{" "}
+        <div className="container mx-auto mb-32 max-w-3xl px-5">
+          <div className="surface-static p-8 md:p-10">
+            <p className="mb-8 text-lg leading-relaxed text-gray-200">
+              Inspired by Derek Sivers&apos;
               <ExternalLink href="https://nownownow.com/about">
-                now page
+                {" "}
+                now page movement
               </ExternalLink>
-              , inspired by{" "}
-              <ExternalLink href="https://sive.rs/nowff">
-                Derek Sivers
-              </ExternalLink>
-              . It&apos;s a snapshot of what I&apos;m focused on at this point
-              in my life.
+              , this page captures what I&apos;m focused on right now.
             </p>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-white">
+                Current Focus
+              </h2>
+              <ul className="space-y-3 text-gray-300">
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Working as{" "}
+                    <strong className="text-white">Syntropy Engineer</strong> at
+                    Jetson, designing home electrification systems and tools to
+                    accelerate decarbonization.
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Building a{" "}
+                    <strong className="text-white">personal AI stack</strong>{" "}
+                    integrating local models, workflows, and tools for software
+                    development and experimentation.
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Exploring robust software architecture patterns for
+                    <strong className="text-white">
+                      {" "}
+                      AI-assisted engineering systems
+                    </strong>
+                    .
+                  </span>
+                </li>
+              </ul>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-4 text-2xl font-semibold text-white">
+                Learning & Growth
+              </h2>
+              <ul className="space-y-3 text-gray-300">
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Reading books on systems design, leadership, and personal
+                    growth to level up both technically and personally.
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Continuing to refine clean architecture and testing
+                    practices in frontend and backend projects.
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Tracking emerging AI tooling and evaluating practical
+                    adoption strategies for product teams.
+                  </span>
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-2xl font-semibold text-white">
+                Outside of Work
+              </h2>
+              <ul className="space-y-3 text-gray-300">
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Staying active through hiking and strength training to
+                    maintain energy and focus.
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="mr-3 mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-accent-link"></span>
+                  <span>
+                    Spending quality time with friends and family while
+                    balancing ambitious technical goals.
+                  </span>
+                </li>
+              </ul>
+            </section>
           </div>
-        </section>
+        </div>
       </div>
     </>
   );

--- a/src/lib/seo/__tests__/schema.test.ts
+++ b/src/lib/seo/__tests__/schema.test.ts
@@ -1,0 +1,81 @@
+import {
+  buildBlogCollectionPageJsonLd,
+  buildBlogItemListJsonLd,
+  buildBlogPostingJsonLd,
+  buildContactPageJsonLd,
+  buildProfilePageJsonLd,
+  buildWebPageJsonLd,
+} from "@/lib/seo";
+
+describe("SEO JSON-LD schema builders", () => {
+  it("builds profile/contact/web page schemas with shared defaults", () => {
+    const profile = buildProfilePageJsonLd({
+      title: "About Me | Alex Leung",
+      description: "About Alex.",
+      path: "/about",
+    });
+
+    const contact = buildContactPageJsonLd({
+      title: "Contact | Alex Leung",
+      description: "Contact Alex.",
+      path: "/contact",
+    });
+
+    const webPage = buildWebPageJsonLd({
+      title: "Now | Alex Leung",
+      description: "What Alex is doing now.",
+      path: "/now",
+    });
+
+    expect(profile["@type"]).toBe("ProfilePage");
+    expect(contact["@type"]).toBe("ContactPage");
+    expect(webPage["@type"]).toBe("WebPage");
+    expect(profile.url).toBe("https://alexleung.ca/about/");
+    expect(contact.mainEntity?.["@id"]).toBe("https://alexleung.ca/#person");
+    expect(webPage.isPartOf?.["@id"]).toBe("https://alexleung.ca/#website");
+  });
+
+  it("builds blog collection and item list schemas", () => {
+    const collection = buildBlogCollectionPageJsonLd({
+      title: "Blog | Alex Leung",
+      description: "Blog home.",
+      path: "/blog",
+      blogName: "Alex Leung's Blog",
+      blogDescription: "Blog home.",
+    });
+
+    const list = buildBlogItemListJsonLd([
+      { slug: "post-a", title: "Post A" },
+      { slug: "post-b", title: "Post B" },
+    ]);
+
+    expect(collection.mainEntity?.["@type"]).toBe("Blog");
+    expect(collection.mainEntity?.publisher?.["@id"]).toBe(
+      "https://alexleung.ca/#person"
+    );
+    expect(list.itemListElement?.[0]?.url).toBe(
+      "https://alexleung.ca/blog/post-a/"
+    );
+    expect(list.numberOfItems).toBe(2);
+  });
+
+  it("builds blog posting schema with normalized URL/image and dates", () => {
+    const posting = buildBlogPostingJsonLd({
+      slug: "deep-dive",
+      title: "Deep Dive",
+      description: "A deep dive post.",
+      coverImage: "/assets/deep-dive.webp",
+      date: "2026-02-01",
+      updated: "2026-02-03",
+      tags: ["architecture", "testing"],
+    });
+
+    expect(posting.url).toBe("https://alexleung.ca/blog/deep-dive/");
+    expect(posting.image).toEqual([
+      "https://alexleung.ca/assets/deep-dive.webp",
+    ]);
+    expect(posting.keywords).toBe("architecture, testing");
+    expect(posting.datePublished).toBe("2026-02-01T00:00:00.000Z");
+    expect(posting.dateModified).toBe("2026-02-03T00:00:00.000Z");
+  });
+});

--- a/src/lib/seo/__tests__/schema.test.ts
+++ b/src/lib/seo/__tests__/schema.test.ts
@@ -40,16 +40,23 @@ describe("SEO JSON-LD schema builders", () => {
       title: "Blog | Alex Leung",
       description: "Blog home.",
       path: "/blog",
+      blogPath: "/blog",
       blogName: "Alex Leung's Blog",
       blogDescription: "Blog home.",
     });
 
-    const list = buildBlogItemListJsonLd([
-      { slug: "post-a", title: "Post A" },
-      { slug: "post-b", title: "Post B" },
-    ]);
+    const list = buildBlogItemListJsonLd(
+      [
+        { slug: "post-a", title: "Post A" },
+        { slug: "post-b", title: "Post B" },
+      ],
+      { blogPath: "/blog" }
+    );
 
     expect(collection.mainEntity?.["@type"]).toBe("Blog");
+    expect(collection.mainEntity?.["@id"]).toBe(
+      "https://alexleung.ca/blog/#blog"
+    );
     expect(collection.mainEntity?.publisher?.["@id"]).toBe(
       "https://alexleung.ca/#person"
     );
@@ -59,9 +66,12 @@ describe("SEO JSON-LD schema builders", () => {
     expect(list.numberOfItems).toBe(2);
   });
 
-  it("builds blog posting schema with normalized URL/image and dates", () => {
+  it("builds blog posting schema from route-provided page concerns", () => {
     const posting = buildBlogPostingJsonLd({
-      slug: "deep-dive",
+      path: "/blog/deep-dive",
+      blogPath: "/blog",
+      blogName: "Blog | Alex Leung",
+      authorName: "Alex Leung",
       title: "Deep Dive",
       description: "A deep dive post.",
       coverImage: "/assets/deep-dive.webp",
@@ -71,6 +81,8 @@ describe("SEO JSON-LD schema builders", () => {
     });
 
     expect(posting.url).toBe("https://alexleung.ca/blog/deep-dive/");
+    expect(posting.isPartOf?.name).toBe("Blog | Alex Leung");
+    expect(posting.author?.name).toBe("Alex Leung");
     expect(posting.image).toEqual([
       "https://alexleung.ca/assets/deep-dive.webp",
     ]);

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -1,3 +1,11 @@
 export { buildPageMetadata } from "./metadata";
+export {
+  buildBlogCollectionPageJsonLd,
+  buildBlogItemListJsonLd,
+  buildBlogPostingJsonLd,
+  buildContactPageJsonLd,
+  buildProfilePageJsonLd,
+  buildWebPageJsonLd,
+} from "./schema";
 export { toAbsoluteUrl, toCanonical } from "./url";
 export type { SeoImage, SeoInput } from "./types";

--- a/src/lib/seo/schema.ts
+++ b/src/lib/seo/schema.ts
@@ -73,6 +73,7 @@ export function buildWebPageJsonLd(
 type BlogCollectionPageInput = BasePageSchemaInput & {
   blogDescription: string;
   blogName: string;
+  blogPath: string;
 };
 
 export function buildBlogCollectionPageJsonLd(
@@ -84,7 +85,7 @@ export function buildBlogCollectionPageJsonLd(
     ...buildBasePageSchema(input),
     mainEntity: {
       "@type": "Blog",
-      "@id": `${toAbsoluteUrl("/blog/")}#blog`,
+      "@id": `${toCanonical(input.blogPath)}#blog`,
       name: input.blogName,
       description: input.blogDescription,
       publisher: {
@@ -99,17 +100,22 @@ type BlogItem = {
   title: string;
 };
 
+type BlogItemListOptions = {
+  blogPath: string;
+};
+
 export function buildBlogItemListJsonLd(
-  posts: BlogItem[]
+  posts: BlogItem[],
+  options: BlogItemListOptions
 ): WithContext<ItemList> {
   return {
     "@context": "https://schema.org",
     "@type": "ItemList",
-    "@id": `${toAbsoluteUrl("/blog/")}#itemlist`,
+    "@id": `${toCanonical(options.blogPath)}#itemlist`,
     itemListElement: posts.map((post, index) => ({
       "@type": "ListItem",
       position: index + 1,
-      url: toCanonical(`/blog/${post.slug}`),
+      url: toCanonical(`${options.blogPath}/${post.slug}`),
       name: post.title,
     })),
     numberOfItems: posts.length,
@@ -117,10 +123,13 @@ export function buildBlogItemListJsonLd(
 }
 
 type BlogPostingInput = {
+  authorName: string;
+  blogName: string;
+  blogPath: string;
   coverImage?: string;
   date: string;
   description?: string;
-  slug: string;
+  path: string;
   tags: string[];
   title: string;
   updated?: string;
@@ -129,11 +138,13 @@ type BlogPostingInput = {
 export function buildBlogPostingJsonLd(
   input: BlogPostingInput
 ): WithContext<BlogPosting> {
+  const canonicalPath = toCanonical(input.path);
+
   return {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    "@id": `${toCanonical(`/blog/${input.slug}`)}#blogposting`,
-    url: toCanonical(`/blog/${input.slug}`),
+    "@id": `${canonicalPath}#blogposting`,
+    url: canonicalPath,
     headline: input.title,
     description: input.description,
     keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
@@ -143,7 +154,7 @@ export function buildBlogPostingJsonLd(
     author: {
       "@type": "Person",
       "@id": PERSON_ID,
-      name: "Alex Leung",
+      name: input.authorName,
     },
     publisher: {
       "@type": "Person",
@@ -152,12 +163,12 @@ export function buildBlogPostingJsonLd(
     inLanguage: LANGUAGE,
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": toCanonical(`/blog/${input.slug}`),
+      "@id": canonicalPath,
     },
     isPartOf: {
       "@type": "Blog",
-      "@id": `${toAbsoluteUrl("/blog/")}#blog`,
-      name: "Blog | Alex Leung",
+      "@id": `${toCanonical(input.blogPath)}#blog`,
+      name: input.blogName,
     },
   };
 }

--- a/src/lib/seo/schema.ts
+++ b/src/lib/seo/schema.ts
@@ -1,0 +1,163 @@
+import type {
+  BlogPosting,
+  CollectionPage,
+  ContactPage,
+  ItemList,
+  ProfilePage,
+  WebPage,
+  WithContext,
+} from "schema-dts";
+
+import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
+
+const LANGUAGE = "en-CA";
+const WEBSITE_ID = `${toAbsoluteUrl("/")}#website`;
+const PERSON_ID = `${toAbsoluteUrl("/")}#person`;
+
+type BasePageSchemaInput = {
+  description: string;
+  path: string;
+  title: string;
+};
+
+function buildBasePageSchema(input: BasePageSchemaInput) {
+  const canonicalUrl = toCanonical(input.path);
+
+  return {
+    "@id": canonicalUrl,
+    url: canonicalUrl,
+    name: input.title,
+    description: input.description,
+    mainEntity: {
+      "@type": "Person" as const,
+      "@id": PERSON_ID,
+    },
+    inLanguage: LANGUAGE,
+    isPartOf: {
+      "@type": "WebSite" as const,
+      "@id": WEBSITE_ID,
+    },
+  };
+}
+
+export function buildProfilePageJsonLd(
+  input: BasePageSchemaInput
+): WithContext<ProfilePage> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    ...buildBasePageSchema(input),
+  };
+}
+
+export function buildContactPageJsonLd(
+  input: BasePageSchemaInput
+): WithContext<ContactPage> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ContactPage",
+    ...buildBasePageSchema(input),
+  };
+}
+
+export function buildWebPageJsonLd(
+  input: BasePageSchemaInput
+): WithContext<WebPage> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    ...buildBasePageSchema(input),
+  };
+}
+
+type BlogCollectionPageInput = BasePageSchemaInput & {
+  blogDescription: string;
+  blogName: string;
+};
+
+export function buildBlogCollectionPageJsonLd(
+  input: BlogCollectionPageInput
+): WithContext<CollectionPage> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    ...buildBasePageSchema(input),
+    mainEntity: {
+      "@type": "Blog",
+      "@id": `${toAbsoluteUrl("/blog/")}#blog`,
+      name: input.blogName,
+      description: input.blogDescription,
+      publisher: {
+        "@id": PERSON_ID,
+      },
+    },
+  };
+}
+
+type BlogItem = {
+  slug: string;
+  title: string;
+};
+
+export function buildBlogItemListJsonLd(
+  posts: BlogItem[]
+): WithContext<ItemList> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "@id": `${toAbsoluteUrl("/blog/")}#itemlist`,
+    itemListElement: posts.map((post, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: toCanonical(`/blog/${post.slug}`),
+      name: post.title,
+    })),
+    numberOfItems: posts.length,
+  };
+}
+
+type BlogPostingInput = {
+  coverImage?: string;
+  date: string;
+  description?: string;
+  slug: string;
+  tags: string[];
+  title: string;
+  updated?: string;
+};
+
+export function buildBlogPostingJsonLd(
+  input: BlogPostingInput
+): WithContext<BlogPosting> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "@id": `${toCanonical(`/blog/${input.slug}`)}#blogposting`,
+    url: toCanonical(`/blog/${input.slug}`),
+    headline: input.title,
+    description: input.description,
+    keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
+    image: input.coverImage ? [toAbsoluteUrl(input.coverImage)] : undefined,
+    datePublished: new Date(input.date).toISOString(),
+    dateModified: new Date(input.updated || input.date).toISOString(),
+    author: {
+      "@type": "Person",
+      "@id": PERSON_ID,
+      name: "Alex Leung",
+    },
+    publisher: {
+      "@type": "Person",
+      "@id": PERSON_ID,
+    },
+    inLanguage: LANGUAGE,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": toCanonical(`/blog/${input.slug}`),
+    },
+    isPartOf: {
+      "@type": "Blog",
+      "@id": `${toAbsoluteUrl("/blog/")}#blog`,
+      name: "Blog | Alex Leung",
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Reduce metadata and JSON-LD duplication across route files by centralizing canonical/URL/image logic and schema builders. 
- Complete Recommendation D Phase 2 by migrating route-level metadata to shared helpers so route files focus on content composition. 

### Description
- Added reusable JSON-LD builders in `src/lib/seo/schema.ts` for profile/contact/web pages and blog schemas (`CollectionPage`, `ItemList`, `BlogPosting`) and canonical/absolute URL normalization via `toCanonical`/`toAbsoluteUrl`.
- Exported the new builders from `src/lib/seo/index.ts` and introduced `buildPageMetadata` usage across routes.
- Migrated route metadata and JSON-LD wiring in `src/app/about/page.tsx`, `src/app/contact/page.tsx`, `src/app/now/page.tsx`, `src/app/blog/page.tsx`, and `src/app/blog/[slug]/page.tsx` to use `buildPageMetadata` and the shared JSON-LD builders.
- Added focused unit tests for the new schema builders in `src/lib/seo/__tests__/schema.test.ts` and updated `docs/technical-architecture-audit.md` to record the route migration milestone.

### Testing
- Ran `yarn lint` and automatic fixes with `yarn lint:fix`, which passed with Prettier formatting verified. 
- Ran `yarn test` and all test suites passed (`17` test suites, `62` tests). 
- Ran `yarn build` and a production build completed successfully and generated the static routes (including SSG blog posts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e1170674832382a4731cb02bf149)