### PR TITLE
Implement UX/UI audit Phase 2 primitives and adopt across pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ src/
 - `docs/README.md` - Documentation directory guide and document index
 - `docs/technical-architecture-audit.md` - Architecture findings and current status
 - `docs/seo-audit.md` - SEO findings and recommendations
+- `docs/ux-ui-audit.md` - UX/UI findings and primitive rollout phases
 - `docs/content-ideas.md` - Future content and page ideas
 
 ## :package: Dependencies

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This folder contains repository-internal documents that support planning, audits
 | --- | --- | --- |
 | `technical-architecture-audit.md` | Architecture patterns, risks, and priorities | After major platform or dependency shifts |
 | `seo-audit.md` | SEO implementation audit and optimization backlog | After metadata/schema/content model updates |
+| `ux-ui-audit.md` | UX/UI audit findings and primitive refactor roadmap | After notable UI system changes |
 | `content-ideas.md` | Idea backlog for new pages and editorial themes | As ideas are added or completed |
 
 ## What belongs in `/docs`

--- a/docs/ux-ui-audit.md
+++ b/docs/ux-ui-audit.md
@@ -137,11 +137,17 @@ It also identifies UI primitives that should be refactored into reusable compone
 3. `Surface`
 4. `CoverImage`
 
-### Phase 2
-5. `SectionBlock`
-6. `Tag` / `Badge`
-7. `LinkText`
-8. `ProseContent`
+### Phase 2 (implemented)
+5. ✅ `SectionBlock`
+6. ✅ `Tag` / `Badge`
+7. ✅ `LinkText`
+8. ✅ `ProseContent`
+
+#### Phase 2 implementation notes
+- Added reusable `SectionBlock` scaffolding and applied it to About and Now route content sections.
+- Introduced `Tag`/`Badge` primitives to standardize metadata and status chips across blog and now-page UI.
+- Added `LinkText` as the canonical link-style primitive and routed `ExternalLink` through it for style consistency.
+- Added `ProseContent` wrapper and migrated blog-post body rendering and now-page footer prose to shared typography defaults.
 
 ### Phase 3
 9. `AppBackground`

--- a/src/app/about/_components/Credentials.tsx
+++ b/src/app/about/_components/Credentials.tsx
@@ -1,84 +1,80 @@
 import { Card } from "@/components/Card";
 import ExternalLink from "@/components/ExternalLink";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { Subtitle } from "@/components/Subtitle";
+import { SectionBlock } from "@/components/SectionBlock";
 
 export function Credentials() {
   return (
     <ResponsiveContainer element="section">
-      <Subtitle title="Credentials" id="credentials" />
+      <SectionBlock title="Credentials" titleId="credentials">
+        <p className="mb-6 leading-relaxed text-gray-300">
+          I try to bring rigor, accountability, and pragmatism to technology
+          work, shaped by my training and experience.
+        </p>
 
-      <p className="mb-6 leading-relaxed text-gray-300">
-        I try to bring rigor, accountability, and pragmatism to technology work,
-        shaped by my training and experience.
-      </p>
-
-      <div className="flex flex-col gap-6">
-        {/* P.Eng. Credential */}
-        <Card>
-          <div className="flex items-start gap-4">
-            <div className="text-3xl">🛠️</div>
-            <div>
-              <h3 className="mb-2 text-xl font-semibold">
-                Professional Engineer (P.Eng.)
-              </h3>
-              <p className="mb-2 text-lg">
-                <ExternalLink href="https://www.peo.on.ca">
-                  Professional Engineers Ontario (PEO)
-                </ExternalLink>
-              </p>
-              <p className="leading-relaxed text-gray-300">
-                Licensed in Ontario. I apply engineering discipline and ethics
-                to software and AI systems.
-              </p>
+        <div className="flex flex-col gap-6">
+          <Card>
+            <div className="flex items-start gap-4">
+              <div className="text-3xl">🛠️</div>
+              <div>
+                <h3 className="mb-2 text-xl font-semibold">
+                  Professional Engineer (P.Eng.)
+                </h3>
+                <p className="mb-2 text-lg">
+                  <ExternalLink href="https://www.peo.on.ca">
+                    Professional Engineers Ontario (PEO)
+                  </ExternalLink>
+                </p>
+                <p className="leading-relaxed text-gray-300">
+                  Licensed in Ontario. I apply engineering discipline and ethics
+                  to software and AI systems.
+                </p>
+              </div>
             </div>
+          </Card>
+
+          <div className="grid gap-8 md:grid-cols-2">
+            <Card>
+              <div className="mb-4">
+                <h3 className="mb-1 text-xl font-semibold">
+                  <ExternalLink href="https://ece.gatech.edu/">
+                    Georgia Institute of Technology
+                  </ExternalLink>
+                </h3>
+                <p className="text-lg font-medium text-white">
+                  MSECE, Electrical & Computer Engineering
+                </p>
+                <p className="text-gray-300">2013 - 2016</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-300">
+                  <strong>Concentrations:</strong> Computer Engineering,
+                  Telecommunications
+                </p>
+              </div>
+            </Card>
+
+            <Card>
+              <div className="mb-4">
+                <h3 className="mb-1 text-xl font-semibold">
+                  <ExternalLink href="https://uwaterloo.ca/electrical-computer-engineering/">
+                    University of Waterloo
+                  </ExternalLink>
+                </h3>
+                <p className="text-lg font-medium text-white">
+                  BASc, Electrical Engineering & Pure Mathematics
+                </p>
+                <p className="text-gray-300">2008 - 2013</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-300">
+                  <strong>Concentrations:</strong> Control, Power, Mathematics
+                </p>
+              </div>
+            </Card>
           </div>
-        </Card>
-
-        {/* Education */}
-        <div className="grid gap-8 md:grid-cols-2">
-          {/* Georgia Tech */}
-          <Card>
-            <div className="mb-4">
-              <h3 className="mb-1 text-xl font-semibold">
-                <ExternalLink href="https://ece.gatech.edu/">
-                  Georgia Institute of Technology
-                </ExternalLink>
-              </h3>
-              <p className="text-lg font-medium text-white">
-                MSECE, Electrical & Computer Engineering
-              </p>
-              <p className="text-gray-300">2013 - 2016</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-300">
-                <strong>Concentrations:</strong> Computer Engineering,
-                Telecommunications
-              </p>
-            </div>
-          </Card>
-
-          {/* University of Waterloo */}
-          <Card>
-            <div className="mb-4">
-              <h3 className="mb-1 text-xl font-semibold">
-                <ExternalLink href="https://uwaterloo.ca/electrical-computer-engineering/">
-                  University of Waterloo
-                </ExternalLink>
-              </h3>
-              <p className="text-lg font-medium text-white">
-                BASc, Electrical Engineering & Pure Mathematics
-              </p>
-              <p className="text-gray-300">2008 - 2013</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-300">
-                <strong>Concentrations:</strong> Control, Power, Mathematics
-              </p>
-            </div>
-          </Card>
         </div>
-      </div>
+      </SectionBlock>
     </ResponsiveContainer>
   );
 }

--- a/src/app/about/_components/MyBackground.tsx
+++ b/src/app/about/_components/MyBackground.tsx
@@ -2,98 +2,104 @@ import Image from "next/image";
 
 import ExternalLink from "@/components/ExternalLink";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { Subtitle } from "@/components/Subtitle";
+import { SectionBlock } from "@/components/SectionBlock";
 
 export function Journey() {
   return (
     <ResponsiveContainer element="section">
-      <Subtitle title="My Background" id="background" />
+      <SectionBlock title="My Background" titleId="background" spacing="lg">
+        <div className="md:grid md:grid-cols-[3fr_2fr] md:gap-x-16 md:pt-8">
+          <div className="text-md mb-8 text-left leading-relaxed lg:text-lg">
+            <div className="mb-6 flex items-start gap-3">
+              <span className="mt-1 flex-shrink-0 text-xl">👋</span>
+              <div>
+                <h3 className="text-heading-sm mb-1 font-semibold">Hello</h3>
+                <p className="leading-relaxed">
+                  Hi! I&apos;m Alex, and I&apos;m glad you&apos;re here.
+                </p>
+              </div>
+            </div>
 
-      <div className="md:grid md:grid-cols-[3fr_2fr] md:gap-x-16 md:pt-8">
-        <div className="text-md mb-8 text-left leading-relaxed lg:text-lg">
-          <div className="mb-6 flex items-start gap-3">
-            <span className="mt-1 flex-shrink-0 text-xl">👋</span>
-            <div>
-              <h3 className="text-heading-sm mb-1 font-semibold">Hello</h3>
-              <p className="leading-relaxed">
-                Hi! I&apos;m Alex, and I&apos;m glad you&apos;re here.
-              </p>
+            <div className="mb-6 flex items-start gap-3">
+              <span className="mt-1 flex-shrink-0 text-xl">💼</span>
+              <div>
+                <h3 className="text-heading-sm mb-1 font-semibold">
+                  What I Do
+                </h3>
+                <p className="leading-relaxed">
+                  I&apos;m currently at{" "}
+                  <ExternalLink href="https://jetsonhome.com">
+                    Jetson
+                  </ExternalLink>
+                  , helping electrify North American homes with vertically
+                  integrated energy solutions.
+                </p>
+                <p className="mt-3 leading-relaxed">
+                  Before that, I worked on AR/AI glasses at{" "}
+                  <ExternalLink href="https://arvr.google.com/">
+                    Google
+                  </ExternalLink>{" "}
+                  and product engineering at{" "}
+                  <ExternalLink href="https://cash.app/">Cash App</ExternalLink>
+                  .
+                </p>
+              </div>
+            </div>
+
+            <div className="mb-6 flex items-start gap-3">
+              <span className="mt-1 flex-shrink-0 text-xl">🚀</span>
+              <div>
+                <h3 className="text-heading-sm mb-1 font-semibold">
+                  How I Work
+                </h3>
+                <p className="leading-relaxed">
+                  I build products from 0→1 and help scale them from 1→100.
+                </p>
+                <p className="mt-3 leading-relaxed">
+                  My background spans distributed systems, embedded systems, and
+                  AI. My approach is simple:{" "}
+                  <strong>prioritize momentum, then optimize for scale.</strong>
+                </p>
+                <ul className="mt-3 list-inside list-disc space-y-1">
+                  <li>Lean into ambiguity</li>
+                  <li>Break large problems into clear roadmaps</li>
+                  <li>Keep teams aligned and shipping</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="mb-6 flex items-start gap-3">
+              <span className="mt-1 flex-shrink-0 text-xl">❤️</span>
+              <div>
+                <h3 className="text-heading-sm mb-1 font-semibold">
+                  Outside Work
+                </h3>
+                <p className="leading-relaxed">
+                  I&apos;m motivated by building useful things, getting
+                  meaningful work done, and learning continuously.
+                </p>
+                <p className="mt-3 leading-relaxed">
+                  Outside of work, I spend time playing tennis 🎾, reading 📚,
+                  hiking 🏔️, rock climbing 🧗, and hanging out with my furmily
+                  🐱.
+                </p>
+              </div>
             </div>
           </div>
 
-          <div className="mb-6 flex items-start gap-3">
-            <span className="mt-1 flex-shrink-0 text-xl">💼</span>
-            <div>
-              <h3 className="text-heading-sm mb-1 font-semibold">What I Do</h3>
-              <p className="leading-relaxed">
-                I&apos;m currently at{" "}
-                <ExternalLink href="https://jetsonhome.com">
-                  Jetson
-                </ExternalLink>
-                , helping electrify North American homes with vertically
-                integrated energy solutions.
-              </p>
-              <p className="mt-3 leading-relaxed">
-                Before that, I worked on AR/AI glasses at{" "}
-                <ExternalLink href="https://arvr.google.com/">
-                  Google
-                </ExternalLink>{" "}
-                and product engineering at{" "}
-                <ExternalLink href="https://cash.app/">Cash App</ExternalLink>.
-              </p>
-            </div>
-          </div>
-
-          <div className="mb-6 flex items-start gap-3">
-            <span className="mt-1 flex-shrink-0 text-xl">🚀</span>
-            <div>
-              <h3 className="text-heading-sm mb-1 font-semibold">How I Work</h3>
-              <p className="leading-relaxed">
-                I build products from 0→1 and help scale them from 1→100.
-              </p>
-              <p className="mt-3 leading-relaxed">
-                My background spans distributed systems, embedded systems, and
-                AI. My approach is simple:{" "}
-                <strong>prioritize momentum, then optimize for scale.</strong>
-              </p>
-              <ul className="mt-3 list-inside list-disc space-y-1">
-                <li>Lean into ambiguity</li>
-                <li>Break large problems into clear roadmaps</li>
-                <li>Keep teams aligned and shipping</li>
-              </ul>
-            </div>
-          </div>
-
-          <div className="mb-6 flex items-start gap-3">
-            <span className="mt-1 flex-shrink-0 text-xl">❤️</span>
-            <div>
-              <h3 className="text-heading-sm mb-1 font-semibold">
-                Outside Work
-              </h3>
-              <p className="leading-relaxed">
-                I&apos;m motivated by building useful things, getting meaningful
-                work done, and learning continuously.
-              </p>
-              <p className="mt-3 leading-relaxed">
-                Outside of work, I spend time playing tennis 🎾, reading 📚,
-                hiking 🏔️, rock climbing 🧗, and hanging out with my furmily 🐱.
-              </p>
-            </div>
+          <div className="flex flex-col gap-4 md:gap-6">
+            <Image
+              src="/assets/about_portrait.webp"
+              alt="Alex Leung sitting on a mountain trail during a hiking adventure"
+              width={400}
+              height={400}
+              priority
+              placeholder="blur"
+              blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAhEAACAQMDBQAAAAAAAAAAAAABAgMABAUGIWGRkqGx0f/EABUBAQEAAAAAAAAAAAAAAAAAAAMF/8QAGhEAAgIDAAAAAAAAAAAAAAAAAAECEgMRkf/aAAwDAQACEQMRAD8AltJagyeH0AthI5xdrLcNM91BF5pX2HaH9bcfaSXWGaRmknyLDSEsAy2kZTNL4a4VNPgABNVMm1kEhQXEmQr/AMHkABFxXjQW0iyRwwq"
+            />
           </div>
         </div>
-
-        <div className="flex flex-col gap-4 md:gap-6">
-          <Image
-            src="/assets/about_portrait.webp"
-            alt="Alex Leung sitting on a mountain trail during a hiking adventure"
-            width={400}
-            height={400}
-            priority
-            placeholder="blur"
-            blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAhEAACAQMDBQAAAAAAAAAAAAABAgMABAUGIWGRkqGx0f/EABUBAQEAAAAAAAAAAAAAAAAAAAMF/8QAGhEAAgIDAAAAAAAAAAAAAAAAAAECEgMRkf/aAAwDAQACEQMRAD8AltJagyeH0AthI5xdrLcNM91BF5pX2HaH9bcfaSXWGaRmknyLDSEsAy2kZTNL4a4VNPgABNVMm1kEhQXEmQr/AMHkABFxXjQW0iyRwwq"
-          />
-        </div>
-      </div>
+      </SectionBlock>
     </ResponsiveContainer>
   );
 }

--- a/src/app/about/_components/TechnicalInterests.tsx
+++ b/src/app/about/_components/TechnicalInterests.tsx
@@ -1,27 +1,28 @@
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { Subtitle } from "@/components/Subtitle";
+import { SectionBlock } from "@/components/SectionBlock";
 import { skills } from "@/constants/skills";
 
 export function Skills({ className }: { className?: string }) {
   return (
     <ResponsiveContainer element="section">
-      <Subtitle title="Technical Interests" id="technicalinterests" />
-      <div className={`text-md flex flex-col lg:text-lg ${className}`}>
-        Here are a few technical areas that I enjoy working in:
-        <ul className="mt-4 grid grid-cols-1 gap-x-4 lg:grid-cols-4">
-          {skills.map(({ skill }) => (
-            <li key={skill} className="mb-3 flex items-start gap-3 leading-6">
-              <span
-                aria-hidden="true"
-                className="pt-[2px] text-xl leading-none"
-              >
-                •
-              </span>
-              <span>{skill}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <SectionBlock title="Technical Interests" titleId="technicalinterests">
+        <div className={`text-md flex flex-col lg:text-lg ${className}`}>
+          Here are a few technical areas that I enjoy working in:
+          <ul className="mt-4 grid grid-cols-1 gap-x-4 lg:grid-cols-4">
+            {skills.map(({ skill }) => (
+              <li key={skill} className="mb-3 flex items-start gap-3 leading-6">
+                <span
+                  aria-hidden="true"
+                  className="pt-[2px] text-xl leading-none"
+                >
+                  •
+                </span>
+                <span>{skill}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </SectionBlock>
     </ResponsiveContainer>
   );
 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -9,8 +9,10 @@ import { BlogPosting } from "schema-dts";
 import { CoverImage } from "@/components/CoverImage";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
+import { ProseContent } from "@/components/ProseContent";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { Surface } from "@/components/Surface";
+import { Tag } from "@/components/Tag";
 import { BASE_URL } from "@/constants";
 import { getAllPosts, getPostBySlug } from "@/lib/blogApi";
 import markdownToHtml from "@/lib/markdownToHtml";
@@ -158,12 +160,7 @@ export default async function Post({ params }: Props) {
             {post.tags.length > 0 && (
               <div className="mb-6 flex flex-wrap gap-2">
                 {post.tags.map((tag) => (
-                  <span
-                    key={`${post.slug}-${tag}`}
-                    className="rounded-full border border-white/20 px-2.5 py-1 text-xs font-semibold text-gray-200"
-                  >
-                    {tag}
-                  </span>
+                  <Tag key={`${post.slug}-${tag}`}>{tag}</Tag>
                 ))}
               </div>
             )}
@@ -174,10 +171,7 @@ export default async function Post({ params }: Props) {
               sizes="(min-width: 1024px) 896px, 100vw"
               className="mb-6 sm:mx-0 md:mb-10"
             />
-            <div
-              className="prose prose-invert max-w-none md:prose-lg prose-headings:text-white prose-p:text-gray-300 prose-a:text-accent-link prose-a:no-underline hover:prose-a:text-accent-link-hover hover:prose-a:underline prose-strong:text-white prose-pre:border prose-pre:border-white/10 prose-pre:bg-black/50"
-              dangerouslySetInnerHTML={{ __html: content }}
-            />
+            <ProseContent html={content} />
           </Surface>
         </ResponsiveContainer>
       </PageShell>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -11,6 +11,7 @@ import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { surfaceClassNames } from "@/components/Surface";
+import { Tag } from "@/components/Tag";
 import { BASE_URL } from "@/constants";
 import { getAllPosts } from "@/lib/blogApi";
 
@@ -142,12 +143,7 @@ export default function BlogIndex() {
                 {post.tags.length > 0 && (
                   <div className="mb-4 flex flex-wrap gap-2">
                     {post.tags.map((tag) => (
-                      <span
-                        key={`${post.slug}-${tag}`}
-                        className="rounded-full border border-white/20 px-2.5 py-1 text-xs font-semibold text-gray-200"
-                      >
-                        {tag}
-                      </span>
+                      <Tag key={`${post.slug}-${tag}`}>{tag}</Tag>
                     ))}
                   </div>
                 )}

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -1,13 +1,17 @@
+import { ReactNode } from "react";
 import { JsonLd } from "react-schemaorg";
 
 import { Metadata } from "next";
 
 import { WebPage } from "schema-dts";
 
+import { Badge } from "@/components/Badge";
 import ExternalLink from "@/components/ExternalLink";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
+import { ProseContent } from "@/components/ProseContent";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
+import { SectionBlock } from "@/components/SectionBlock";
 import { BASE_URL } from "@/constants";
 
 export const NOW_PAGE_LAST_UPDATED_ISO = "2026-02-20";
@@ -49,6 +53,28 @@ export const metadata: Metadata = {
   },
 };
 
+function NowItem({
+  emoji,
+  title,
+  children,
+}: {
+  emoji: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
+        {emoji}
+      </span>
+      <div>
+        <h3 className="text-heading-sm mb-2 font-semibold">{title}</h3>
+        <div className="space-y-3 leading-relaxed">{children}</div>
+      </div>
+    </div>
+  );
+}
+
 export default function NowPage() {
   return (
     <>
@@ -79,103 +105,75 @@ export default function NowPage() {
       />
 
       <PageShell title="What I'm Doing Now" titleId="now">
-        <p className="mb-8 text-center text-sm">
-          Last updated: {NOW_PAGE_LAST_UPDATED_DISPLAY}
-        </p>
+        <div className="mb-8 text-center">
+          <Badge tone="info">
+            Last updated: {NOW_PAGE_LAST_UPDATED_DISPLAY}
+          </Badge>
+        </div>
 
         <ResponsiveContainer element="section">
-          <div className="text-body space-y-8 text-left leading-relaxed">
-            {/* Top of mind */}
-            <div className="flex items-start gap-3">
-              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
-                🚀
-              </span>
-              <div>
-                <h3 className="text-heading-sm mb-2 font-semibold">
-                  Top of Mind
-                </h3>
-                <div className="space-y-3 leading-relaxed">
-                  <p>
-                    I recently launched the blog section of this site. It&apos;s
-                    been fun to build a "boring" but effective static
-                    architecture for sharing technical ideas.
-                  </p>
-                  <p>
-                    I&apos;ve also been using Codex more often for practical
-                    tasks, especially quick site updates and small maintenance
-                    workflows. I&apos;ve also started using{" "}
-                    <ExternalLink href="https://www.conductor.build/">
-                      Conductor
-                    </ExternalLink>
-                    ; I like the UI and how easy it is to spin up new worktrees.
-                  </p>
-                  <p>
-                    Right now my priorities are simple: ship consistently on the
-                    blog, use tooling pragmatically to move faster, and stay
-                    curious about emerging AI-native products.
-                  </p>
-                </div>
-              </div>
-            </div>
+          <SectionBlock spacing="lg">
+            <div className="text-body space-y-8 text-left leading-relaxed">
+              <NowItem emoji="🚀" title="Top of Mind">
+                <p>
+                  I recently launched the blog section of this site. It&apos;s
+                  been fun to build a "boring" but effective static architecture
+                  for sharing technical ideas.
+                </p>
+                <p>
+                  I&apos;ve also been using Codex more often for practical
+                  tasks, especially quick site updates and small maintenance
+                  workflows. I&apos;ve also started using{" "}
+                  <ExternalLink href="https://www.conductor.build/">
+                    Conductor
+                  </ExternalLink>
+                  ; I like the UI and how easy it is to spin up new worktrees.
+                </p>
+                <p>
+                  Right now my priorities are simple: ship consistently on the
+                  blog, use tooling pragmatically to move faster, and stay
+                  curious about emerging AI-native products.
+                </p>
+              </NowItem>
 
-            {/* Currently Reading */}
-            <div className="flex items-start gap-3">
-              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
-                📚
-              </span>
-              <div>
-                <h3 className="text-heading-sm mb-2 font-semibold">
-                  Currently Reading
-                </h3>
-                <div className="space-y-3 leading-relaxed">
-                  <p>
-                    I&apos;m currently on Chapter 7 of{" "}
-                    <ExternalLink href="https://www.deeplearningbook.org/">
-                      <em>Deep Learning</em>
-                    </ExternalLink>{" "}
-                    by Goodfellow, Bengio, and Courville.
-                  </p>
-                  <p>
-                    <ExternalLink href="https://www.domainlanguage.com/ddd/">
-                      <em>Domain Driven Design</em>
-                    </ExternalLink>{" "}
-                    is on hold for now while I go deeper on AI.
-                  </p>
-                </div>
-              </div>
-            </div>
+              <NowItem emoji="📚" title="Currently Reading">
+                <p>
+                  I&apos;m currently on Chapter 7 of{" "}
+                  <ExternalLink href="https://www.deeplearningbook.org/">
+                    <em>Deep Learning</em>
+                  </ExternalLink>{" "}
+                  by Goodfellow, Bengio, and Courville.
+                </p>
+                <p>
+                  <ExternalLink href="https://www.domainlanguage.com/ddd/">
+                    <em>Domain Driven Design</em>
+                  </ExternalLink>{" "}
+                  is on hold for now while I go deeper on AI.
+                </p>
+              </NowItem>
 
-            {/* Current Goals */}
-            <div className="flex items-start gap-3">
-              <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
-                🎯
-              </span>
-              <div>
-                <h3 className="text-heading-sm mb-2 font-semibold">
-                  Current Goals
-                </h3>
+              <NowItem emoji="🎯" title="Current Goals">
                 <ul className="mt-3 list-outside list-disc space-y-1 pl-6 leading-relaxed">
                   <li>Finish and understand the Deep Learning book</li>
                   <li>Leveling up my tennis game</li>
                   <li>Get to A2 proficiency in Chinese</li>
                 </ul>
-              </div>
+              </NowItem>
             </div>
-          </div>
 
-          {/* Footer note about Now pages */}
-          <div className="mt-12 border-t border-gray-700 pt-8 text-sm leading-relaxed text-gray-300">
-            <p>
-              This is a{" "}
-              <ExternalLink href="https://nownownow.com/about">
-                now page
-              </ExternalLink>
-              . You can read more about the format{" "}
-              <ExternalLink href="https://sive.rs/nowff">here</ExternalLink>.
-              It&apos;s a snapshot of what I&apos;m focused on at this point in
-              my life.
-            </p>
-          </div>
+            <ProseContent className="border-t border-gray-700 pt-8 text-sm">
+              <p>
+                This is a{" "}
+                <ExternalLink href="https://nownownow.com/about">
+                  now page
+                </ExternalLink>
+                . You can read more about the format{" "}
+                <ExternalLink href="https://sive.rs/nowff">here</ExternalLink>.
+                It&apos;s a snapshot of what I&apos;m focused on at this point
+                in my life.
+              </p>
+            </ProseContent>
+          </SectionBlock>
         </ResponsiveContainer>
       </PageShell>
     </>

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+
+type BadgeTone = "info" | "success" | "warning";
+
+type BadgeProps = {
+  children: ReactNode;
+  tone?: BadgeTone;
+  className?: string;
+};
+
+const toneClasses: Record<BadgeTone, string> = {
+  info: "border-accent-link/40 bg-accent-link/15 text-accent-link",
+  success: "border-accent-success/40 bg-accent-success/15 text-accent-success",
+  warning: "border-accent-warning/40 bg-accent-warning/15 text-accent-warning",
+};
+
+export function Badge({ children, tone = "info", className = "" }: BadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${toneClasses[tone]} ${className}`.trim()}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from "react";
 
+import { LinkText } from "@/components/LinkText";
+
 export interface ExternalLinkProps {
   href: string;
   children: ReactNode;
@@ -9,16 +11,11 @@ export interface ExternalLinkProps {
 export default function ExternalLink({
   href,
   children,
-  className = "text-accent-link hover:text-accent-link-hover transition-colors underline decoration-accent-link/50 hover:decoration-accent-link-hover",
+  className,
 }: ExternalLinkProps) {
   return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={className}
-    >
+    <LinkText href={href} external className={className}>
       {children}
-    </a>
+    </LinkText>
   );
 }

--- a/src/components/LinkText.tsx
+++ b/src/components/LinkText.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from "react";
+
+import Link from "next/link";
+
+type LinkTextProps = {
+  href: string;
+  children: ReactNode;
+  className?: string;
+  external?: boolean;
+};
+
+const defaultClassName =
+  "text-accent-link underline decoration-accent-link/50 transition-colors hover:text-accent-link-hover hover:decoration-accent-link-hover";
+
+export function LinkText({
+  href,
+  children,
+  className = defaultClassName,
+  external = false,
+}: LinkTextProps) {
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/ProseContent.tsx
+++ b/src/components/ProseContent.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+
+type ProseContentProps = {
+  className?: string;
+  children?: ReactNode;
+  html?: string;
+};
+
+const proseClasses =
+  "prose prose-invert max-w-none prose-headings:text-white prose-p:text-gray-300 prose-a:text-accent-link prose-a:no-underline hover:prose-a:text-accent-link-hover hover:prose-a:underline prose-strong:text-white prose-pre:border prose-pre:border-white/10 prose-pre:bg-black/50 md:prose-lg";
+
+export function ProseContent({
+  className = "",
+  children,
+  html,
+}: ProseContentProps) {
+  if (html) {
+    return (
+      <div
+        className={`${proseClasses} ${className}`.trim()}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  }
+
+  return (
+    <div className={`${proseClasses} ${className}`.trim()}>{children}</div>
+  );
+}

--- a/src/components/SectionBlock.tsx
+++ b/src/components/SectionBlock.tsx
@@ -1,0 +1,53 @@
+import { ElementType, ReactNode } from "react";
+
+import { Subtitle } from "@/components/Subtitle";
+
+type SectionSpacing = "sm" | "md" | "lg";
+type SectionAlign = "left" | "center";
+
+type SectionBlockProps<T extends ElementType = "section"> = {
+  element?: T;
+  title?: string;
+  subtitle?: string;
+  titleId?: string;
+  align?: SectionAlign;
+  spacing?: SectionSpacing;
+  className?: string;
+  children: ReactNode;
+};
+
+const spacingClasses: Record<SectionSpacing, string> = {
+  sm: "space-y-4",
+  md: "space-y-6",
+  lg: "space-y-8",
+};
+
+const alignClasses: Record<SectionAlign, string> = {
+  left: "text-left",
+  center: "text-center",
+};
+
+export function SectionBlock<T extends ElementType = "section">({
+  element,
+  title,
+  subtitle,
+  titleId,
+  align = "left",
+  spacing = "md",
+  className = "",
+  children,
+}: SectionBlockProps<T>) {
+  const Component = element ?? "section";
+
+  return (
+    <Component className={`${spacingClasses[spacing]} ${className}`.trim()}>
+      {title ? <Subtitle title={title} id={titleId} /> : null}
+      {subtitle ? (
+        <p className={`text-sm text-gray-300 ${alignClasses[align]}`.trim()}>
+          {subtitle}
+        </p>
+      ) : null}
+      <div className={alignClasses[align]}>{children}</div>
+    </Component>
+  );
+}

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+
+type TagProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function Tag({ children, className = "" }: TagProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border border-white/20 px-2.5 py-1 text-xs font-semibold text-gray-200 ${className}`.trim()}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/__tests__/Badge.test.tsx
+++ b/src/components/__tests__/Badge.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+
+import { Badge } from "../Badge";
+
+describe("Badge", () => {
+  it("uses default info tone", () => {
+    render(<Badge>Status</Badge>);
+
+    expect(screen.getByText("Status")).toHaveClass("text-accent-link");
+  });
+
+  it("supports success tone", () => {
+    render(<Badge tone="success">Done</Badge>);
+
+    expect(screen.getByText("Done")).toHaveClass("text-accent-success");
+  });
+});

--- a/src/components/__tests__/LinkText.test.tsx
+++ b/src/components/__tests__/LinkText.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+
+import { LinkText } from "../LinkText";
+
+describe("LinkText", () => {
+  it("renders external links with security attributes", () => {
+    render(
+      <LinkText href="https://example.com" external>
+        External
+      </LinkText>
+    );
+
+    const link = screen.getByText("External");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders internal links", () => {
+    render(<LinkText href="/blog">Blog</LinkText>);
+
+    expect(screen.getByText("Blog")).toHaveAttribute("href", "/blog");
+  });
+});

--- a/src/components/__tests__/ProseContent.test.tsx
+++ b/src/components/__tests__/ProseContent.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+
+import { ProseContent } from "../ProseContent";
+
+describe("ProseContent", () => {
+  it("renders children content", () => {
+    render(
+      <ProseContent>
+        <p>Hello prose</p>
+      </ProseContent>
+    );
+
+    expect(screen.getByText("Hello prose")).toBeInTheDocument();
+  });
+
+  it("renders html content", () => {
+    render(<ProseContent html="<p>Rendered HTML</p>" />);
+
+    expect(screen.getByText("Rendered HTML")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Tag.test.tsx
+++ b/src/components/__tests__/Tag.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+
+import { Tag } from "../Tag";
+
+describe("Tag", () => {
+  it("renders content with base classes", () => {
+    render(<Tag>TypeScript</Tag>);
+
+    const tag = screen.getByText("TypeScript");
+    expect(tag).toHaveClass("rounded-full", "border", "text-xs");
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement Phase 2 of the UX/UI audit to reduce duplicated utility classes and provide shared primitives for section scaffolding, metadata chips, link styles, and long-form typography.
- Apply these primitives to key pages (About, Now, Blog) to improve consistency and make future UI changes lower-risk and faster to implement.

### Description
- Added new primitives: `SectionBlock`, `Tag`, `Badge`, `LinkText`, and `ProseContent` in `src/components/` and included focused unit tests for each (`src/components/__tests__/*`).
- Routed `ExternalLink` through the new `LinkText` primitive to centralize external/internal link behavior and styling (`src/components/ExternalLink.tsx`).
- Adopted primitives across pages and components: About route blocks (`Journey`, `Skills`, `Credentials`) now use `SectionBlock`; Blog index and post pages use `Tag` for tags and `ProseContent` for post body; Now page uses `SectionBlock`, `Badge`, and `ProseContent` for unified scaffolding and prose treatment.
- Updated documentation to mark Phase 2 implemented in `docs/ux-ui-audit.md` and added `docs/ux-ui-audit.md` to documentation indexes (`docs/README.md` and root `README.md`).

### Testing
- Ran `corepack enable && corepack install` to pin Yarn; succeeded.
- Ran `yarn lint:fix` then `yarn lint` to enforce formatting and lint rules; both completed successfully.
- Ran `yarn test` and all test suites passed (`20` suites, `66` tests passed).
- Built the site with `yarn build` and the Next.js static export completed successfully (all routes generated).
- Started a dev server (`yarn dev`) and performed a visual regression sweep with a Playwright script capturing screenshots of main routes (`/`, `/about/`, `/blog/`, `/blog/boring-blog-architecture/`, `/contact/`, `/now/`); the sweep completed and screenshots were produced.
- No automated tests or linters failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e9bdb9448323a2f49311b5e94599)