### PR TITLE
Update site copy and metadata; add article author/timestamps to blog post header

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,9 +12,9 @@ import { buildPageMetadata, buildProfilePageSchema } from "@/lib/seo";
 
 import { Skills } from "./_components/TechnicalInterests";
 
-const title = "About Me | Alex Leung";
+const title = "About | Alex Leung";
 const description =
-  "Learn about Alex Leung's journey - from University of Waterloo and Georgia Tech to end-to-end product development.";
+  "Learn about Alex Leung's background, credentials, and approach to building software products end to end.";
 const path = "/about";
 
 export const metadata: Metadata = buildPageMetadata({

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -61,6 +61,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     ...metadata,
+    authors: [{ name: "Alex Leung", url: toCanonical("/about") }],
     openGraph: {
       type: "article",
       title,
@@ -146,8 +147,16 @@ export default async function Post({ params }: Props) {
           className="mb-12"
         >
           <Surface className="mx-auto" padding="sm">
-            <div className="mb-3 text-lg text-gray-300">
-              {formatIsoDateForDisplay(post.date)}
+            <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-lg text-gray-300">
+              <span>By Alex Leung</span>
+              <time dateTime={post.date}>
+                Published {formatIsoDateForDisplay(post.date)}
+              </time>
+              {post.updated && post.updated !== post.date && (
+                <time dateTime={post.updated}>
+                  Updated {formatIsoDateForDisplay(post.updated)}
+                </time>
+              )}
             </div>
             {post.tags.length > 0 && (
               <div className="mb-6 flex flex-wrap gap-2">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -18,7 +18,7 @@ import {
 
 const title = "Blog | Alex Leung";
 const description =
-  "Thoughts on software engineering, product development, and life as a developer.";
+  "Notes on software engineering, distributed systems, AI engineering, and practical product development.";
 const path = "/blog";
 
 export function generateMetadata(): Metadata {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ import "./globals.css";
 
 const title = "Alex Leung | Syntropy Engineer and Programmer, P.Eng.";
 const description =
-  "Personal website of Alex Leung, a Syntropy Engineer and Programmer, featuring writing on software, systems, and learning in public.";
+  "Alex Leung is a Syntropy Engineer and Programmer writing about software systems, AI engineering, and learning in public.";
 
 const lato = Lato({
   subsets: ["latin"],
@@ -45,15 +45,15 @@ export const metadata: Metadata = {
     locale: "en_CA",
     images: [
       {
-        url: "/assets/alex_vibing.webp",
-        width: 1536,
-        height: 1024,
-        alt: title,
-      },
-      {
         url: "/assets/screenshot.png",
         width: 1200,
         height: 630,
+        alt: title,
+      },
+      {
+        url: "/assets/alex_vibing.webp",
+        width: 1536,
+        height: 1024,
         alt: title,
       },
     ],

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -27,9 +27,9 @@ export const NOW_PAGE_LAST_UPDATED_DISPLAY = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 }).format(nowPageLastUpdatedDate);
 
-const title = "What I'm Doing Now | Alex Leung";
+const title = "Now | Alex Leung";
 const description =
-  "Current projects, books, and goals - a snapshot of what Alex Leung is focused on right now.";
+  "A living snapshot of Alex Leung's current priorities, projects, reading, and experiments.";
 const path = "/now";
 
 export const metadata: Metadata = buildPageMetadata({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { buildHomePageSchema } from "@/lib/seo";
 
 const title = "Alex Leung | Syntropy Engineer and Programmer, P.Eng.";
 const description =
-  "Personal website of Alex Leung, a Syntropy Engineer and Programmer, featuring writing on software, systems, and learning in public.";
+  "Alex Leung is a Syntropy Engineer and Programmer writing about software systems, AI engineering, and learning in public.";
 const path = "/";
 
 export default function Page() {


### PR DESCRIPTION
### Motivation

- Harmonize and clarify site copy to emphasize software systems and AI engineering across the Home, Blog, About, and Now pages.
- Improve SEO and social sharing metadata by refining descriptions and Open Graph images ordering.
- Surface article authorship and publication/updated timestamps in the blog post UI for clearer attribution and better schema data.

### Description

- Updated page titles and descriptions for the Home, About, Blog index, and Now pages to reflect revised copy and focus areas.
- Reordered and adjusted Open Graph/Twitter images in `metadata` within `src/app/layout.tsx` and updated site-level description and keywords.
- Added `authors: [{ name: "Alex Leung", url: toCanonical("/about") }]` to the per-post `generateMetadata` return in `src/app/blog/[slug]/page.tsx` and added matching visible author and published/updated times in the post header.
- Minor content tweaks include changing the About page title/description and updating the Blog index description to mention AI engineering and product development.

### Testing

- Ran a production build with `next build` which completed successfully.
- Ran linting with `pnpm lint` which reported no new issues.
- Executed the test suite with `pnpm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b0a95af08323b08b9f595a61c856)