### PR TITLE
Remove author byline from blog post header

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -148,7 +148,6 @@ export default async function Post({ params }: Props) {
         >
           <Surface className="mx-auto" padding="sm">
             <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-lg text-gray-300">
-              <span>By Alex Leung</span>
               <time dateTime={post.date}>
                 Published {formatIsoDateForDisplay(post.date)}
               </time>


### PR DESCRIPTION
### Motivation
- The explicit author line is redundant on a personal blog; remove the `By Alex Leung` byline from individual post pages to simplify the metadata row.

### Description
- Deleted the `<span>By Alex Leung</span>` element from the blog post header in `src/app/blog/[slug]/page.tsx`, leaving the published/updated timestamps and tags intact.

### Testing
- Ran `corepack enable && corepack install && yarn lint`, which completed successfully; attempting to start the dev server with `yarn dev` produced runtime module resolution errors for KaTeX/remark dependencies (`katex`, `rehype-katex`, `remark-math`) so a local visual verification could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a325407c7483239a49f86f92e002ea)