### PR TITLE
fix(blog): render inline code formatting in excerpts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { notFound } from "next/navigation";
 import { Article, BlogPosting } from "schema-dts";
 
 import { CoverImage } from "@/components/CoverImage";
+import { ExcerptText } from "@/components/ExcerptText";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ProseContent } from "@/components/ProseContent";
@@ -214,7 +215,7 @@ export default async function Post({ params }: Props) {
                         </p>
                         {relatedPost.excerpt ? (
                           <p className="mt-2 line-clamp-3 text-sm text-gray-200">
-                            {relatedPost.excerpt}
+                            <ExcerptText text={relatedPost.excerpt} />
                           </p>
                         ) : null}
                       </Surface>

--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { CoverImage } from "@/components/CoverImage";
+import { ExcerptText } from "@/components/ExcerptText";
 import { surfaceClassNames } from "@/components/Surface";
 import { Tag } from "@/components/Tag";
 import { Post } from "@/lib/blogApi";
@@ -56,7 +57,7 @@ export function BlogPostCard({
       </div>
       {post.excerpt ? (
         <p className="mb-4 text-base leading-relaxed text-gray-200 md:text-gray-300">
-          {post.excerpt}
+          <ExcerptText text={post.excerpt} />
         </p>
       ) : null}
       {post.tags.length > 0 && (

--- a/src/components/ExcerptText.tsx
+++ b/src/components/ExcerptText.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+
+const inlineCodePattern = /`([^`\n]+)`/g;
+
+type ExcerptTextProps = {
+  text: string;
+};
+
+export function ExcerptText({ text }: ExcerptTextProps) {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let match = inlineCodePattern.exec(text);
+
+  while (match) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+
+    nodes.push(
+      <code
+        key={`excerpt-code-${match.index}`}
+        className="rounded bg-white/10 px-1 py-0.5 font-mono text-[0.92em] text-gray-100"
+      >
+        {match[1]}
+      </code>
+    );
+
+    lastIndex = match.index + match[0].length;
+    match = inlineCodePattern.exec(text);
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return <>{nodes.length > 0 ? nodes : text}</>;
+}

--- a/src/components/__tests__/BlogPostCard.test.tsx
+++ b/src/components/__tests__/BlogPostCard.test.tsx
@@ -25,4 +25,23 @@ describe("BlogPostCard", () => {
     expect(screen.getByText("January 1, 2026")).toBeInTheDocument();
     expect(screen.getByText("ai")).toBeInTheDocument();
   });
+
+  it("formats inline code spans in excerpt text", () => {
+    render(
+      <BlogPostCard
+        post={{
+          slug: "inline-code-post",
+          title: "Inline Code Post",
+          date: "2026-01-01T00:00:00.000Z",
+          coverImage: undefined,
+          excerpt: "Use `srcSet` variants to improve performance.",
+          tags: [],
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText("srcSet", { selector: "code" })
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add ExcerptText to render inline backtick spans as styled code in excerpt text
- use the renderer for /blog cards and related post excerpts on blog detail pages
- add test coverage to verify code-span rendering in BlogPostCard

## Validation
- yarn lint
- yarn test
- yarn typecheck
