### PR TITLE
Add curated related post links to blog front matter

### DIFF
--- a/content/posts/boring-blog-architecture.md
+++ b/content/posts/boring-blog-architecture.md
@@ -8,6 +8,10 @@ tags:
   - "Next.js"
   - "Architecture"
   - "Blogging"
+related:
+  - "from-coder-to-orchestrator"
+  - "medium-and-meaning"
+  - "everyone-is-a-builder"
 
 ---
 

--- a/content/posts/deep-learning-part-1-review.md
+++ b/content/posts/deep-learning-part-1-review.md
@@ -7,6 +7,10 @@ coverImage: "/assets/blog/deep-learning-part-1-review/cover.webp"
 tags:
   - "Deep Learning"
   - "Book Notes"
+related:
+  - "structural-reasoning-about-deep-networks"
+  - "from-coder-to-orchestrator"
+  - "everyone-is-a-builder"
 
 ---
 

--- a/content/posts/everyone-is-a-builder.md
+++ b/content/posts/everyone-is-a-builder.md
@@ -7,6 +7,10 @@ tags:
   - "AI"
   - "Future of Work"
   - "Reflection"
+related:
+  - "medium-and-meaning"
+  - "from-coder-to-orchestrator"
+  - "boring-blog-architecture"
 ---
 
 Over cocktails recently, a few colleagues and I kept circling the same idea: AI is making everyone a builder. You still get leverage from software engineering skill, but you no longer need a formal engineering background to prototype, automate, and ship something useful.

--- a/content/posts/from-coder-to-orchestrator.md
+++ b/content/posts/from-coder-to-orchestrator.md
@@ -8,6 +8,10 @@ tags:
   - "AI Engineering"
   - "Developer Workflow"
 
+related:
+  - "everyone-is-a-builder"
+  - "medium-and-meaning"
+  - "boring-blog-architecture"
 ---
 
 Over the past two years, my day-to-day work has shifted from direct implementation toward orchestration and verification. In early 2024, I used AI mostly for autocomplete-level tasks such as snippets, error explanations, and small refactors. By 2026, I still write code when needed, but far more of my time goes to defining tasks clearly, checking outputs, and fixing edge cases the agents miss.

--- a/content/posts/medium-and-meaning.md
+++ b/content/posts/medium-and-meaning.md
@@ -7,6 +7,10 @@ tags:
   - "AI"
   - "Creativity"
   - "Reflection"
+related:
+  - "everyone-is-a-builder"
+  - "from-coder-to-orchestrator"
+  - "boring-blog-architecture"
 ---
 
 Lately, I've been using Codex a lot to improve this site, often from my phone — fixing a layout bug, tweaking copy, adjusting spacing by a few pixels.

--- a/content/posts/structural-reasoning-about-deep-networks.md
+++ b/content/posts/structural-reasoning-about-deep-networks.md
@@ -9,6 +9,10 @@ tags:
   - "Neural Networks"
   - "ML Theory"
 
+related:
+  - "deep-learning-part-1-review"
+  - "from-coder-to-orchestrator"
+  - "everyone-is-a-builder"
 ---
 
 Working through Chapter 6, _Deep Feedforward Networks_, sharpened how I reason about neural networks. It did not expand my practical toolkit so much as refine my conceptual boundaries. After completing coursework like the DeepLearning.AI specialization, I was comfortable training multilayer perceptrons and reasoning about gradients. What this chapter clarified is that architecture is not just a tuning dimension—it is a structural assumption about the function class we are willing to search.


### PR DESCRIPTION
### Motivation
- Surface intentional, context-aware follow-up reads by using the blog's new manual `related` front-matter override instead of relying only on automatic scoring.
- Group posts into thematic clusters (AI/workflow/reflection and deep-learning theory) to improve reader navigation and engagement.

### Description
- Added a `related` front-matter array to six published posts: `boring-blog-architecture`, `deep-learning-part-1-review`, `everyone-is-a-builder`, `from-coder-to-orchestrator`, `medium-and-meaning`, and `structural-reasoning-about-deep-networks`.
- Each `related` list contains valid slugs that point to existing posts and connects posts by theme (workflow/reflection cluster and deep-learning cluster).
- No code changes to `blogApi.ts` were required; this leverages the existing manual related-post override logic.

### Testing
- Ran `corepack enable && corepack install` successfully to ensure the pinned Yarn is available.
- Executed `yarn test src/lib/__tests__/blogApi.test.ts` and all tests passed (`17 passed, 0 failed`).
- Verified runtime rendering with `yarn dev` and captured a UI screenshot via a Playwright script to confirm related posts display on a post page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5098d83308323a291ab55a1f1bcd4)