### PR TITLE
Strengthen metadata assertions in SEO tests

### DIFF
--- a/src/lib/seo/__tests__/metadata.test.ts
+++ b/src/lib/seo/__tests__/metadata.test.ts
@@ -14,15 +14,11 @@ describe("buildPageMetadata", () => {
     expect(metadata.alternates?.canonical).toBe("https://alexleung.ca/about/");
     expect(openGraph?.url).toBe("https://alexleung.ca/about/");
 
-    if (openGraph && "type" in openGraph) {
-      expect(openGraph.type).toBe("website");
-    }
+    expect(openGraph).toMatchObject({ type: "website" });
 
     expect(openGraph?.siteName).toBe("Alex Leung");
 
-    if (twitter && "card" in twitter) {
-      expect(twitter.card).toBe("summary");
-    }
+    expect(twitter).toMatchObject({ card: "summary" });
   });
 
   it("normalizes image URLs and uses large-image twitter card when images exist", () => {
@@ -59,9 +55,7 @@ describe("buildPageMetadata", () => {
       },
     ]);
 
-    if (twitter && "card" in twitter) {
-      expect(twitter.card).toBe("summary_large_image");
-    }
+    expect(twitter).toMatchObject({ card: "summary_large_image" });
   });
 
   it("supports overriding metadata type and twitter card", () => {
@@ -76,12 +70,8 @@ describe("buildPageMetadata", () => {
     const openGraph = metadata.openGraph;
     const twitter = metadata.twitter;
 
-    if (openGraph && "type" in openGraph) {
-      expect(openGraph.type).toBe("article");
-    }
+    expect(openGraph).toMatchObject({ type: "article" });
 
-    if (twitter && "card" in twitter) {
-      expect(twitter.card).toBe("summary");
-    }
+    expect(twitter).toMatchObject({ card: "summary" });
   });
 });


### PR DESCRIPTION
### Motivation
- Avoid silent test passes caused by guarded checks that skip assertions when fields are missing. 
- Ensure regressions that remove `openGraph.type` or `twitter.card` fail CI rather than being silently ignored.

### Description
- Replaced conditional guards with unconditional assertions in `src/lib/seo/__tests__/metadata.test.ts` so `openGraph.type` and `twitter.card` are asserted via `toMatchObject`.
- Updated three test cases to use `expect(openGraph).toMatchObject({ type: ... })` and `expect(twitter).toMatchObject({ card: ... })` to enforce presence and value.
- No production code changes were made; only the test file was modified.

### Testing
- Ran `corepack enable` and `corepack install` to ensure the pinned Yarn is available. 
- Ran `yarn test src/lib/seo/__tests__/metadata.test.ts`, which completed successfully with the file's test suite passing (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a8a5d4b448323bc62a640a3407a56)