### PR TITLE
Infer related blog posts instead of manual frontmatter

### DIFF
--- a/content/posts/boring-blog-architecture.md
+++ b/content/posts/boring-blog-architecture.md
@@ -8,11 +8,6 @@ tags:
   - "Next.js"
   - "Architecture"
   - "Blogging"
-related:
-  - "from-coder-to-orchestrator"
-  - "medium-and-meaning"
-  - "everyone-is-a-builder"
-
 ---
 
 I recently finished implementing the blog section of this personal website. Rather than reaching for a complex CMS, I decided to build it directly into my existing Next.js application using standard tools.

--- a/content/posts/deep-learning-part-1-review.md
+++ b/content/posts/deep-learning-part-1-review.md
@@ -7,11 +7,6 @@ coverImage: "/assets/blog/deep-learning-part-1-review/cover.webp"
 tags:
   - "Deep Learning"
   - "Book Notes"
-related:
-  - "structural-reasoning-about-deep-networks"
-  - "from-coder-to-orchestrator"
-  - "everyone-is-a-builder"
-
 ---
 
 I recently finished Part I of _Deep Learning_ by Goodfellow, Bengio, and Courville. It was a clear and efficient primer on the mathematical preliminaries needed to engage more deeply with the subject. I appreciated the refresher in linear algebra, probability, and numerical computation, which helped reestablish important foundations. In places, I found myself wishing for more proofs—or at least proof sketches—as I often wanted to understand where results came from rather than accept them at face value.

--- a/content/posts/everyone-is-a-builder.md
+++ b/content/posts/everyone-is-a-builder.md
@@ -7,10 +7,6 @@ tags:
   - "AI"
   - "Future of Work"
   - "Reflection"
-related:
-  - "medium-and-meaning"
-  - "from-coder-to-orchestrator"
-  - "boring-blog-architecture"
 ---
 
 Over cocktails recently, a few colleagues and I kept circling the same idea: AI is making everyone a builder. You still get leverage from software engineering skill, but you no longer need a formal engineering background to prototype, automate, and ship something useful.

--- a/content/posts/from-coder-to-orchestrator.md
+++ b/content/posts/from-coder-to-orchestrator.md
@@ -8,10 +8,6 @@ tags:
   - "AI Engineering"
   - "Developer Workflow"
 
-related:
-  - "everyone-is-a-builder"
-  - "medium-and-meaning"
-  - "boring-blog-architecture"
 ---
 
 Over the past two years, my day-to-day work has shifted from direct implementation toward orchestration and verification. In early 2024, I used AI mostly for autocomplete-level tasks such as snippets, error explanations, and small refactors. By 2026, I still write code when needed, but far more of my time goes to defining tasks clearly, checking outputs, and fixing edge cases the agents miss.

--- a/content/posts/medium-and-meaning.md
+++ b/content/posts/medium-and-meaning.md
@@ -7,10 +7,6 @@ tags:
   - "AI"
   - "Creativity"
   - "Reflection"
-related:
-  - "everyone-is-a-builder"
-  - "from-coder-to-orchestrator"
-  - "boring-blog-architecture"
 ---
 
 Lately, I've been using Codex a lot to improve this site, often from my phone — fixing a layout bug, tweaking copy, adjusting spacing by a few pixels.

--- a/content/posts/structural-reasoning-about-deep-networks.md
+++ b/content/posts/structural-reasoning-about-deep-networks.md
@@ -9,10 +9,6 @@ tags:
   - "Neural Networks"
   - "ML Theory"
 
-related:
-  - "deep-learning-part-1-review"
-  - "from-coder-to-orchestrator"
-  - "everyone-is-a-builder"
 ---
 
 Working through Chapter 6, _Deep Feedforward Networks_, sharpened how I reason about neural networks. It did not expand my practical toolkit so much as refine my conceptual boundaries. After completing coursework like the DeepLearning.AI specialization, I was comfortable training multilayer perceptrons and reasoning about gradients. What this chapter clarified is that architecture is not just a tuning dimension—it is a structural assumption about the function class we are willing to search.

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -37,7 +37,6 @@ describe("blogApi front matter validation", () => {
     expect(post).not.toBeNull();
     expect(post?.title).toBe("Hello");
     expect(post?.tags).toEqual([]);
-    expect(post?.related).toEqual([]);
     expect(post?.draft).toBe(false);
   });
 
@@ -139,17 +138,6 @@ describe("blogApi front matter validation", () => {
     ).toEqual(["draft"]);
   });
 
-  test("throws when related slug does not exist", async () => {
-    const tempDir = setupTempPosts({
-      main: `---\ntitle: "Main"\ndate: "2026-02-16"\nrelated:\n  - "missing"\n---\nBody`,
-      other: `---\ntitle: "Other"\ndate: "2026-02-15"\n---\nBody`,
-    });
-
-    const { getAllPosts } = await loadBlogApiAtCwd(tempDir);
-
-    expect(() => getAllPosts()).toThrow(/does not exist/);
-  });
-
   test("throws when seriesOrder duplicates within the same series", async () => {
     const tempDir = setupTempPosts({
       a: `---\ntitle: "A"\ndate: "2026-02-16"\nseries: "s"\nseriesOrder: 1\n---\nBody`,
@@ -163,18 +151,6 @@ describe("blogApi front matter validation", () => {
 });
 
 describe("getRelatedPosts", () => {
-  test("returns manual overrides first when present", async () => {
-    const tempDir = setupTempPosts({
-      a: `---\ntitle: "A"\ndate: "2026-02-16"\nrelated:\n  - "c"\n  - "b"\n---\nBody`,
-      b: `---\ntitle: "B"\ndate: "2026-02-15"\n---\nBody`,
-      c: `---\ntitle: "C"\ndate: "2026-02-14"\n---\nBody`,
-    });
-
-    const { getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
-
-    expect(getRelatedPosts("a").map((post) => post.slug)).toEqual(["c", "b"]);
-  });
-
   test("ranks by score and then date for automatic selection", async () => {
     const tempDir = setupTempPosts({
       target: `---\ntitle: "Target"\ndate: "2026-02-16"\ntags:\n  - "AI"\n  - "Systems"\nseries: "notes"\n---\nBody`,
@@ -207,41 +183,43 @@ describe("getRelatedPosts", () => {
     ).toEqual(["newest", "older"]);
   });
 
-  test("allows published posts to reference draft related slugs by default", async () => {
+  test("does not include drafts by default", async () => {
     const tempDir = setupTempPosts({
       published: `---
 title: "Published"
 date: "2026-02-16"
-related:
-  - "draft-post"
+tags:
+  - "AI"
 ---
 Body`,
       "draft-post": `---
 title: "Draft"
 date: "2026-02-17"
+tags:
+  - "AI"
 draft: true
 ---
 Body`,
     });
 
-    const { getAllPosts, getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
-
-    expect(() => getAllPosts()).not.toThrow();
+    const { getRelatedPosts } = await loadBlogApiAtCwd(tempDir);
     expect(getRelatedPosts("published")).toEqual([]);
   });
 
-  test("includes draft related targets when includeDrafts is true", async () => {
+  test("includes draft candidates when includeDrafts is true", async () => {
     const tempDir = setupTempPosts({
       published: `---
 title: "Published"
 date: "2026-02-16"
-related:
-  - "draft-post"
+tags:
+  - "AI"
 ---
 Body`,
       "draft-post": `---
 title: "Draft"
 date: "2026-02-17"
+tags:
+  - "AI"
 draft: true
 ---
 Body`,

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -15,7 +15,6 @@ const POST_FIELDS = [
   "tags",
   "series",
   "seriesOrder",
-  "related",
   "readingTimeMinutes",
   "draft",
   "content",
@@ -37,7 +36,6 @@ export type Post = {
   tags: string[];
   series?: string;
   seriesOrder?: number;
-  related: string[];
   readingTimeMinutes?: number;
   draft: boolean;
   content: string;
@@ -89,10 +87,6 @@ const PostFrontMatterSchema = z
       .positive()
       .optional()
       .describe("Optional order index for posts within a series."),
-    related: z
-      .array(z.string().trim().min(1))
-      .default([])
-      .describe("Optional manual related-post slug overrides."),
     readingTimeMinutes: z
       .number()
       .int()
@@ -181,7 +175,6 @@ function parsePostBySlug(slug: string): Post | null {
     tags: frontMatter.tags,
     series: frontMatter.series,
     seriesOrder: frontMatter.seriesOrder,
-    related: frontMatter.related,
     readingTimeMinutes: frontMatter.readingTimeMinutes,
     draft: frontMatter.draft,
     content,
@@ -206,26 +199,6 @@ function assertUniqueSeriesOrder(posts: readonly Post[]) {
 
     existing.add(post.seriesOrder);
     seen.set(post.series, existing);
-  }
-}
-
-function assertRelatedSlugsExist(posts: readonly Post[]) {
-  const slugs = new Set(posts.map((post) => post.slug));
-
-  for (const post of posts) {
-    for (const relatedSlug of post.related) {
-      if (relatedSlug === post.slug) {
-        throw new Error(
-          `Invalid related slug in "${post.slug}": post cannot relate to itself`
-        );
-      }
-
-      if (!slugs.has(relatedSlug)) {
-        throw new Error(
-          `Invalid related slug in "${post.slug}": "${relatedSlug}" does not exist`
-        );
-      }
-    }
   }
 }
 
@@ -351,7 +324,6 @@ export function getAllPosts<T extends PostField>(
     .filter((post): post is Post => post !== null);
 
   assertUniqueSeriesOrder(allPosts);
-  assertRelatedSlugsExist(allPosts);
 
   const posts = allPosts
     .filter((post) => includeDrafts || !post.draft)
@@ -393,16 +365,6 @@ export function getRelatedPosts(
   }
 
   const candidates = allPosts.filter((post) => post.slug !== slug);
-
-  if (target.related.length > 0) {
-    const relatedBySlug = new Map(candidates.map((post) => [post.slug, post]));
-
-    return target.related
-      .map((relatedSlug) => relatedBySlug.get(relatedSlug))
-      .filter((post): post is Post => Boolean(post))
-      .slice(0, limit)
-      .map(toRelatedPost);
-  }
 
   const scored = candidates
     .map((candidate) => ({


### PR DESCRIPTION
### Motivation
- Remove the burden of maintaining manual `related` slug lists in front matter and avoid invalid references by inferring related posts from existing metadata. 
- Make related-post selection deterministic and simpler by relying on the existing relevance scoring (shared `tags`, same `series`, and recency). 

### Description
- Remove the `related` field from the front-matter schema and the `Post` type in `src/lib/blogApi.ts`. 
- Delete manual-related validation (`assertRelatedSlugsExist`) and the manual-override branch in `getRelatedPosts`, so candidates are always ranked by `getRelatedScore`. 
- Update tests in `src/lib/__tests__/blogApi.test.ts` to remove manual-override and related-existence assertions and to adjust draft-related behavior tests. 
- Clean up existing content by removing `related:` blocks from several files under `content/posts/` so front matter matches the new schema. 

### Testing
- Ran `corepack enable && corepack install` successfully to ensure the pinned Yarn is available. 
- Ran `yarn test src/lib/__tests__/blogApi.test.ts` and all tests passed (`15 passed, 15 total`). 
- Ran `yarn typecheck` with no type errors reported. 
- Ran `yarn lint` and formatting checks passed (`All matched files use Prettier code style!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5237803b88323b798e092f8469167)