### PR TITLE
Fix blog card heading hierarchy

### DIFF
--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -43,9 +43,9 @@ export function BlogPostCard({
           imageClassName="transition-transform duration-200 group-hover:scale-105"
         />
       </div>
-      <h3 className="mb-3 text-2xl font-bold leading-snug text-white transition-colors group-hover:text-accent-link">
+      <h2 className="mb-3 text-2xl font-bold leading-snug text-white transition-colors group-hover:text-accent-link">
         {post.title}
-      </h3>
+      </h2>
       <div className="mb-4 text-sm text-gray-300">
         {formatIsoDateForDisplay(post.date)}
       </div>


### PR DESCRIPTION
## Summary
- change blog post card titles from h3 to h2
- preserve visual styling while fixing heading level sequence for accessibility

## Testing
- yarn test src/components/__tests__/BlogPostCard.test.tsx
