### PR TITLE
Enhance structured data coverage with richer JSON-LD

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -117,7 +117,7 @@ describe("RootLayout", () => {
       expect(schema.sameAs).toBeDefined();
       expect(schema.sameAs.length).toBeGreaterThan(0);
       expect(schema.sameAs).toContain("https://www.linkedin.com/in/aclinic");
-      expect(schema.sameAs).toContain("https://www.github.com/aclinic");
+      expect(schema.sameAs).toContain("https://github.com/aclinic");
     });
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import { useEffect } from "react";
+import { JsonLd } from "react-schemaorg";
+
+import type { WebPage } from "schema-dts";
 
 import { Hero } from "@/components/Hero";
+import { buildHomePageSchema } from "@/lib/seo";
+
+const title = "Alex Leung | Syntropy Engineer and Programmer, P.Eng.";
+const description =
+  "Personal website of Alex Leung, a Syntropy Engineer and Programmer, featuring writing on software, systems, and learning in public.";
+const path = "/";
 
 export default function Page() {
   useEffect(() => {
@@ -14,5 +23,16 @@ export default function Page() {
     }
   }, []);
 
-  return <Hero />;
+  return (
+    <>
+      <JsonLd<WebPage>
+        item={buildHomePageSchema({
+          path,
+          title,
+          description,
+        })}
+      />
+      <Hero />
+    </>
+  );
 }

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -3,8 +3,11 @@ import {
   buildBlogItemListSchema,
   buildBlogPostingSchema,
   buildContactPageSchema,
+  buildHomePageSchema,
+  buildPersonSchema,
   buildProfilePageSchema,
   buildWebPageSchema,
+  buildWebsiteSchema,
 } from "@/lib/seo";
 
 describe("seo jsonld builders", () => {
@@ -55,6 +58,60 @@ describe("seo jsonld builders", () => {
       name: "Post 1",
       position: 1,
       url: "https://alexleung.ca/blog/post-1",
+    });
+  });
+
+
+  it("builds enhanced home and website schemas", () => {
+    const home = buildHomePageSchema({
+      path: "/",
+      title: "Alex Leung | Syntropy Engineer and Programmer, P.Eng.",
+      description: "Homepage description",
+    });
+    const website = buildWebsiteSchema({
+      description: "Website description",
+    });
+
+    expect(home.primaryImageOfPage).toMatchObject({
+      "@type": "ImageObject",
+      url: "https://alexleung.ca/assets/alex_vibing.webp",
+    });
+
+    const hasPart = website.hasPart;
+    expect(Array.isArray(hasPart)).toBe(true);
+
+    if (!Array.isArray(hasPart)) {
+      throw new Error("Expected hasPart to be an array");
+    }
+
+    expect(hasPart).toHaveLength(4);
+    expect(hasPart[0]).toEqual({
+      "@type": "WebPage",
+      "@id": "https://alexleung.ca/about/",
+    });
+  });
+
+  it("builds person schema with richer identity metadata", () => {
+    const person = buildPersonSchema({
+      description: "Person description",
+    });
+
+    if (typeof person === "string") {
+      throw new Error("Expected person schema object");
+    }
+
+    expect(person.givenName).toBe("Alex");
+    expect(person.familyName).toBe("Leung");
+    expect(person.honorificSuffix).toBe("P.Eng.");
+    expect(person.memberOf).toMatchObject({
+      "@type": "Organization",
+      name: "Professional Engineers Ontario",
+    });
+    expect(person.knowsLanguage).toEqual(["en-CA"]);
+    expect(person.sameAs).toContain("https://github.com/aclinic");
+    expect(person.hasOccupation).toMatchObject({
+      "@type": "Occupation",
+      name: "Software Engineer",
     });
   });
 

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -61,7 +61,6 @@ describe("seo jsonld builders", () => {
     });
   });
 
-
   it("builds enhanced home and website schemas", () => {
     const home = buildHomePageSchema({
       path: "/",

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -4,6 +4,7 @@ export {
   buildBlogItemListSchema,
   buildBlogPostingSchema,
   buildContactPageSchema,
+  buildHomePageSchema,
   buildPersonSchema,
   buildProfilePageSchema,
   buildWebPageSchema,

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -3,6 +3,7 @@ import type {
   CollectionPage,
   ContactPage,
   ItemList,
+  Occupation,
   Person,
   ProfilePage,
   WebPage,
@@ -83,6 +84,28 @@ export function buildWebPageSchema(input: {
     mainEntity: {
       "@type": "Person",
       "@id": toAbsoluteUrl(PERSON_ID),
+    },
+  };
+}
+
+export function buildHomePageSchema(input: {
+  description: string;
+  path: string;
+  title: string;
+}): WithContext<WebPage> {
+  return {
+    ...buildBasePageSchema({ ...input, pageType: "WebPage" }),
+    about: {
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+    mainEntity: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+    primaryImageOfPage: {
+      "@type": "ImageObject",
+      url: toAbsoluteUrl("/assets/alex_vibing.webp"),
+      caption: "Alex Leung",
     },
   };
 }
@@ -170,11 +193,24 @@ export function buildBlogPostingSchema(input: {
 export function buildPersonSchema(input: {
   description: string;
 }): WithContext<Person> {
+  const currentOccupation: Occupation = {
+    "@type": "Occupation",
+    name: "Software Engineer",
+    occupationLocation: {
+      "@type": "City",
+      name: "Waterloo, Ontario, Canada",
+    },
+    skills: "Product development, software architecture, and AI engineering",
+  };
+
   return {
     "@context": "https://schema.org" as const,
     "@type": "Person",
     "@id": toAbsoluteUrl(PERSON_ID),
     name: "Alex Leung",
+    givenName: "Alex",
+    familyName: "Leung",
+    honorificSuffix: "P.Eng.",
     alternateName: [
       "Alexander Leung",
       "Alexander Clayton Leung",
@@ -198,10 +234,12 @@ export function buildPersonSchema(input: {
       },
     ],
     jobTitle: "Software Engineer",
+    hasOccupation: currentOccupation,
     description: input.description,
+    knowsLanguage: ["en-CA"],
     sameAs: [
       "https://www.linkedin.com/in/aclinic",
-      "https://www.github.com/aclinic",
+      "https://github.com/aclinic",
       "https://www.x.com/aclyxpse",
       "https://bsky.app/profile/aclinic.bsky.social",
       "https://www.instagram.com/rootpanda",
@@ -278,6 +316,11 @@ export function buildPersonSchema(input: {
         },
       },
     ],
+    memberOf: {
+      "@type": "Organization",
+      name: "Professional Engineers Ontario",
+      url: "https://www.peo.on.ca",
+    },
   };
 }
 
@@ -291,9 +334,30 @@ export function buildWebsiteSchema(input: {
     url: getSiteRoot(),
     name: "Alex Leung",
     description: input.description,
+    about: {
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
     publisher: {
       "@id": toAbsoluteUrl(PERSON_ID),
     },
+    hasPart: [
+      {
+        "@type": "WebPage",
+        "@id": toCanonical("/about"),
+      },
+      {
+        "@type": "CollectionPage",
+        "@id": toCanonical("/blog"),
+      },
+      {
+        "@type": "ContactPage",
+        "@id": toCanonical("/contact"),
+      },
+      {
+        "@type": "WebPage",
+        "@id": toCanonical("/now"),
+      },
+    ],
     inLanguage: "en-CA",
   };
 }


### PR DESCRIPTION
### Motivation

- Improve site SEO and search appearance by providing more complete and explicit JSON-LD for the homepage, website, and person entities.
- Tie the homepage and website metadata explicitly to the site owner entity so search engines can understand relationships between pages and the author.
- Surface additional identity and professional attributes (occupation, credentials, membership, language) to better represent the author in structured data.

### Description

- Added a dedicated homepage JSON-LD builder `buildHomePageSchema` and wired it into `src/app/page.tsx` so the root page emits an enriched `WebPage` schema with `primaryImageOfPage` and `about` linkage to the person entity.
- Expanded the person schema in `src/lib/seo/jsonld.ts` to include `givenName`, `familyName`, `honorificSuffix`, `hasOccupation`, `memberOf`, `knowsLanguage`, and a normalized GitHub URL to better represent identity and professional context.
- Enriched the website schema with an `about` pointer and a `hasPart` array referencing key site sections (`/about`, `/blog`, `/contact`, `/now`).
- Exported the new homepage builder from the SEO barrel (`src/lib/seo/index.ts`) and extended unit tests in `src/lib/seo/__tests__/jsonld.test.ts` to cover the new homepage, website, and person fields.

### Testing

- Ran `corepack enable && corepack install` to ensure the pinned Yarn version was available and the step succeeded.
- Ran `yarn test src/lib/seo/__tests__/jsonld.test.ts` which passed (the JSON-LD builders tests completed successfully).
- Ran `yarn typecheck` which completed with success after tests were updated to avoid TypeScript type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a139dfecec83239cfaba8fc01f7f81)