### PR TITLE
Organize .gitignore entries by category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,40 +5,41 @@
 /.pnp
 .pnp.js
 
-# Chrome-for-Testing downloads used by local LHCI in Codespaces
-.cache
-
-# testing
-/coverage
-
-# production
-/build
-/out
-
-# misc
-.DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
+# package manager logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# build output
+/build
+/out
+
 # next.js
 .next
 
+# testing and reports
+/coverage
+.lighthouseci
+
+# Chrome-for-Testing downloads used by local LHCI in Codespaces
+.cache
+
+# TypeScript
+tsconfig.tsbuildinfo
+
 # yarn berry
 /.yarn/*
-!/.yarn/releases
-!/.yarn/plugins
 !/.yarn/patches
+!/.yarn/plugins
+!/.yarn/releases
 !/.yarn/sdks
 !/.yarn/versions
 
-# lighthouse
-.lighthouseci
+# environment files
+.env.development.local
+.env.local
+.env.production.local
+.env.test.local
 
-# tsc
-tsconfig.tsbuildinfo
+# misc
+.DS_Store


### PR DESCRIPTION
### Motivation
- Improve readability and maintenance of `.gitignore` by grouping related patterns and standardizing ordering so future updates are easier and less error-prone.

### Description
- Reordered and grouped entries into sections: dependencies, package manager logs, build output, Next.js, testing/reports, cache, TypeScript, Yarn Berry allowlist, environment files, and misc, while preserving existing ignore semantics and sorting the Yarn allowlist entries.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a666ef5e408323a725609ab38cf8fa)