### PR TITLE
Add related-posts generation, frontmatter fields, UI render, and tests

### DIFF
--- a/docs/engagement-audit.md
+++ b/docs/engagement-audit.md
@@ -1,0 +1,463 @@
+# Engagement Audit: Content + Site Structure
+
+Date: 2026-03-01
+
+## Executive summary
+
+Your site already has strong engagement foundations:
+
+- A clear and credible positioning statement on the hero section.
+- A consistent publishing rhythm in February 2026.
+- Good topical coherence around AI engineering, software systems, and reflective technical writing.
+- Static architecture + SEO/JSON-LD implementation that supports discoverability.
+
+The largest engagement upside now is **not visual polish**; it is adding stronger **reader journey mechanics**:
+
+1. Convert first-time visitors into repeat readers.
+2. Increase page depth (one post → second post).
+3. Give high-intent readers an explicit next step (contact/collab/subscribe).
+
+---
+
+## What the current structure is doing well
+
+### 1) Home page positioning is clear and concise
+
+The hero immediately communicates identity and topic focus, and has two direct CTAs (`Read My Blog`, `About Me`). This is excellent for first-impression clarity.
+
+### 2) Information architecture is simple and easy to parse
+
+Top-level nav (`Home`, `About`, `Now`, `Blog`, `Contact`) is straightforward and helps visitors self-select intent quickly.
+
+### 3) Blog card design supports scanning
+
+Cards include image, title, date, excerpt, and tags, which is a good default for discoverability and click-through.
+
+### 4) Metadata/structured data is already mature
+
+You are using page metadata and JSON-LD on home/blog/article pages, which gives you a strong SEO baseline.
+
+### 5) Content quality and voice are differentiated
+
+Your writing combines practical implementation details and reflective thinking. This balance is rare and can become a signature.
+
+---
+
+## Engagement opportunities (prioritized)
+
+## P0 — High impact, low complexity
+
+### A) Add a primary email capture or subscription CTA
+
+Current CTAs send visitors to blog/about, but there is no explicit mechanism to retain readers over time. Add one persistent CTA:
+
+- Header button: `Subscribe` (if newsletter exists) or `Get updates`.
+- End-of-post CTA block: "If this was useful, get future posts by email."
+- Home section: single-field email opt-in, or at minimum a "Follow on X/Bluesky + RSS" block.
+
+**Why:** This directly improves return traffic and lifetime engagement.
+
+### B) Add “Related posts” on blog post pages
+
+Today post pages focus on single-article consumption. Add 2–4 related post links by shared tags (or recency fallback).
+
+**Why:** This is usually the highest-leverage way to improve page depth and total session duration.
+
+### C) Add a stronger contact intent split
+
+On contact page, split intent into specific paths:
+
+- Collaboration / consulting
+- Speaking / podcast
+- General hello
+
+Optionally include a one-line expected response time.
+
+**Why:** Reduces friction and increases conversion from interested visitors.
+
+---
+
+## P1 — Medium impact
+
+### D) Surface “Start here” paths by reader type
+
+Create a short section (home or blog index):
+
+- New to my writing? Start here.
+- AI Engineering posts
+- Architecture posts
+- Reflection/opinion posts
+
+Curate 1–3 links per path.
+
+**Why:** Helps first-time readers quickly find relevance and lowers bounce.
+
+### E) Add reading-time metadata visibly on cards and posts
+
+Your post model already supports `readingTimeMinutes`. Display it on cards and at top of posts.
+
+**Why:** Time expectations increase click confidence and completion.
+
+### F) Add “featured post” + “latest” separation on blog index
+
+Instead of a flat grid only, make first slot a featured post (or latest long-form), then show rest in grid.
+
+**Why:** Better editorial guidance increases CTR to strategically important content.
+
+---
+
+## P2 — Strategic / compounding
+
+### G) Build a lightweight content series structure
+
+Some posts naturally form tracks (e.g., deep learning notes, AI workflow evolution). Add optional frontmatter fields:
+
+- `series`
+- `seriesOrder`
+
+Then render “Part X of Y” with prev/next links.
+
+**Why:** Series design improves repeat visits and completion loops.
+
+### H) Publish consistency cues + social proof
+
+Add small indicators:
+
+- "Published X posts this month"
+- "Most read posts" (can be manual if no analytics yet)
+- "Last updated" for selected evergreen pages (already done on Now page—extend pattern)
+
+**Why:** Freshness and social proof reduce hesitation.
+
+### I) Add lightweight on-site search or tag landing pages
+
+If full search feels heavy, start with tag landing pages (`/blog/tags/[tag]`) and a tag directory.
+
+**Why:** Better discoverability for returning readers with specific topic intent.
+
+---
+
+## Content strategy observations
+
+## What’s resonating in your current direction
+
+- Clear niche intersection: AI engineering + software architecture + reflective practice.
+- Posts that combine implementation details and personal decision-making are especially brand-consistent.
+- Recent cadence is strong; maintain it.
+
+## Gaps to close
+
+1. **No explicit “why follow” promise:** state what readers get and how often.
+2. **No retention loop:** no capture mechanism (email/RSS emphasis) embedded in reading flow.
+3. **No guided depth:** limited cross-linking and progression paths between posts.
+
+## Suggested editorial mix (monthly)
+
+- 2× practical engineering posts (implementation, architecture, workflow).
+- 1× conceptual/learning note (deep learning, systems reasoning).
+- 1× reflective career/creator post.
+
+This protects breadth while preserving your core identity.
+
+---
+
+## Recommended implementation sequence (4 weeks)
+
+### Week 1 (quick wins)
+
+1. Add end-of-post CTA block (subscribe/follow/contact).
+2. Add related posts module under each article.
+3. Show reading time in blog cards and post headers.
+
+### Week 2
+
+4. Add "Start here" section on blog index.
+5. Add intent-based contact options.
+
+### Week 3
+
+6. Introduce featured post on blog index.
+7. Add simple tag pages.
+
+### Week 4
+
+8. Add series metadata support + prev/next series nav.
+9. Add one recurring conversion block on home.
+
+---
+
+## Metrics to watch (engagement KPI set)
+
+Track these before/after each change:
+
+- Blog index click-through rate to post pages.
+- Average pages per session.
+- Percentage of sessions with 2+ post views.
+- Contact conversion rate.
+- Returning visitor rate (7-day and 30-day).
+- Email/RSS follower growth (if introduced).
+
+If you only track one KPI first, pick **% sessions with 2+ post views**.
+
+---
+
+## Bottom line
+
+Your foundation is strong: good writing, clear identity, and clean architecture. The next 20% effort should focus on **reader flow and retention systems** (subscribe, related posts, guided paths), because those changes most directly compound audience growth.
+
+---
+
+## Related posts: classification and maintenance design (markdown-first, no CMS)
+
+This section answers the implementation choices directly.
+
+### 1) Relationship model: use **directional (one-way) links generated from a symmetric similarity score**
+
+Recommendation:
+
+- Compute a similarity score between the current post and every other post.
+- For each post, publish only its top `N` results as outgoing related links.
+
+Why this model:
+
+- Similarity itself is naturally two-way (A is similar to B), but display should be one-way per page.
+- Requiring strict reciprocal links (A→B and B→A always) creates editorial coupling and brittle behavior as new posts are added.
+- One-way output is easier to maintain and still gives good user journeys.
+
+### 2) Time direction: **do not force backward-only links**
+
+Recommendation:
+
+- Default to both older and newer posts.
+- Optionally guarantee at least one older post when available (helps archive depth).
+
+Why:
+
+- Backward-only avoids stale old posts linking to future content, but it lowers quality for newer-post discovery.
+- For static rebuilds, old posts can safely point to newer posts after each build with no CMS complexity.
+- Bidirectional-in-time recommendations generally improve engagement better than backward-only.
+
+### 3) Upper limit: cap related links at **3** (hard max 4)
+
+Recommendation:
+
+- Render 3 related posts by default.
+- Use 4 only if you later add clear visual hierarchy or larger desktop layouts.
+
+Why:
+
+- 2 can feel sparse; 5+ creates decision fatigue.
+- 3 is a reliable sweet spot for click-through without clutter.
+
+### 4) Ranking heuristic (simple + maintainable)
+
+Use deterministic scoring from frontmatter you already have:
+
+- +4 for each shared tag.
+- +2 if same optional `series`.
+- +1 if publish dates are within 90 days.
+- -small penalty if candidate is same day and much shorter (optional tie-break).
+
+Then sort by score desc, then by date desc.
+
+If score is zero for all candidates, fallback to latest non-current posts.
+
+### 5) Frontmatter design (still markdown-only)
+
+Keep authoring in markdown with optional fields (no CMS):
+
+```yaml
+# optional
+series: "deep-learning-notes"
+seriesOrder: 2
+related:
+  - "from-coder-to-orchestrator" # manual override, optional
+  - "boring-blog-architecture"
+```
+
+Behavior:
+
+- `related` (if present) is a curated override list.
+- Otherwise use automatic tag/series/date scoring.
+- This hybrid approach preserves automation while allowing occasional editorial curation.
+
+### 6) Maintainability policy for future posts
+
+Recommended policy:
+
+1. **Default automation first** (tags + optional series).
+2. **Curate only cornerstone posts** with explicit `related` overrides.
+3. Keep tags normalized (singular/plural and naming consistency) to preserve recommendation quality.
+4. Add a small validation step in build/test:
+   - `related` slugs must exist.
+   - `seriesOrder` must be unique within a series.
+
+This keeps ongoing maintenance low while preserving quality as the archive grows.
+
+### 7) Practical implementation path in this codebase
+
+1. Extend frontmatter schema in `src/lib/blogApi.ts` with optional `series`, `seriesOrder`, and `related`.
+2. Add `getRelatedPosts(slug, limit = 3)` utility in `src/lib/blogApi.ts`.
+3. Render a related-posts block in `src/app/blog/[slug]/page.tsx` below article content.
+4. Add tests in `src/lib/__tests__/blogApi.test.ts` for:
+   - scoring,
+   - cap behavior,
+   - manual override,
+   - fallback when no tags match.
+
+This remains fully static and markdown-managed.
+
+### Recommendation summary (direct answers)
+
+- Two-way or one-way? **One-way display generated from symmetric similarity scores**.
+- Backwards-only? **No**; allow both directions in time for better discovery.
+- Upper limit? **3 related posts** (optionally 4 later).
+- CMS needed? **No**; use markdown frontmatter + deterministic generation at build time.
+
+---
+
+## Implementation proposal (concrete, code-first)
+
+This proposal translates the strategy above into an incremental implementation plan that preserves your current static + markdown workflow.
+
+### Scope
+
+In scope:
+
+- Add optional post metadata (`series`, `seriesOrder`, `related`) in markdown frontmatter.
+- Implement deterministic related-post selection in `src/lib/blogApi.ts`.
+- Render a "Related posts" module on post pages.
+- Add tests and validations to keep long-term maintenance low.
+
+Out of scope (for phase 1):
+
+- Any CMS integration.
+- Personalized recommendations.
+- Runtime analytics-based ranking.
+
+### Data model changes
+
+Extend `PostFrontMatterSchema` and `Post` in `src/lib/blogApi.ts` with:
+
+- `series?: string`
+- `seriesOrder?: number`
+- `related?: string[]`
+
+Validation rules:
+
+1. `seriesOrder` requires `series`.
+2. `seriesOrder` must be a positive integer.
+3. `related` cannot include current post slug.
+4. `related` slugs must exist in `content/posts`.
+5. Within a given series, `seriesOrder` must be unique.
+
+### Proposed API additions
+
+Add to `src/lib/blogApi.ts`:
+
+```ts
+type GetRelatedPostsOptions = {
+  limit?: number; // default 3
+};
+
+export function getRelatedPosts(
+  slug: string,
+  options?: GetRelatedPostsOptions
+): Array<Pick<Post, "slug" | "title" | "date" | "excerpt" | "coverImage" | "tags">>;
+```
+
+Implementation behavior:
+
+1. Load target post.
+2. If target has `related`, return those (filtered to valid + existing slugs), capped by `limit`.
+3. Else score all candidates using deterministic heuristic.
+4. If all candidate scores are 0, fallback to newest non-current posts.
+5. Return top `limit` items.
+
+### Scoring spec (v1)
+
+Given `target` and `candidate`:
+
+- `tagScore = sharedTagCount * 4`
+- `seriesScore = +2` if both have same non-empty `series`
+- `recencyScore = +1` if abs(date diff) <= 90 days
+- `total = tagScore + seriesScore + recencyScore`
+
+Tie-break order:
+
+1. Higher `total`
+2. Newer `date`
+3. Lexicographic slug (stable deterministic output)
+
+### UI integration
+
+In `src/app/blog/[slug]/page.tsx`:
+
+- Fetch `relatedPosts = getRelatedPosts(post.slug, { limit: 3 })`.
+- Render below the article body in a dedicated section:
+  - Heading: `Related posts`
+  - 3 compact cards (title, date, optional excerpt)
+  - Link target: `/blog/${slug}`
+
+Accessibility/content details:
+
+- Use semantic heading level following the page structure.
+- Keep module hidden when no related posts exist.
+- Preserve current page performance by using existing static data path.
+
+### Tests
+
+Add/extend tests in `src/lib/__tests__/blogApi.test.ts`:
+
+1. Returns manual override when `related` is present.
+2. Ignores non-existent override slugs and still returns valid ones.
+3. Applies score ordering for shared tags/series/date window.
+4. Enforces cap (`limit`, default 3).
+5. Falls back to newest posts when all scores are zero.
+6. Throws on invalid schema combinations (`seriesOrder` without `series`, duplicate order in series).
+
+Add route-level rendering test(s) if desired in `src/app/.../__tests__` later, but keep phase 1 focused on `blogApi` correctness.
+
+### Rollout plan
+
+#### Phase 1 (core backend logic)
+
+- Update schema + types.
+- Implement `getRelatedPosts` + tests.
+- No UI change yet (safe backend merge).
+
+#### Phase 2 (UI)
+
+- Add related-posts module to post page.
+- Add component tests for rendering + empty state.
+
+#### Phase 3 (editorial polish)
+
+- Add `series` metadata to selected existing posts.
+- Add manual `related` only for cornerstone posts.
+
+### Acceptance criteria
+
+- Build succeeds with no CMS dependency.
+- Existing posts without new fields continue to work.
+- For any published post, `getRelatedPosts` returns deterministic output.
+- Default related count is 3 and never exceeds limit.
+- `yarn lint`, `yarn test`, and `yarn typecheck` pass after implementation.
+
+### Risks and mitigations
+
+- **Risk:** Tag taxonomy drift reduces recommendation quality.
+  - **Mitigation:** Normalize tag naming conventions and optionally add a lightweight tag lint rule.
+
+- **Risk:** Manual overrides become stale.
+  - **Mitigation:** Validate override slugs in tests/build checks.
+
+- **Risk:** Over-linking to very recent posts only.
+  - **Mitigation:** Keep tag weight dominant over recency in scoring.
+
+### Why this is maintainable long-term
+
+- Authoring remains markdown-only in `content/posts/*.md`.
+- Ranking is deterministic and testable.
+- Manual curation is optional and limited to high-value posts.
+- No external service or CMS integration is required.

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { JsonLd } from "react-schemaorg";
 
 import { Metadata } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Article, BlogPosting } from "schema-dts";
@@ -12,7 +13,7 @@ import { ProseContent } from "@/components/ProseContent";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { Surface } from "@/components/Surface";
 import { Tag } from "@/components/Tag";
-import { getAllPosts, getPostBySlug } from "@/lib/blogApi";
+import { getAllPosts, getPostBySlug, getRelatedPosts } from "@/lib/blogApi";
 import { formatIsoDateForDisplay } from "@/lib/date";
 import markdownToHtml from "@/lib/markdownToHtml";
 import {
@@ -108,6 +109,7 @@ export default async function Post({ params }: Props) {
   }
 
   const content = await markdownToHtml(post.content || "");
+  const relatedPosts = getRelatedPosts(post.slug, { limit: 3 });
 
   return (
     <>
@@ -172,6 +174,46 @@ export default async function Post({ params }: Props) {
               className="mb-6 sm:mx-0 md:mb-10"
             />
             <ProseContent html={content} />
+
+            {relatedPosts.length > 0 && (
+              <section
+                aria-labelledby="related-posts-heading"
+                className="mt-12 border-t border-white/10 pt-8"
+              >
+                <h2
+                  id="related-posts-heading"
+                  className="mb-5 text-2xl font-bold text-white"
+                >
+                  Related posts
+                </h2>
+                <div className="grid gap-4 md:grid-cols-3">
+                  {relatedPosts.map((relatedPost) => (
+                    <Link
+                      key={relatedPost.slug}
+                      href={`/blog/${relatedPost.slug}`}
+                      className="block"
+                    >
+                      <Surface
+                        className="h-full p-4 transition-colors hover:border-white/30"
+                        interactive
+                      >
+                        <h3 className="text-base font-semibold text-white">
+                          {relatedPost.title}
+                        </h3>
+                        <p className="mt-1 text-sm text-gray-300">
+                          {formatIsoDateForDisplay(relatedPost.date)}
+                        </p>
+                        {relatedPost.excerpt ? (
+                          <p className="mt-2 line-clamp-3 text-sm text-gray-200">
+                            {relatedPost.excerpt}
+                          </p>
+                        ) : null}
+                      </Surface>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
           </Surface>
         </ResponsiveContainer>
       </PageShell>

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -207,6 +207,55 @@ describe("getRelatedPosts", () => {
     ).toEqual(["newest", "older"]);
   });
 
+  test("allows published posts to reference draft related slugs by default", async () => {
+    const tempDir = setupTempPosts({
+      published: `---
+title: "Published"
+date: "2026-02-16"
+related:
+  - "draft-post"
+---
+Body`,
+      "draft-post": `---
+title: "Draft"
+date: "2026-02-17"
+draft: true
+---
+Body`,
+    });
+
+    const { getAllPosts, getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(() => getAllPosts()).not.toThrow();
+    expect(getRelatedPosts("published")).toEqual([]);
+  });
+
+  test("includes draft related targets when includeDrafts is true", async () => {
+    const tempDir = setupTempPosts({
+      published: `---
+title: "Published"
+date: "2026-02-16"
+related:
+  - "draft-post"
+---
+Body`,
+      "draft-post": `---
+title: "Draft"
+date: "2026-02-17"
+draft: true
+---
+Body`,
+    });
+
+    const { getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(
+      getRelatedPosts("published", { includeDrafts: true }).map(
+        (post) => post.slug
+      )
+    ).toEqual(["draft-post"]);
+  });
+
   test("returns an empty list for missing post or zero limit", async () => {
     const tempDir = setupTempPosts({
       a: `---\ntitle: "A"\ndate: "2026-02-16"\n---\nBody`,

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -37,6 +37,7 @@ describe("blogApi front matter validation", () => {
     expect(post).not.toBeNull();
     expect(post?.title).toBe("Hello");
     expect(post?.tags).toEqual([]);
+    expect(post?.related).toEqual([]);
     expect(post?.draft).toBe(false);
   });
 
@@ -73,6 +74,18 @@ describe("blogApi front matter validation", () => {
 
     expect(() => getPostBySlug("unknown-key")).toThrow(
       /Invalid front matter.*Unrecognized key/
+    );
+  });
+
+  test("throws when seriesOrder exists without series", async () => {
+    const tempDir = setupTempPosts({
+      "bad-series": `---\ntitle: "Bad"\ndate: "2026-02-16"\nseriesOrder: 1\n---\nBody`,
+    });
+
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+
+    expect(() => getPostBySlug("bad-series")).toThrow(
+      /seriesOrder requires series/
     );
   });
 
@@ -124,5 +137,85 @@ describe("blogApi front matter validation", () => {
     expect(
       getAllPosts({ includeDrafts: true }).map((post) => post.slug)
     ).toEqual(["draft"]);
+  });
+
+  test("throws when related slug does not exist", async () => {
+    const tempDir = setupTempPosts({
+      main: `---\ntitle: "Main"\ndate: "2026-02-16"\nrelated:\n  - "missing"\n---\nBody`,
+      other: `---\ntitle: "Other"\ndate: "2026-02-15"\n---\nBody`,
+    });
+
+    const { getAllPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(() => getAllPosts()).toThrow(/does not exist/);
+  });
+
+  test("throws when seriesOrder duplicates within the same series", async () => {
+    const tempDir = setupTempPosts({
+      a: `---\ntitle: "A"\ndate: "2026-02-16"\nseries: "s"\nseriesOrder: 1\n---\nBody`,
+      b: `---\ntitle: "B"\ndate: "2026-02-15"\nseries: "s"\nseriesOrder: 1\n---\nBody`,
+    });
+
+    const { getAllPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(() => getAllPosts()).toThrow(/Duplicate seriesOrder/);
+  });
+});
+
+describe("getRelatedPosts", () => {
+  test("returns manual overrides first when present", async () => {
+    const tempDir = setupTempPosts({
+      a: `---\ntitle: "A"\ndate: "2026-02-16"\nrelated:\n  - "c"\n  - "b"\n---\nBody`,
+      b: `---\ntitle: "B"\ndate: "2026-02-15"\n---\nBody`,
+      c: `---\ntitle: "C"\ndate: "2026-02-14"\n---\nBody`,
+    });
+
+    const { getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(getRelatedPosts("a").map((post) => post.slug)).toEqual(["c", "b"]);
+  });
+
+  test("ranks by score and then date for automatic selection", async () => {
+    const tempDir = setupTempPosts({
+      target: `---\ntitle: "Target"\ndate: "2026-02-16"\ntags:\n  - "AI"\n  - "Systems"\nseries: "notes"\n---\nBody`,
+      strong: `---\ntitle: "Strong"\ndate: "2026-02-15"\ntags:\n  - "AI"\n  - "Systems"\nseries: "notes"\n---\nBody`,
+      medium: `---\ntitle: "Medium"\ndate: "2026-02-14"\ntags:\n  - "AI"\n---\nBody`,
+      weak: `---\ntitle: "Weak"\ndate: "2025-01-01"\ntags:\n  - "Other"\n---\nBody`,
+    });
+
+    const { getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(getRelatedPosts("target").map((post) => post.slug)).toEqual([
+      "strong",
+      "medium",
+      "weak",
+    ]);
+  });
+
+  test("falls back to newest posts when no candidate has a positive score", async () => {
+    const tempDir = setupTempPosts({
+      target: `---\ntitle: "Target"\ndate: "2026-02-16"\ntags:\n  - "AI"\n---\nBody`,
+      newest: `---\ntitle: "Newest"\ndate: "2024-03-02"\ntags:\n  - "X"\n---\nBody`,
+      older: `---\ntitle: "Older"\ndate: "2024-03-01"\ntags:\n  - "Y"\n---\nBody`,
+      oldest: `---\ntitle: "Oldest"\ndate: "2024-02-20"\ntags:\n  - "Z"\n---\nBody`,
+    });
+
+    const { getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(
+      getRelatedPosts("target", { limit: 2 }).map((post) => post.slug)
+    ).toEqual(["newest", "older"]);
+  });
+
+  test("returns an empty list for missing post or zero limit", async () => {
+    const tempDir = setupTempPosts({
+      a: `---\ntitle: "A"\ndate: "2026-02-16"\n---\nBody`,
+      b: `---\ntitle: "B"\ndate: "2026-02-15"\n---\nBody`,
+    });
+
+    const { getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(getRelatedPosts("missing")).toEqual([]);
+    expect(getRelatedPosts("a", { limit: 0 })).toEqual([]);
   });
 });

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -13,6 +13,9 @@ const POST_FIELDS = [
   "excerpt",
   "coverImage",
   "tags",
+  "series",
+  "seriesOrder",
+  "related",
   "readingTimeMinutes",
   "draft",
   "content",
@@ -32,6 +35,9 @@ export type Post = {
   excerpt?: string;
   coverImage?: string;
   tags: string[];
+  series?: string;
+  seriesOrder?: number;
+  related: string[];
   readingTimeMinutes?: number;
   draft: boolean;
   content: string;
@@ -71,6 +77,22 @@ const PostFrontMatterSchema = z
       .array(z.string().trim().min(1))
       .default([])
       .describe("Optional list of taxonomy tags for post grouping."),
+    series: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Optional series name for grouping related posts."),
+    seriesOrder: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Optional order index for posts within a series."),
+    related: z
+      .array(z.string().trim().min(1))
+      .default([])
+      .describe("Optional manual related-post slug overrides."),
     readingTimeMinutes: z
       .number()
       .int()
@@ -117,6 +139,12 @@ function parseFrontMatter(
     throw new Error(`Invalid front matter in ${slug}.md: ${errors}`);
   }
 
+  if (parsed.data.seriesOrder && !parsed.data.series) {
+    throw new Error(
+      `Invalid front matter in ${slug}.md: seriesOrder requires series`
+    );
+  }
+
   return parsed.data;
 }
 
@@ -151,10 +179,95 @@ function parsePostBySlug(slug: string): Post | null {
     excerpt: frontMatter.excerpt,
     coverImage: frontMatter.coverImage,
     tags: frontMatter.tags,
+    series: frontMatter.series,
+    seriesOrder: frontMatter.seriesOrder,
+    related: frontMatter.related,
     readingTimeMinutes: frontMatter.readingTimeMinutes,
     draft: frontMatter.draft,
     content,
   };
+}
+
+function assertUniqueSeriesOrder(posts: readonly Post[]) {
+  const seen = new Map<string, Set<number>>();
+
+  for (const post of posts) {
+    if (!post.series || !post.seriesOrder) {
+      continue;
+    }
+
+    const existing = seen.get(post.series) ?? new Set<number>();
+
+    if (existing.has(post.seriesOrder)) {
+      throw new Error(
+        `Duplicate seriesOrder ${post.seriesOrder} in series "${post.series}"`
+      );
+    }
+
+    existing.add(post.seriesOrder);
+    seen.set(post.series, existing);
+  }
+}
+
+function assertRelatedSlugsExist(posts: readonly Post[]) {
+  const slugs = new Set(posts.map((post) => post.slug));
+
+  for (const post of posts) {
+    for (const relatedSlug of post.related) {
+      if (relatedSlug === post.slug) {
+        throw new Error(
+          `Invalid related slug in "${post.slug}": post cannot relate to itself`
+        );
+      }
+
+      if (!slugs.has(relatedSlug)) {
+        throw new Error(
+          `Invalid related slug in "${post.slug}": "${relatedSlug}" does not exist`
+        );
+      }
+    }
+  }
+}
+
+type RelatedPost = Pick<
+  Post,
+  "slug" | "title" | "date" | "excerpt" | "coverImage" | "tags"
+>;
+
+type GetRelatedPostsOptions = {
+  limit?: number;
+  includeDrafts?: boolean;
+};
+
+function toRelatedPost(post: Post): RelatedPost {
+  return {
+    slug: post.slug,
+    title: post.title,
+    date: post.date,
+    excerpt: post.excerpt,
+    coverImage: post.coverImage,
+    tags: post.tags,
+  };
+}
+
+function getRelatedScore(target: Post, candidate: Post): number {
+  const targetTags = new Set(target.tags);
+  const sharedTagCount = candidate.tags.filter((tag) =>
+    targetTags.has(tag)
+  ).length;
+  const tagScore = sharedTagCount * 4;
+  const seriesScore =
+    target.series && candidate.series && target.series === candidate.series
+      ? 2
+      : 0;
+  const daysDiff =
+    Math.abs(
+      new Date(target.date).getTime() - new Date(candidate.date).getTime()
+    ) /
+    (1000 * 60 * 60 * 24);
+  const recencyScore = daysDiff <= 90 ? 1 : 0;
+
+  return tagScore + seriesScore + recencyScore;
 }
 
 function pickPostFields<T extends PostField>(
@@ -242,6 +355,9 @@ export function getAllPosts<T extends PostField>(
         new Date(post2.date).getTime() - new Date(post1.date).getTime()
     );
 
+  assertUniqueSeriesOrder(posts);
+  assertRelatedSlugsExist(posts);
+
   if (!fields || fields.length === 0) {
     return posts;
   }
@@ -253,4 +369,66 @@ export function getAllPosts<T extends PostField>(
   }
 
   return posts.map((post) => pickPostFields(post, fields));
+}
+
+export function getRelatedPosts(
+  slug: string,
+  options?: GetRelatedPostsOptions
+): RelatedPost[] {
+  const limit = options?.limit ?? 3;
+
+  if (limit <= 0) {
+    return [];
+  }
+
+  const allPosts = getAllPosts({
+    includeDrafts: options?.includeDrafts ?? false,
+  });
+  const target = allPosts.find((post) => post.slug === slug);
+
+  if (!target) {
+    return [];
+  }
+
+  const candidates = allPosts.filter((post) => post.slug !== slug);
+
+  if (target.related.length > 0) {
+    const relatedBySlug = new Map(candidates.map((post) => [post.slug, post]));
+
+    return target.related
+      .map((relatedSlug) => relatedBySlug.get(relatedSlug))
+      .filter((post): post is Post => Boolean(post))
+      .slice(0, limit)
+      .map(toRelatedPost);
+  }
+
+  const scored = candidates
+    .map((candidate) => ({
+      post: candidate,
+      score: getRelatedScore(target, candidate),
+    }))
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+
+      const dateDelta =
+        new Date(b.post.date).getTime() - new Date(a.post.date).getTime();
+
+      if (dateDelta !== 0) {
+        return dateDelta;
+      }
+
+      return a.post.slug.localeCompare(b.post.slug);
+    });
+
+  const hasNonZeroScore = scored.some((entry) => entry.score > 0);
+  const ranked = hasNonZeroScore
+    ? scored
+    : scored.sort(
+        (a, b) =>
+          new Date(b.post.date).getTime() - new Date(a.post.date).getTime()
+      );
+
+  return ranked.slice(0, limit).map((entry) => toRelatedPost(entry.post));
 }

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -346,17 +346,19 @@ export function getAllPosts<T extends PostField>(
     : fieldsOrOptions;
 
   const includeDrafts = options?.includeDrafts ?? false;
-  const posts = getPostSlugs()
+  const allPosts = getPostSlugs()
     .map((slug) => parsePostBySlug(slug))
-    .filter((post): post is Post => post !== null)
+    .filter((post): post is Post => post !== null);
+
+  assertUniqueSeriesOrder(allPosts);
+  assertRelatedSlugsExist(allPosts);
+
+  const posts = allPosts
     .filter((post) => includeDrafts || !post.draft)
     .sort(
       (post1, post2) =>
         new Date(post2.date).getTime() - new Date(post1.date).getTime()
     );
-
-  assertUniqueSeriesOrder(posts);
-  assertRelatedSlugsExist(posts);
 
   if (!fields || fields.length === 0) {
     return posts;


### PR DESCRIPTION
### Motivation

- Enable on-site reader journeys by generating and displaying related posts to increase page depth and retention.
- Support lightweight series and manual curation via frontmatter so authors can control relationships without a CMS.
- Add deterministic, testable recommendation logic that works at build time with the existing markdown workflow.

### Description

- Extend the frontmatter schema in `src/lib/blogApi.ts` with `series`, `seriesOrder`, and `related` and add validation for `seriesOrder` and `related` slugs.
- Implement `getRelatedPosts(slug, options?)` with manual `related` override and a deterministic scoring heuristic (tags, series, recency) and cap the result by `limit`.
- Render a `Related posts` section in `src/app/blog/[slug]/page.tsx` using `getRelatedPosts` and `next/link` with compact cards and an accessible heading.
- Add/modify unit tests in `src/lib/__tests__/blogApi.test.ts` to cover frontmatter validation, series/order rules, related-slug validation, scoring, fallback behavior, and the manual-override flow, and add a new `docs/engagement-audit.md` audit document.

### Testing

- Ran the updated unit tests in `src/lib/__tests__/blogApi.test.ts` via `yarn test`, which exercise frontmatter parsing, `getRelatedPosts` behavior, and validation rules, and they passed.
- Ran a typecheck via `yarn typecheck` and a lint check via `yarn lint` to ensure API and UI integration are typed and styled, and both succeeded.
- Verified that `getRelatedPosts` returns deterministic output for seeded scenarios including manual overrides, score ordering, zero-score fallback, and empty/missing-post cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3c2f2b7b083238d98826355996c1c)