### PR TITLE
fix: sanitize markdown rendering pipeline

### DIFF
--- a/docs/codebase-structure-review.md
+++ b/docs/codebase-structure-review.md
@@ -1,0 +1,90 @@
+# Codebase Structure Review (2026-02-21)
+
+## Scope
+
+This review focuses on repository organization, architectural boundaries, maintainability, and quality gates.
+
+## What is working well
+
+- **Clear high-level separation of concerns**: route entrypoints under `src/app`, shared UI primitives under `src/components`, reusable logic under `src/lib`, and static/config data in `src/constants`.
+- **Route-scoped composition is mostly clean**: feature-specific components live close to routes (e.g., `src/app/about/_components`), while broadly reused components are centralized.
+- **Static-export-friendly setup is explicit**: Next config and deployment workflows are aligned with GitHub Pages.
+- **Testing baseline is healthy**: Jest + RTL are configured with explicit coverage thresholds and a practical test file layout.
+
+## Structural weaknesses and risks
+
+### 1) Metadata and structured-data patterns are still partially duplicated
+
+Although shared SEO helpers exist in `src/lib/seo`, route files still define repeated metadata and JSON-LD scaffolding directly. As more pages/content types are added, this increases drift risk and makes changes harder to apply consistently.
+
+**Impact**
+
+- Inconsistent canonical URL/open graph behavior over time.
+- Harder maintenance when shared SEO requirements change.
+
+**Recommendation**
+
+- Complete route migration to `src/lib/seo/metadata.ts` builders.
+- Extract shared JSON-LD builders (`ProfilePage`, `ContactPage`, `BlogPosting`) into `src/lib/seo` and keep route files focused on page composition.
+
+### 2) Markdown rendering trust boundary remains under-specified
+
+`markdownToHtml` transforms Markdown into HTML for rendering, but there is no explicit sanitization stage in the pipeline.
+
+**Impact**
+
+- Current risk is low if content is fully trusted, but this becomes a security liability if content sources ever expand (guest posts, CMS, automation, etc.).
+
+**Recommendation**
+
+- Add `rehype-sanitize` with an explicit allowlist schema compatible with syntax highlighting.
+- Add tests for disallowed HTML/script payload stripping.
+
+### 3) No first-class typecheck command in package scripts or CI
+
+The repo uses TypeScript, but scripts/workflows run lint, tests, and build without an explicit `tsc --noEmit` stage.
+
+**Impact**
+
+- Type regressions can surface later than necessary, especially if build settings evolve.
+
+**Recommendation**
+
+- Add `"typecheck": "tsc --noEmit"` to `package.json`.
+- Run `yarn typecheck` in PR checks and deployment workflow.
+
+### 4) Documentation of architecture status is split across multiple files
+
+Architecture guidance exists in `README.md` and `docs/technical-architecture-audit.md`, but status and next steps can diverge without a single source of truth.
+
+**Impact**
+
+- Higher onboarding cost and potential confusion about what is current vs. aspirational.
+
+**Recommendation**
+
+- Keep `README.md` concise and stable.
+- Treat architecture audit docs as authoritative for roadmap/status, with a small changelog section updated alongside major merges.
+
+### 5) Growth boundary for content model is not yet formalized
+
+The content model in `blogApi` is stronger than before (schema-based front matter), but there is still no explicit pattern for future content types (projects/case studies/notes) beyond blog posts.
+
+**Impact**
+
+- Future expansion may duplicate parsing/validation patterns and create parallel implementations.
+
+**Recommendation**
+
+- Define a common content-domain boundary in `src/lib/content` (schema, loader, and mapping conventions) before introducing new content sections.
+
+## Priority order
+
+1. **Security + correctness first**: sanitize markdown pipeline.
+2. **Quality gate**: add and enforce `typecheck` in CI.
+3. **Maintainability**: finish SEO helper migration and JSON-LD extraction.
+4. **Scale readiness**: introduce shared content-domain conventions for future content types.
+
+## Summary
+
+The project structure is solid for a static personal site. The main weaknesses are less about fundamental architecture and more about **future-proofing boundaries** (SEO abstraction completion, markdown sanitization, and stronger CI typing guarantees).

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.2.3",
     "react-icons": "^5.3.0",
     "react-schemaorg": "^2.0.0",
+    "rehype-sanitize": "^6.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -1,7 +1,20 @@
+import type { Schema } from "hast-util-sanitize";
 import rehypePrettyCode from "rehype-pretty-code";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeStringify from "rehype-stringify";
 import { remark } from "remark";
 import remarkRehype from "remark-rehype";
+
+const sanitizeSchema: Schema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    pre: [...(defaultSchema.attributes?.pre || []), ["className"]],
+    code: [...(defaultSchema.attributes?.code || []), ["className"]],
+    span: [...(defaultSchema.attributes?.span || []), ["className"], ["style"]],
+    div: [...(defaultSchema.attributes?.div || []), ["className"]],
+  },
+};
 
 export default async function markdownToHtml(markdown: string) {
   const result = await remark()
@@ -10,7 +23,9 @@ export default async function markdownToHtml(markdown: string) {
       theme: "github-dark",
       keepBackground: true,
     })
+    .use(rehypeSanitize, sanitizeSchema)
     .use(rehypeStringify)
     .process(markdown);
+
   return result.toString();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,6 +2614,7 @@ __metadata:
     react-schemaorg: "npm:^2.0.0"
     rehype-highlight: "npm:^7.0.2"
     rehype-pretty-code: "npm:^0.14.1"
+    rehype-sanitize: "npm:^6.0.0"
     rehype-stringify: "npm:^10.0.1"
     remark: "npm:^15.0.1"
     remark-html: "npm:^16.0.1"
@@ -7724,6 +7725,16 @@ __metadata:
   peerDependencies:
     shiki: ^1.0.0 || ^2.0.0 || ^3.0.0
   checksum: 10c0/9f51a965edfd49d086f6421d13fa4725e59c891187fcb82aba0fe471425058af3b98210cedf2a9790e85575d1bd6d817ee88bf007628123e7878636c2c00bb1a
+  languageName: node
+  linkType: hard
+
+"rehype-sanitize@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "rehype-sanitize@npm:6.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    hast-util-sanitize: "npm:^5.0.0"
+  checksum: 10c0/43d6c056e63c994cf56e5ee0e157052d2030dc5ac160845ee494af9a26e5906bf5ec5af56c7d90c99f9c4dc0091e45a48a168618135fb6c64a76481ad3c449e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation

- Harden the Markdown-to-HTML pipeline to remove unsafe HTML/JS while preserving syntax highlighting attributes required for code blocks.
- Address the security risk called out in the codebase review that `markdownToHtml` lacked an explicit sanitization stage. 

### Description

- Add `rehype-sanitize` as a runtime dependency and update `yarn.lock` and `package.json` so the sanitizer is available during build and static rendering. 
- Extend the `defaultSchema` from `rehype-sanitize` in `src/lib/markdownToHtml.ts` to allow `className` on `pre`, `code`, and `div`, and `className`/`style` on `span` to keep syntax-highlighting output intact. 
- Import the `Schema` type from `hast-util-sanitize` and pass the composed `sanitizeSchema` into the remark/rehype pipeline via `.use(rehypeSanitize, sanitizeSchema)`. 

### Testing

- Ran `corepack enable && corepack install` followed by `yarn lint`, and lint checks passed after applying automatic fixes. 
- Ran `yarn test` and all test suites passed (`21` suites, `67` tests). 
- Ran `yarn build` and the Next.js production build completed successfully with static pages generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1c61942883239988d2d94e2ecb28)