### PR TITLE
fix(about): normalize typography and section spacing

### DIFF
--- a/src/app/about/_components/MyBackground.tsx
+++ b/src/app/about/_components/MyBackground.tsx
@@ -16,7 +16,7 @@ export function Journey() {
     <ResponsiveContainer element="section">
       <SectionBlock title="My Background" titleId="background" spacing="lg">
         <div className="md:grid md:grid-cols-[3fr_2fr] md:gap-x-16 md:pt-8">
-          <div className="text-md mb-8 space-y-6 text-left lg:text-lg">
+          <div className="text-body mb-8 space-y-6 text-left">
             <IconTextRow icon="👋" title="Hello" contentClassName="space-y-0">
               <p>Hi! I&apos;m Alex, and I&apos;m glad you&apos;re here.</p>
             </IconTextRow>

--- a/src/app/about/_components/TechnicalInterests.tsx
+++ b/src/app/about/_components/TechnicalInterests.tsx
@@ -2,11 +2,11 @@ import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { SectionBlock } from "@/components/SectionBlock";
 import { skills } from "@/constants/skills";
 
-export function Skills({ className }: { className?: string }) {
+export function Skills() {
   return (
     <ResponsiveContainer element="section">
       <SectionBlock title="Technical Interests" titleId="technicalinterests">
-        <div className={`text-md flex flex-col lg:text-lg ${className}`}>
+        <div className="text-body flex flex-col">
           Here are a few technical areas that I enjoy working in:
           <ul className="mt-4 grid grid-cols-1 gap-x-4 lg:grid-cols-4">
             {skills.map(({ skill }) => (

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -49,9 +49,11 @@ export default function AboutPage() {
       />
 
       <PageShell title="About Me" titleId="about">
-        <Journey />
-        <Skills className="mt-12" />
-        <Credentials />
+        <div className="space-y-12 md:space-y-14">
+          <Journey />
+          <Skills />
+          <Credentials />
+        </div>
       </PageShell>
     </>
   );


### PR DESCRIPTION
## Summary
- switch About body text wrappers to shared `text-body` token for desktop consistency with Now/blog
- move About section rhythm to page-level stack spacing (`space-y-12 md:space-y-14`)
- remove per-section spacing prop plumbing from `Skills`

## Testing
- yarn typecheck