### PR TITLE
docs: add Codespaces Lighthouse setup and troubleshooting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.pnp
 .pnp.js
 
+# Chrome-for-Testing downloads used by local LHCI in Codespaces
+.cache
+
 # testing
 /coverage
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,34 @@ Personal website and writing hub for Alex Leung. Built with Next.js 16, React 19
 
 > This project targets static export deployment, so there is no runtime Next.js production server command.
 
+## Codespaces: Lighthouse Setup
+
+In GitHub Codespaces, `yarn perf:lighthouse` may fail by default because:
+
+- no Chrome binary is preinstalled in the container
+- required shared libraries for headless Chrome are missing
+
+Use this one-time setup:
+
+```bash
+sudo apt-get install -y --no-install-recommends \
+  libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libxkbcommon0 \
+  libatspi2.0-0t64 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+  libgbm1 libasound2t64
+
+yarn dlx @puppeteer/browsers install chrome@stable --path ./.cache/puppeteer-browsers
+export CHROME_PATH="$(ls -1d .cache/puppeteer-browsers/chrome/linux-*/chrome-linux64/chrome | tail -n1)"
+```
+
+Then run:
+
+```bash
+yarn build
+yarn perf:lighthouse
+```
+
+If you want `CHROME_PATH` to persist across terminals in Codespaces, add the export line to `~/.bashrc`.
+
 ## Blog Cover Variant Automation
 
 - Variant generator script:
@@ -90,6 +118,7 @@ src/
 ## Documentation Map
 
 - `docs/README.md` — docs directory guide
+- `docs/codespaces.md` — Codespaces environment notes (including Lighthouse setup)
 - `docs/technical-architecture-audit.md` — current architecture status
 - `docs/seo-audit.md` — current SEO status and backlog
 - `docs/content-ideas.md` — content/page idea backlog

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This folder contains active repository-internal documentation used for planning 
 
 | File | Purpose | Update cadence |
 | --- | --- | --- |
+| `codespaces.md` | Local environment notes for GitHub Codespaces, including Lighthouse prerequisites | When dev environment prerequisites change |
 | `technical-architecture-audit.md` | Current architecture status and forward-looking technical recommendations | After major framework/content-pipeline changes |
 | `seo-audit.md` | Current SEO implementation status and optimization backlog | After metadata/schema/content-model changes |
 | `content-ideas.md` | Backlog of future site/page/content ideas | As ideas are added, promoted, or completed |

--- a/docs/codespaces.md
+++ b/docs/codespaces.md
@@ -1,0 +1,63 @@
+# Codespaces Notes
+
+Machine profile used for these notes:
+
+- GitHub Codespaces container on Ubuntu 24.04
+- Node.js `v24.11.1`
+- Corepack `0.34.2`
+- Yarn `4.12.0`
+
+## Lighthouse in Codespaces
+
+### Symptom
+
+`yarn perf:lighthouse` fails during LHCI healthcheck with:
+
+- `Chrome installation not found`
+
+After adding a Chrome binary, it can still fail with shared library errors such as:
+
+- `error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file`
+
+### Cause
+
+- Ubuntu Codespaces image does not include a Chrome/Chromium binary by default.
+- The container also does not include all desktop libraries required by headless Chrome.
+
+### One-time setup
+
+Install required runtime libraries:
+
+```bash
+sudo apt-get install -y --no-install-recommends \
+  libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libxkbcommon0 \
+  libatspi2.0-0t64 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+  libgbm1 libasound2t64
+```
+
+Install Chrome for Testing into workspace-local cache:
+
+```bash
+yarn dlx @puppeteer/browsers install chrome@stable --path ./.cache/puppeteer-browsers
+```
+
+Point Lighthouse CI to the installed binary:
+
+```bash
+export CHROME_PATH="$(ls -1d .cache/puppeteer-browsers/chrome/linux-*/chrome-linux64/chrome | tail -n1)"
+```
+
+Run performance checks:
+
+```bash
+yarn build
+yarn perf:lighthouse
+```
+
+### Optional: persist `CHROME_PATH`
+
+```bash
+echo 'export CHROME_PATH="$(ls -1d /workspaces/alexleung.ca/.cache/puppeteer-browsers/chrome/linux-*/chrome-linux64/chrome | tail -n1)"' >> ~/.bashrc
+```
+
+Open a new terminal (or `source ~/.bashrc`) afterward.


### PR DESCRIPTION
## Summary
- add a Codespaces-specific Lighthouse setup section to the root README
- add a dedicated `docs/codespaces.md` runbook for symptoms, root cause, and one-time setup
- index the new doc in `docs/README.md`
- document why `.cache` is ignored (Chrome-for-Testing download path)

## Testing
- not run (documentation-only changes)
