### PR TITLE
Refine blog cover presentation and post tag placement

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -165,13 +165,6 @@ export default async function Post({ params }: Props) {
                 </time>
               )}
             </div>
-            {post.tags.length > 0 && (
-              <div className="mb-6 flex flex-wrap gap-2">
-                {post.tags.map((tag) => (
-                  <Tag key={`${post.slug}-${tag}`}>{tag}</Tag>
-                ))}
-              </div>
-            )}
             <CoverImage
               src={heroCoverImage || post.coverImage}
               srcSet={heroCoverSrcSet}
@@ -181,6 +174,15 @@ export default async function Post({ params }: Props) {
               className="mb-6 sm:mx-0 md:mb-10"
             />
             <ProseContent html={content} />
+            {post.tags.length > 0 && (
+              <section aria-label="Post tags" className="mt-8 pt-2">
+                <div className="flex flex-wrap gap-2">
+                  {post.tags.map((tag) => (
+                    <Tag key={`${post.slug}-${tag}`}>{tag}</Tag>
+                  ))}
+                </div>
+              </section>
+            )}
 
             {relatedPosts.length > 0 && (
               <section

--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -45,7 +45,7 @@ export function BlogPostCard({
           sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
           priority={coverPriority}
           className="mb-4"
-          imageClassName="transition-transform duration-200 group-hover:scale-105"
+          imageClassName="transition-opacity duration-200 group-hover:opacity-90"
         />
       </div>
       <h2 className="mb-3 text-2xl font-bold leading-snug text-white transition-colors group-hover:text-accent-link">

--- a/src/components/CoverImage.tsx
+++ b/src/components/CoverImage.tsx
@@ -25,13 +25,16 @@ export function CoverImage({
 }: CoverImageProps) {
   const wrapperClassName =
     variant === "card"
-      ? "h-48 w-full overflow-hidden rounded-lg bg-gray-800"
-      : "overflow-hidden rounded-lg";
+      ? "h-52 w-full overflow-hidden rounded-lg bg-gray-800"
+      : "overflow-hidden rounded-lg bg-gray-800";
+
+  const basePictureClassName =
+    variant === "card" ? "block h-full w-full" : "block w-full";
 
   const baseImageClassName =
     variant === "card"
-      ? "h-full w-full object-cover"
-      : "aspect-[21/9] w-full object-cover shadow-sm";
+      ? "h-full w-full object-contain object-center"
+      : "aspect-[2/1] w-full object-contain object-center shadow-sm";
 
   if (!src) {
     return (
@@ -52,6 +55,7 @@ export function CoverImage({
         width={1200}
         height={630}
         sizes={sizes}
+        pictureClassName={basePictureClassName}
         priority={priority}
         loading={priority ? "eager" : "lazy"}
         fetchPriority={priority ? "high" : "auto"}


### PR DESCRIPTION
## Summary
- switch blog card and post hero covers to contain-mode rendering so full cover images are visible
- make cover frames taller (`h-52` cards, `aspect-[2/1]` hero) for better visual balance
- move post tags to the bottom of article content and simplify that block (no visible heading/divider)
- replace card image zoom hover with subtle opacity hover to avoid perceived re-cropping

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
