### PR TITLE
Make blog dates timezone-stable by formatting in UTC

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,7 +3,6 @@ import { JsonLd } from "react-schemaorg";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { format } from "date-fns";
 import { BlogPosting } from "schema-dts";
 
 import { CoverImage } from "@/components/CoverImage";
@@ -14,6 +13,7 @@ import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { Surface } from "@/components/Surface";
 import { Tag } from "@/components/Tag";
 import { getAllPosts, getPostBySlug } from "@/lib/blogApi";
+import { formatIsoDateForDisplay } from "@/lib/date";
 import markdownToHtml from "@/lib/markdownToHtml";
 import {
   buildBlogPostingSchema,
@@ -135,7 +135,7 @@ export default async function Post({ params }: Props) {
         >
           <Surface className="mx-auto" padding="sm">
             <div className="mb-3 text-lg text-gray-300">
-              {format(new Date(post.date), "MMMM d, yyyy")}
+              {formatIsoDateForDisplay(post.date)}
             </div>
             {post.tags.length > 0 && (
               <div className="mb-6 flex flex-wrap gap-2">

--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -1,11 +1,10 @@
 import Link from "next/link";
 
-import { format } from "date-fns";
-
 import { CoverImage } from "@/components/CoverImage";
 import { surfaceClassNames } from "@/components/Surface";
 import { Tag } from "@/components/Tag";
 import { Post } from "@/lib/blogApi";
+import { formatIsoDateForDisplay } from "@/lib/date";
 
 type BlogPostCardProps = {
   post: Pick<
@@ -38,7 +37,7 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
         {post.title}
       </h3>
       <div className="mb-4 text-sm text-gray-300">
-        {format(new Date(post.date), "MMMM d, yyyy")}
+        {formatIsoDateForDisplay(post.date)}
       </div>
       {post.excerpt ? (
         <p className="mb-4 text-base leading-relaxed text-gray-200 md:text-gray-300">

--- a/src/components/__tests__/BlogPostCard.test.tsx
+++ b/src/components/__tests__/BlogPostCard.test.tsx
@@ -22,6 +22,7 @@ describe("BlogPostCard", () => {
       "/blog/test-post"
     );
     expect(screen.getByText("A short summary")).toBeInTheDocument();
+    expect(screen.getByText("January 1, 2026")).toBeInTheDocument();
     expect(screen.getByText("ai")).toBeInTheDocument();
   });
 });

--- a/src/lib/__tests__/date.test.ts
+++ b/src/lib/__tests__/date.test.ts
@@ -1,0 +1,13 @@
+import { formatIsoDateForDisplay } from "@/lib/date";
+
+describe("formatIsoDateForDisplay", () => {
+  it("formats ISO dates using UTC so output is timezone-stable", () => {
+    expect(formatIsoDateForDisplay("2026-02-22T00:00:00.000Z")).toBe(
+      "February 22, 2026"
+    );
+  });
+
+  it("formats YYYY-MM-DD values as the same calendar day", () => {
+    expect(formatIsoDateForDisplay("2026-02-22")).toBe("February 22, 2026");
+  });
+});

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,8 @@
+export function formatIsoDateForDisplay(isoDate: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(isoDate));
+}


### PR DESCRIPTION
### Motivation

- Dates stored as ISO / `YYYY-MM-DD` were being rendered with local-time formatting which could show the previous calendar day in timezones behind UTC. 
- The change ensures visible publish dates match the source date consistently across browsers and timezones.

### Description

- Added a shared helper `formatIsoDateForDisplay` in `src/lib/date.ts` which formats dates using `Intl.DateTimeFormat` with `timeZone: "UTC"` so formatting is calendar-day stable.  
- Replaced local `date-fns`-based rendering with the shared formatter in `src/components/BlogPostCard.tsx` and `src/app/blog/[slug]/page.tsx`.  
- Added unit tests `src/lib/__tests__/date.test.ts` to assert UTC-stable behavior and updated `src/components/__tests__/BlogPostCard.test.tsx` to assert the rendered date string.

### Testing

- Ran `yarn test src/lib/__tests__/date.test.ts src/components/__tests__/BlogPostCard.test.tsx` and both test suites passed.  
- Ran `yarn typecheck` and no type errors were reported.  
- Ran `yarn lint` and code was formatted / lint-checked successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b21d3cf4483238d54c5d0558e1c0f)