### PR TITLE
Add Article JSON-LD schema for blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { JsonLd } from "react-schemaorg";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { BlogPosting } from "schema-dts";
+import { Article, BlogPosting } from "schema-dts";
 
 import { CoverImage } from "@/components/CoverImage";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
@@ -16,6 +16,7 @@ import { getAllPosts, getPostBySlug } from "@/lib/blogApi";
 import { formatIsoDateForDisplay } from "@/lib/date";
 import markdownToHtml from "@/lib/markdownToHtml";
 import {
+  buildArticleSchema,
   buildBlogPostingSchema,
   buildPageMetadata,
   toCanonical,
@@ -118,6 +119,17 @@ export default async function Post({ params }: Props) {
       />
       <JsonLd<BlogPosting>
         item={buildBlogPostingSchema({
+          slug: post.slug,
+          title: post.title,
+          description: post.excerpt,
+          coverImage: post.coverImage,
+          date: post.date,
+          updated: post.updated,
+          tags: post.tags,
+        })}
+      />
+      <JsonLd<Article>
+        item={buildArticleSchema({
           slug: post.slug,
           title: post.title,
           description: post.excerpt,

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildArticleSchema,
   buildBlogCollectionPageSchema,
   buildBlogItemListSchema,
   buildBlogPostingSchema,
@@ -82,6 +83,25 @@ describe("seo jsonld builders", () => {
     expect(posting.mainEntityOfPage).toEqual({
       "@type": "WebPage",
       "@id": "https://alexleung.ca/blog/deep-dive/",
+    });
+  });
+
+  it("builds article schema for blog posts", () => {
+    const article = buildArticleSchema({
+      slug: "deep-dive",
+      title: "Deep Dive",
+      description: "A deep dive post",
+      coverImage: "/assets/blog/cover.webp",
+      date: "2026-02-16",
+      updated: "2026-02-18",
+      tags: ["ai", "systems"],
+    });
+
+    expect(article.url).toBe("https://alexleung.ca/blog/deep-dive/");
+    expect(article["@id"]).toBe("https://alexleung.ca/blog/deep-dive/#article");
+    expect(article.author).toMatchObject({
+      "@id": "https://alexleung.ca/#person",
+      url: "https://alexleung.ca/about/",
     });
   });
 });

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -1,6 +1,7 @@
 export { buildPageMetadata } from "./metadata";
 export {
   buildBlogCollectionPageSchema,
+  buildArticleSchema,
   buildBlogItemListSchema,
   buildBlogPostingSchema,
   buildContactPageSchema,

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -1,4 +1,5 @@
 import type {
+  Article,
   BlogPosting,
   CollectionPage,
   ContactPage,
@@ -163,6 +164,46 @@ export function buildBlogPostingSchema(input: {
       "@type": "Blog",
       "@id": toAbsoluteUrl("/blog/#blog"),
       name: "Blog | Alex Leung",
+    },
+  };
+}
+
+export function buildArticleSchema(input: {
+  coverImage?: string;
+  date: string;
+  description?: string;
+  slug: string;
+  tags: string[];
+  title: string;
+  updated?: string;
+}): WithContext<Article> {
+  const canonicalPostUrl = toCanonical(`/blog/${input.slug}`);
+
+  return {
+    "@context": "https://schema.org" as const,
+    "@type": "Article",
+    "@id": `${canonicalPostUrl}#article`,
+    url: canonicalPostUrl,
+    headline: input.title,
+    description: input.description,
+    keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
+    image: input.coverImage ? [toAbsoluteUrl(input.coverImage)] : undefined,
+    datePublished: new Date(input.date).toISOString(),
+    dateModified: new Date(input.updated || input.date).toISOString(),
+    author: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+      name: "Alex Leung",
+      url: toCanonical("/about"),
+    },
+    publisher: {
+      "@type": "Person",
+      "@id": toAbsoluteUrl(PERSON_ID),
+    },
+    inLanguage: "en-CA",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": canonicalPostUrl,
     },
   };
 }


### PR DESCRIPTION
### Motivation

- Improve technical SEO by emitting explicit `Article` JSON-LD for blog posts in addition to existing `BlogPosting` and breadcrumb schema. 
- Surface canonical IDs, publish/modify dates, keywords, images, and an explicit author profile URL to help search engines better understand post and author relationships.

### Description

- Added a new `buildArticleSchema` JSON-LD builder in `src/lib/seo/jsonld.ts` that produces `Article` structured data including `@id`, canonical `url`, `headline`, `datePublished`, `dateModified`, `keywords`, `image` (absolute URLs), `author` (linked to the person ID and `/about/`), and `publisher`.
- Exported the new `buildArticleSchema` from the SEO barrel file in `src/lib/seo/index.ts`.
- Injected `Article` JSON-LD into individual blog post pages by rendering `<JsonLd<Article> item={buildArticleSchema(...)}/>` alongside the existing `BlogPosting` and breadcrumbs in `src/app/blog/[slug]/page.tsx`.
- Added unit test coverage in `src/lib/seo/__tests__/jsonld.test.ts` to validate the generated `Article` schema shape, canonical URL, `@id`, and author profile URL mapping.

### Testing

- Ran `yarn test --runTestsByPath src/lib/seo/__tests__/jsonld.test.ts`, and the test suite passed (4 tests, all green).
- Ran `yarn lint` to confirm formatting/linting, and checks passed (Prettier formatting OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13d8fa86c83238a6b592793968a8e)