### PR TITLE
Migrate route metadata to shared SEO builders and extract JSON-LD helpers

### DIFF
--- a/docs/technical-architecture-audit.md
+++ b/docs/technical-architecture-audit.md
@@ -93,7 +93,8 @@ Metadata and JSON-LD are robust, but they are currently authored across route fi
   - `src/lib/seo/url.ts` for canonical and absolute URL derivation
   - `src/lib/seo/metadata.ts` for standardized `Metadata` generation
   - tests added for URL normalization and metadata defaults/overrides
-- 🔄 **Remaining work**: apply these utilities route-by-route and extract shared JSON-LD helper builders.
+- ✅ **Phase 2 metadata migration complete**: `about`, `contact`, `now`, `blog`, and `blog/[slug]` now use shared SEO helpers for metadata generation.
+- ✅ **JSON-LD extraction complete**: reusable schema builders now live in `src/lib/seo/jsonld.ts`, including profile/contact/web page, blog collection/item list, blog posting, person, and website schema builders.
 
 ### E) Performance Budget Not Yet Explicit (Medium)
 
@@ -142,3 +143,5 @@ The site has good baseline choices, but no explicit performance budget or regres
 ## Progress Log
 
 - **2026-02-16**: Recommendation D has completed foundational work (Phase 0 + Phase 1 utilities and tests). Remaining scope is route migration + JSON-LD extraction under Phase 2.
+
+- **2026-02-22**: Recommendation D route migration + JSON-LD extraction completed with shared builders in `src/lib/seo/jsonld.ts` and route adoption across key pages.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -8,49 +8,28 @@ import { Credentials } from "@/app/about/_components/Credentials";
 import { Journey } from "@/app/about/_components/MyBackground";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
-import { BASE_URL } from "@/constants";
+import { buildPageMetadata, buildProfilePageSchema } from "@/lib/seo";
 
 import { Skills } from "./_components/TechnicalInterests";
 
 const title = "About Me | Alex Leung";
 const description =
   "Learn about Alex Leung's journey - from University of Waterloo and Georgia Tech to end-to-end product development.";
-const url = `${BASE_URL}/about/`;
+const path = "/about";
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-    images: [
-      {
-        url: "/assets/about_portrait.webp",
-        width: 5712,
-        height: 4284,
-        alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-    images: [
-      {
-        url: "/assets/about_portrait.webp",
-        alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
-      },
-    ],
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+  images: [
+    {
+      url: "/assets/about_portrait.webp",
+      width: 5712,
+      height: 4284,
+      alt: "Alex Leung sitting on a mountain trail during a hiking adventure",
+    },
+  ],
+});
 
 export default function AboutPage() {
   return (
@@ -62,23 +41,11 @@ export default function AboutPage() {
         ]}
       />
       <JsonLd<schemadts.ProfilePage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ProfilePage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildProfilePageSchema({
+          path,
+          title,
+          description,
+        })}
       />
 
       <PageShell title="About Me" titleId="about">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,44 +8,35 @@ import { BlogPostCard } from "@/components/BlogPostCard";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { BASE_URL } from "@/constants";
 import { getAllPosts } from "@/lib/blogApi";
+import {
+  buildBlogCollectionPageSchema,
+  buildBlogItemListSchema,
+  buildPageMetadata,
+  toAbsoluteUrl,
+} from "@/lib/seo";
 
 const title = "Blog | Alex Leung";
 const description =
   "Thoughts on software engineering, product development, and life as a developer.";
-const url = `${BASE_URL}/blog/`;
+const path = "/blog";
 
 export function generateMetadata(): Metadata {
   const posts = getAllPosts(["coverImage"]);
   const firstCoverImage = posts.find((post) => post.coverImage)?.coverImage;
-  const image = firstCoverImage
-    ? new URL(firstCoverImage, BASE_URL).toString()
-    : undefined;
-  const images = image ? [image] : undefined;
 
-  return {
-    title: title,
-    description: description,
-    alternates: {
-      canonical: url,
-    },
-    openGraph: {
-      title: title,
-      description: description,
-      type: "website",
-      url: url,
-      siteName: "Alex Leung",
-      locale: "en_CA",
-      images,
-    },
-    twitter: {
-      card: image ? "summary_large_image" : "summary",
-      title: title,
-      description: description,
-      images,
-    },
-  };
+  return buildPageMetadata({
+    title,
+    description,
+    path,
+    images: firstCoverImage
+      ? [
+          {
+            url: toAbsoluteUrl(firstCoverImage),
+          },
+        ]
+      : undefined,
+  });
 }
 
 export default function BlogIndex() {
@@ -67,42 +58,12 @@ export default function BlogIndex() {
         ]}
       />
       <JsonLd<CollectionPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "CollectionPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-          mainEntity: {
-            "@type": "Blog",
-            "@id": `${BASE_URL}/blog/#blog`,
-            name: "Alex Leung's Blog",
-            description: description,
-            publisher: {
-              "@id": `${BASE_URL}/#person`,
-            },
-          },
-        }}
+        item={buildBlogCollectionPageSchema({ path, title, description })}
       />
       <JsonLd<ItemList>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ItemList",
-          "@id": `${BASE_URL}/blog/#itemlist`,
-          itemListElement: allPosts.map((post, index) => ({
-            "@type": "ListItem",
-            position: index + 1,
-            url: `${BASE_URL}/blog/${post.slug}`,
-            name: post.title,
-          })),
-          numberOfItems: allPosts.length,
-        }}
+        item={buildBlogItemListSchema(
+          allPosts.map((post) => ({ slug: post.slug, title: post.title }))
+        )}
       />
       <PageShell title="Blog">
         <ResponsiveContainer variant="wide">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ import * as schemadts from "schema-dts";
 
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
-import { BASE_URL } from "@/constants";
+import { buildContactPageSchema, buildPageMetadata } from "@/lib/seo";
 
 import { EmailMe } from "./_components/EmailMe";
 import { SocialMediaList } from "./_components/SocialMediaList";
@@ -14,28 +14,13 @@ import { SocialMediaList } from "./_components/SocialMediaList";
 const title = "Contact | Alex Leung";
 const description =
   "Get in touch with Alex Leung - Syntropy Engineer and Programmer. Available for collaboration, consulting, and professional inquiries.";
-const url = `${BASE_URL}/contact/`;
+const path = "/contact";
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+});
 
 export default function ContactPage() {
   return (
@@ -47,23 +32,11 @@ export default function ContactPage() {
         ]}
       />
       <JsonLd<schemadts.ContactPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "ContactPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildContactPageSchema({
+          path,
+          title,
+          description,
+        })}
       />
 
       <PageShell title="Contact" titleId="contact">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,13 +4,12 @@ import { JsonLd } from "react-schemaorg";
 import type { Metadata, Viewport } from "next";
 import { Lato } from "next/font/google";
 
-import * as schemadts from "schema-dts";
-
 import { AppBackground } from "@/components/AppBackground";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
 import SocialLinks from "@/components/SocialLinks";
 import { BASE_URL } from "@/constants";
+import { buildPersonSchema, buildWebsiteSchema } from "@/lib/seo";
 
 import "./globals.css";
 
@@ -85,141 +84,12 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
-function buildPersonSchema(): schemadts.WithContext<schemadts.Person> {
-  return {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    // This ID is the "Digital Fingerprint" that tells Google this is an ENTITY, not just a page
-    "@id": `${BASE_URL}/#person`,
-    name: "Alex Leung",
-    alternateName: [
-      "Alexander Leung",
-      "Alexander Clayton Leung",
-      "Alex C Leung",
-    ],
-    url: BASE_URL,
-    // Links the Person to the Webpage as the primary subject
-    mainEntityOfPage: {
-      "@type": "WebPage",
-      "@id": BASE_URL,
-    },
-    image: [
-      {
-        "@type": "ImageObject",
-        url: `${BASE_URL}/assets/about_portrait.webp`,
-        caption: "Alex Leung",
-      },
-      {
-        "@type": "ImageObject",
-        url: `${BASE_URL}/assets/about_portrait_mountain.webp`,
-        caption: "Alex Leung's portrait on a mountain",
-      },
-    ],
-    jobTitle: "Software Engineer",
-    description: description,
-    sameAs: [
-      "https://www.linkedin.com/in/aclinic",
-      "https://www.github.com/aclinic",
-      "https://www.x.com/aclyxpse",
-      "https://bsky.app/profile/aclinic.bsky.social",
-      "https://www.instagram.com/rootpanda",
-      "https://scholar.google.ca/citations?user=NcOOsPIAAAAJ",
-    ],
-    address: {
-      "@type": "PostalAddress",
-      addressLocality: "Waterloo",
-      addressRegion: "Ontario",
-      addressCountry: "Canada",
-    },
-    alumniOf: [
-      {
-        "@type": "CollegeOrUniversity",
-        name: "University of Waterloo",
-        sameAs: "https://en.wikipedia.org/wiki/University_of_Waterloo",
-      },
-      {
-        "@type": "CollegeOrUniversity",
-        name: "Georgia Institute of Technology",
-        sameAs: "https://en.wikipedia.org/wiki/Georgia_Institute_of_Technology",
-      },
-    ],
-    knowsAbout: [
-      "Product Development",
-      "Technical Leadership",
-      "Software Engineering",
-      "AI Engineering",
-      "Distributed Systems",
-      "Embedded Systems",
-      "Web Development",
-      "Systems Design",
-      "Electrical Engineering",
-    ],
-    worksFor: {
-      "@type": "Organization",
-      name: "Jetson",
-      url: "https://jetsonhome.com",
-    },
-    hasCredential: [
-      {
-        "@type": "EducationalOccupationalCredential",
-        name: "Professional Engineer (P.Eng.)",
-        credentialCategory: "Professional License",
-        recognizedBy: {
-          "@type": "Organization",
-          name: "Professional Engineers Ontario",
-          url: "https://www.peo.on.ca",
-          sameAs:
-            "https://en.wikipedia.org/wiki/Professional_Engineers_Ontario",
-        },
-      },
-      {
-        "@type": "EducationalOccupationalCredential",
-        name: "Master of Science in Electrical and Computer Engineering",
-        credentialCategory: "Degree",
-        educationalLevel: "Master's Degree",
-        recognizedBy: {
-          "@type": "CollegeOrUniversity",
-          name: "Georgia Institute of Technology",
-          sameAs:
-            "https://en.wikipedia.org/wiki/Georgia_Institute_of_Technology",
-        },
-      },
-      {
-        "@type": "EducationalOccupationalCredential",
-        name: "Bachelor of Applied Science in Electrical Engineering",
-        credentialCategory: "Degree",
-        educationalLevel: "Bachelor's Degree",
-        recognizedBy: {
-          "@type": "CollegeOrUniversity",
-          name: "University of Waterloo",
-          sameAs: "https://en.wikipedia.org/wiki/University_of_Waterloo",
-        },
-      },
-    ],
-  };
-}
-
-function buildWebSiteSchema(): schemadts.WithContext<schemadts.WebSite> {
-  return {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "@id": `${BASE_URL}/#website`,
-    url: BASE_URL,
-    name: "Alex Leung",
-    description: description,
-    publisher: {
-      "@id": `${BASE_URL}/#person`,
-    },
-    inLanguage: "en-CA",
-  };
-}
-
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
       <body className={`${lato.className} flex min-h-screen flex-col`}>
-        <JsonLd item={buildPersonSchema()} />
-        <JsonLd item={buildWebSiteSchema()} />
+        <JsonLd item={buildPersonSchema({ description })} />
+        <JsonLd item={buildWebsiteSchema({ description })} />
         <AppBackground />
         <Header />
         <SocialLinks />

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -12,7 +12,7 @@ import { PageShell } from "@/components/PageShell";
 import { ProseContent } from "@/components/ProseContent";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { SectionBlock } from "@/components/SectionBlock";
-import { BASE_URL } from "@/constants";
+import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
 
 export const NOW_PAGE_LAST_UPDATED_ISO = "2026-02-20";
 
@@ -30,28 +30,13 @@ export const NOW_PAGE_LAST_UPDATED_DISPLAY = new Intl.DateTimeFormat("en-US", {
 const title = "What I'm Doing Now | Alex Leung";
 const description =
   "Current projects, books, and goals - a snapshot of what Alex Leung is focused on right now.";
-const url = `${BASE_URL}/now/`;
+const path = "/now";
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  alternates: {
-    canonical: url,
-  },
-  openGraph: {
-    title: title,
-    description: description,
-    type: "website",
-    url: url,
-    siteName: "Alex Leung",
-    locale: "en_CA",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+});
 
 export default function NowPage() {
   return (
@@ -63,23 +48,11 @@ export default function NowPage() {
         ]}
       />
       <JsonLd<WebPage>
-        item={{
-          "@context": "https://schema.org",
-          "@type": "WebPage",
-          "@id": url,
-          url: url,
-          name: title,
-          description: description,
-          mainEntity: {
-            "@type": "Person",
-            "@id": `${BASE_URL}/#person`,
-          },
-          inLanguage: "en-CA",
-          isPartOf: {
-            "@type": "WebSite",
-            "@id": `${BASE_URL}/#website`,
-          },
-        }}
+        item={buildWebPageSchema({
+          path,
+          title,
+          description,
+        })}
       />
 
       <PageShell title="What I'm Doing Now" titleId="now">

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -1,0 +1,72 @@
+import {
+  buildBlogCollectionPageSchema,
+  buildBlogItemListSchema,
+  buildBlogPostingSchema,
+  buildContactPageSchema,
+  buildProfilePageSchema,
+  buildWebPageSchema,
+} from "@/lib/seo";
+
+describe("seo jsonld builders", () => {
+  it("builds profile/contact/web page schemas with canonical IDs", () => {
+    const profile = buildProfilePageSchema({
+      path: "/about",
+      title: "About Me | Alex Leung",
+      description: "About page description",
+    });
+    const contact = buildContactPageSchema({
+      path: "/contact",
+      title: "Contact | Alex Leung",
+      description: "Contact page description",
+    });
+    const now = buildWebPageSchema({
+      path: "/now",
+      title: "What I'm Doing Now | Alex Leung",
+      description: "Now page description",
+    });
+
+    expect(profile["@id"]).toBe("https://alexleung.ca/about/");
+    expect(contact["@id"]).toBe("https://alexleung.ca/contact/");
+    expect(now["@id"]).toBe("https://alexleung.ca/now/");
+  });
+
+  it("builds blog collection and item list schemas", () => {
+    const collection = buildBlogCollectionPageSchema({
+      path: "/blog",
+      title: "Blog | Alex Leung",
+      description: "Blog index description",
+    });
+    const itemList = buildBlogItemListSchema([
+      { slug: "post-1", title: "Post 1" },
+      { slug: "post-2", title: "Post 2" },
+    ]);
+
+    expect(collection.mainEntity && "@id" in collection.mainEntity).toBe(true);
+    expect(itemList.numberOfItems).toBe(2);
+    expect(itemList.itemListElement?.[0]).toMatchObject({
+      name: "Post 1",
+      position: 1,
+      url: "https://alexleung.ca/blog/post-1",
+    });
+  });
+
+  it("builds blog posting schema with normalized urls and keywords", () => {
+    const posting = buildBlogPostingSchema({
+      slug: "deep-dive",
+      title: "Deep Dive",
+      description: "A deep dive post",
+      coverImage: "/assets/blog/cover.webp",
+      date: "2026-02-16",
+      updated: "2026-02-18",
+      tags: ["ai", "systems"],
+    });
+
+    expect(posting.url).toBe("https://alexleung.ca/blog/deep-dive");
+    expect(posting.image).toEqual([
+      "https://alexleung.ca/assets/blog/cover.webp",
+    ]);
+    expect(posting.keywords).toBe("ai, systems");
+    expect(posting.datePublished).toBe("2026-02-16T00:00:00.000Z");
+    expect(posting.dateModified).toBe("2026-02-18T00:00:00.000Z");
+  });
+});

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -41,9 +41,17 @@ describe("seo jsonld builders", () => {
       { slug: "post-2", title: "Post 2" },
     ]);
 
-    expect(collection.mainEntity && "@id" in collection.mainEntity).toBe(true);
+    expect(collection.mainEntity).toBeDefined();
+
+    const itemListElement = itemList.itemListElement;
+    expect(Array.isArray(itemListElement)).toBe(true);
     expect(itemList.numberOfItems).toBe(2);
-    expect(itemList.itemListElement?.[0]).toMatchObject({
+
+    if (!Array.isArray(itemListElement)) {
+      throw new Error("Expected itemListElement to be an array");
+    }
+
+    expect(itemListElement[0]).toMatchObject({
       name: "Post 1",
       position: 1,
       url: "https://alexleung.ca/blog/post-1",

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -61,12 +61,19 @@ describe("seo jsonld builders", () => {
       tags: ["ai", "systems"],
     });
 
-    expect(posting.url).toBe("https://alexleung.ca/blog/deep-dive");
+    expect(posting.url).toBe("https://alexleung.ca/blog/deep-dive/");
+    expect(posting["@id"]).toBe(
+      "https://alexleung.ca/blog/deep-dive/#blogposting"
+    );
     expect(posting.image).toEqual([
       "https://alexleung.ca/assets/blog/cover.webp",
     ]);
     expect(posting.keywords).toBe("ai, systems");
     expect(posting.datePublished).toBe("2026-02-16T00:00:00.000Z");
     expect(posting.dateModified).toBe("2026-02-18T00:00:00.000Z");
+    expect(posting.mainEntityOfPage).toEqual({
+      "@type": "WebPage",
+      "@id": "https://alexleung.ca/blog/deep-dive/",
+    });
   });
 });

--- a/src/lib/seo/__tests__/metadata.test.ts
+++ b/src/lib/seo/__tests__/metadata.test.ts
@@ -1,25 +1,5 @@
 import { buildPageMetadata } from "@/lib/seo/metadata";
 
-function getOpenGraphType(metadata: ReturnType<typeof buildPageMetadata>) {
-  const openGraph = metadata.openGraph;
-
-  if (openGraph && "type" in openGraph) {
-    return openGraph.type;
-  }
-
-  return undefined;
-}
-
-function getTwitterCard(metadata: ReturnType<typeof buildPageMetadata>) {
-  const twitter = metadata.twitter;
-
-  if (twitter && "card" in twitter) {
-    return twitter.card;
-  }
-
-  return undefined;
-}
-
 describe("buildPageMetadata", () => {
   it("builds canonical, Open Graph, and Twitter metadata with defaults", () => {
     const metadata = buildPageMetadata({

--- a/src/lib/seo/__tests__/metadata.test.ts
+++ b/src/lib/seo/__tests__/metadata.test.ts
@@ -1,5 +1,25 @@
 import { buildPageMetadata } from "@/lib/seo/metadata";
 
+function getOpenGraphType(metadata: ReturnType<typeof buildPageMetadata>) {
+  const openGraph = metadata.openGraph;
+
+  if (openGraph && "type" in openGraph) {
+    return openGraph.type;
+  }
+
+  return undefined;
+}
+
+function getTwitterCard(metadata: ReturnType<typeof buildPageMetadata>) {
+  const twitter = metadata.twitter;
+
+  if (twitter && "card" in twitter) {
+    return twitter.card;
+  }
+
+  return undefined;
+}
+
 describe("buildPageMetadata", () => {
   it("builds canonical, Open Graph, and Twitter metadata with defaults", () => {
     const metadata = buildPageMetadata({

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -1,3 +1,14 @@
 export { buildPageMetadata } from "./metadata";
-export { toAbsoluteUrl, toCanonical } from "./url";
+export {
+  buildBlogCollectionPageSchema,
+  buildBlogItemListSchema,
+  buildBlogPostingSchema,
+  buildContactPageSchema,
+  buildPersonSchema,
+  buildProfilePageSchema,
+  buildWebPageSchema,
+  buildWebsiteSchema,
+  getPersonId,
+} from "./jsonld";
 export type { SeoImage, SeoInput } from "./types";
+export { toAbsoluteUrl, toCanonical } from "./url";

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -132,11 +132,13 @@ export function buildBlogPostingSchema(input: {
   title: string;
   updated?: string;
 }): WithContext<BlogPosting> {
+  const canonicalPostUrl = toCanonical(`/blog/${input.slug}`);
+
   return {
     "@context": "https://schema.org" as const,
     "@type": "BlogPosting",
-    "@id": toAbsoluteUrl(`/blog/${input.slug}#blogposting`),
-    url: toAbsoluteUrl(`/blog/${input.slug}`),
+    "@id": `${canonicalPostUrl}#blogposting`,
+    url: canonicalPostUrl,
     headline: input.title,
     description: input.description,
     keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
@@ -155,7 +157,7 @@ export function buildBlogPostingSchema(input: {
     inLanguage: "en-CA",
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": toAbsoluteUrl(`/blog/${input.slug}`),
+      "@id": canonicalPostUrl,
     },
     isPartOf: {
       "@type": "Blog",

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -1,0 +1,301 @@
+import type {
+  BlogPosting,
+  CollectionPage,
+  ContactPage,
+  ItemList,
+  Person,
+  ProfilePage,
+  WebPage,
+  WebSite,
+  WithContext,
+} from "schema-dts";
+
+import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
+
+const PERSON_ID = "/#person";
+const WEBSITE_ID = "/#website";
+
+function getSiteRoot(): string {
+  return toAbsoluteUrl("/").replace(/\/$/, "");
+}
+
+function buildBasePageSchema<TPageType extends string>({
+  description,
+  pageType,
+  path,
+  title,
+}: {
+  description: string;
+  pageType: TPageType;
+  path: string;
+  title: string;
+}) {
+  return {
+    "@context": "https://schema.org" as const,
+    "@type": pageType,
+    "@id": toCanonical(path),
+    url: toCanonical(path),
+    name: title,
+    description,
+    inLanguage: "en-CA",
+    isPartOf: {
+      "@type": "WebSite" as const,
+      "@id": toAbsoluteUrl(WEBSITE_ID),
+    },
+  };
+}
+
+export function buildProfilePageSchema(input: {
+  description: string;
+  path: string;
+  title: string;
+}): WithContext<ProfilePage> {
+  return {
+    ...buildBasePageSchema({ ...input, pageType: "ProfilePage" }),
+    mainEntity: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+  };
+}
+
+export function buildContactPageSchema(input: {
+  description: string;
+  path: string;
+  title: string;
+}): WithContext<ContactPage> {
+  return {
+    ...buildBasePageSchema({ ...input, pageType: "ContactPage" }),
+    mainEntity: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+  };
+}
+
+export function buildWebPageSchema(input: {
+  description: string;
+  path: string;
+  title: string;
+}): WithContext<WebPage> {
+  return {
+    ...buildBasePageSchema({ ...input, pageType: "WebPage" }),
+    mainEntity: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+  };
+}
+
+export function buildBlogCollectionPageSchema(input: {
+  description: string;
+  path: string;
+  title: string;
+}): WithContext<CollectionPage> {
+  return {
+    ...buildBasePageSchema({ ...input, pageType: "CollectionPage" }),
+    mainEntity: {
+      "@type": "Blog",
+      "@id": toAbsoluteUrl("/blog/#blog"),
+      name: "Alex Leung's Blog",
+      description: input.description,
+      publisher: {
+        "@id": toAbsoluteUrl(PERSON_ID),
+      },
+    },
+  };
+}
+
+export function buildBlogItemListSchema(
+  posts: Array<{ slug: string; title: string }>
+): WithContext<ItemList> {
+  return {
+    "@context": "https://schema.org" as const,
+    "@type": "ItemList",
+    "@id": toAbsoluteUrl("/blog/#itemlist"),
+    itemListElement: posts.map((post, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: toAbsoluteUrl(`/blog/${post.slug}`),
+      name: post.title,
+    })),
+    numberOfItems: posts.length,
+  };
+}
+
+export function buildBlogPostingSchema(input: {
+  coverImage?: string;
+  date: string;
+  description?: string;
+  slug: string;
+  tags: string[];
+  title: string;
+  updated?: string;
+}): WithContext<BlogPosting> {
+  return {
+    "@context": "https://schema.org" as const,
+    "@type": "BlogPosting",
+    "@id": toAbsoluteUrl(`/blog/${input.slug}#blogposting`),
+    url: toAbsoluteUrl(`/blog/${input.slug}`),
+    headline: input.title,
+    description: input.description,
+    keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
+    image: input.coverImage ? [toAbsoluteUrl(input.coverImage)] : undefined,
+    datePublished: new Date(input.date).toISOString(),
+    dateModified: new Date(input.updated || input.date).toISOString(),
+    author: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+      name: "Alex Leung",
+    },
+    publisher: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+    inLanguage: "en-CA",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": toAbsoluteUrl(`/blog/${input.slug}`),
+    },
+    isPartOf: {
+      "@type": "Blog",
+      "@id": toAbsoluteUrl("/blog/#blog"),
+      name: "Blog | Alex Leung",
+    },
+  };
+}
+
+export function buildPersonSchema(input: {
+  description: string;
+}): WithContext<Person> {
+  return {
+    "@context": "https://schema.org" as const,
+    "@type": "Person",
+    "@id": toAbsoluteUrl(PERSON_ID),
+    name: "Alex Leung",
+    alternateName: [
+      "Alexander Leung",
+      "Alexander Clayton Leung",
+      "Alex C Leung",
+    ],
+    url: getSiteRoot(),
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": getSiteRoot(),
+    },
+    image: [
+      {
+        "@type": "ImageObject",
+        url: toAbsoluteUrl("/assets/about_portrait.webp"),
+        caption: "Alex Leung",
+      },
+      {
+        "@type": "ImageObject",
+        url: toAbsoluteUrl("/assets/about_portrait_mountain.webp"),
+        caption: "Alex Leung's portrait on a mountain",
+      },
+    ],
+    jobTitle: "Software Engineer",
+    description: input.description,
+    sameAs: [
+      "https://www.linkedin.com/in/aclinic",
+      "https://www.github.com/aclinic",
+      "https://www.x.com/aclyxpse",
+      "https://bsky.app/profile/aclinic.bsky.social",
+      "https://www.instagram.com/rootpanda",
+      "https://scholar.google.ca/citations?user=NcOOsPIAAAAJ",
+    ],
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Waterloo",
+      addressRegion: "Ontario",
+      addressCountry: "Canada",
+    },
+    alumniOf: [
+      {
+        "@type": "CollegeOrUniversity",
+        name: "University of Waterloo",
+        sameAs: "https://en.wikipedia.org/wiki/University_of_Waterloo",
+      },
+      {
+        "@type": "CollegeOrUniversity",
+        name: "Georgia Institute of Technology",
+        sameAs: "https://en.wikipedia.org/wiki/Georgia_Institute_of_Technology",
+      },
+    ],
+    knowsAbout: [
+      "Product Development",
+      "Technical Leadership",
+      "Software Engineering",
+      "AI Engineering",
+      "Distributed Systems",
+      "Embedded Systems",
+      "Web Development",
+      "Systems Design",
+      "Electrical Engineering",
+    ],
+    worksFor: {
+      "@type": "Organization",
+      name: "Jetson",
+      url: "https://jetsonhome.com",
+    },
+    hasCredential: [
+      {
+        "@type": "EducationalOccupationalCredential",
+        name: "Professional Engineer (P.Eng.)",
+        credentialCategory: "Professional License",
+        recognizedBy: {
+          "@type": "Organization",
+          name: "Professional Engineers Ontario",
+          url: "https://www.peo.on.ca",
+          sameAs:
+            "https://en.wikipedia.org/wiki/Professional_Engineers_Ontario",
+        },
+      },
+      {
+        "@type": "EducationalOccupationalCredential",
+        name: "Master of Science in Electrical and Computer Engineering",
+        credentialCategory: "Degree",
+        educationalLevel: "Master's Degree",
+        recognizedBy: {
+          "@type": "CollegeOrUniversity",
+          name: "Georgia Institute of Technology",
+          sameAs:
+            "https://en.wikipedia.org/wiki/Georgia_Institute_of_Technology",
+        },
+      },
+      {
+        "@type": "EducationalOccupationalCredential",
+        name: "Bachelor of Applied Science in Electrical Engineering",
+        credentialCategory: "Degree",
+        educationalLevel: "Bachelor's Degree",
+        recognizedBy: {
+          "@type": "CollegeOrUniversity",
+          name: "University of Waterloo",
+          sameAs: "https://en.wikipedia.org/wiki/University_of_Waterloo",
+        },
+      },
+    ],
+  };
+}
+
+export function buildWebsiteSchema(input: {
+  description: string;
+}): WithContext<WebSite> {
+  return {
+    "@context": "https://schema.org" as const,
+    "@type": "WebSite",
+    "@id": toAbsoluteUrl(WEBSITE_ID),
+    url: getSiteRoot(),
+    name: "Alex Leung",
+    description: input.description,
+    publisher: {
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+    inLanguage: "en-CA",
+  };
+}
+
+export function getPersonId() {
+  return toAbsoluteUrl(PERSON_ID);
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication and drift in route-level metadata and JSON-LD by centralizing canonical URL, image normalization, and schema builders into a single SEO surface.
- Make route files focused on content composition and ensure consistent metadata/JSON-LD across pages as the site scales.

### Description
- Added a centralized JSON-LD builder module at `src/lib/seo/jsonld.ts` with reusable builders for profile/contact/web pages, blog collection/item list, blog posting, person, and website schemas.
- Updated `src/lib/seo/index.ts` to export the new JSON-LD builders alongside existing metadata helpers (`toAbsoluteUrl`, `toCanonical`, and `buildPageMetadata`).
- Migrated per-route metadata and JSON-LD usage to the shared helpers by updating `src/app/about/page.tsx`, `src/app/contact/page.tsx`, `src/app/now/page.tsx`, `src/app/blog/page.tsx`, and `src/app/blog/[slug]/page.tsx` to use `buildPageMetadata` and the appropriate `build*Schema` functions.
- Replaced inline Person/WebSite JSON-LD in `src/app/layout.tsx` with `buildPersonSchema` and `buildWebsiteSchema`, and added unit tests for the JSON-LD builders in `src/lib/seo/__tests__/jsonld.test.ts`, plus an update to `docs/technical-architecture-audit.md` marking Recommendation D as complete.

### Testing
- Ran `corepack enable && corepack install` to ensure the pinned Yarn is available and then ran `yarn lint`, which completed successfully after minor fixes were applied.
- Ran `yarn test`, which executed the Jest suite including the new `src/lib/seo/__tests__/jsonld.test.ts` and resulted in all tests passing.
- Built the site with `yarn build`, which completed successfully and prerendered the static routes without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a78932fbc832397527a067faeed25)