### PR TITLE
Fix /now accessibility + SEO Lighthouse failures

### DIFF
--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -65,7 +65,7 @@ export default function NowPage() {
         <ResponsiveContainer element="section">
           <SectionBlock spacing="lg">
             <div className="text-body space-y-8 text-left leading-relaxed">
-              <IconTextRow icon="🚀" title="Top of Mind">
+              <IconTextRow icon="🚀" title="Top of Mind" headingLevel="h2">
                 <p>
                   I recently launched the blog section of this site. It&apos;s
                   been fun to build a "boring" but effective static architecture
@@ -87,7 +87,11 @@ export default function NowPage() {
                 </p>
               </IconTextRow>
 
-              <IconTextRow icon="📚" title="Currently Reading">
+              <IconTextRow
+                icon="📚"
+                title="Currently Reading"
+                headingLevel="h2"
+              >
                 <p>
                   I&apos;m currently on Chapter 7 of{" "}
                   <ExternalLink href="https://www.deeplearningbook.org/">
@@ -103,7 +107,7 @@ export default function NowPage() {
                 </p>
               </IconTextRow>
 
-              <IconTextRow icon="🎯" title="Current Goals">
+              <IconTextRow icon="🎯" title="Current Goals" headingLevel="h2">
                 <ul className="list-outside list-disc space-y-1 pl-6">
                   <li>Finish and understand the Deep Learning book</li>
                   <li>Leveling up my tennis game</li>
@@ -119,8 +123,10 @@ export default function NowPage() {
                   now page
                 </ExternalLink>
                 . You can read more about the format{" "}
-                <ExternalLink href="https://sive.rs/nowff">here</ExternalLink>.
-                It&apos;s a snapshot of what I&apos;m focused on at this point
+                <ExternalLink href="https://sive.rs/nowff">
+                  in Derek Sivers&apos; now page explainer
+                </ExternalLink>
+                . It&apos;s a snapshot of what I&apos;m focused on at this point
                 in my life.
               </p>
             </ProseContent>

--- a/src/components/IconTextRow.tsx
+++ b/src/components/IconTextRow.tsx
@@ -6,6 +6,7 @@ type IconTextRowProps = {
   children: ReactNode;
   className?: string;
   contentClassName?: string;
+  headingLevel?: "h2" | "h3" | "h4";
 };
 
 export function IconTextRow({
@@ -14,14 +15,19 @@ export function IconTextRow({
   children,
   className,
   contentClassName,
+  headingLevel = "h3",
 }: IconTextRowProps) {
+  const HeadingTag = headingLevel;
+
   return (
     <div className={`flex items-start gap-3 ${className ?? ""}`.trim()}>
       <span aria-hidden="true" className="mt-1 flex-shrink-0 text-xl">
         {icon}
       </span>
       <div className={contentClassName}>
-        <h3 className="text-heading-sm mb-2 font-semibold">{title}</h3>
+        <HeadingTag className="text-heading-sm mb-2 font-semibold">
+          {title}
+        </HeadingTag>
         <div className="space-y-3 leading-relaxed">{children}</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fix heading hierarchy on `/now/` by rendering section titles as `h2` under the page `h1`
- make `IconTextRow` heading level configurable (`h2 | h3 | h4`) with default `h3`
- replace non-descriptive link text (`here`) with descriptive anchor text

## Why
Lighthouse flagged two failing audits on `/now/`:
- Accessibility: `heading-order`
- SEO: `link-text`

## Validation
- `yarn lint`
- `yarn build`
- `yarn lhci collect --config=.lighthouserc.json --url=http://localhost/now/ --numberOfRuns=1`
  - `/now/` scored 1.00 for both Accessibility and SEO in the generated LHR