### PR TITLE
Use alex_vibing for social metadata and align manifest screenshot size

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -116,7 +116,7 @@
   "screenshots": [
     {
       "src": "assets/screenshot.png",
-      "sizes": "1200x630",
+      "sizes": "3440x1732",
       "type": "image/png",
       "form_factor": "wide",
       "label": "Alex Leung - Professional Portfolio"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,12 +49,6 @@ export const metadata: Metadata = {
     locale: "en_CA",
     images: [
       {
-        url: "/assets/screenshot.png",
-        width: 1200,
-        height: 630,
-        alt: title,
-      },
-      {
         url: "/assets/alex_vibing.webp",
         width: 1536,
         height: 1024,
@@ -69,10 +63,6 @@ export const metadata: Metadata = {
     images: [
       {
         url: "/assets/alex_vibing.webp",
-        alt: title,
-      },
-      {
-        url: "/assets/screenshot.png",
         alt: title,
       },
     ],


### PR DESCRIPTION
## Summary
- remove `screenshot.png` from site-level Open Graph and Twitter metadata in `src/app/layout.tsx`
- keep `alex_vibing.webp` as the sole social preview image
- update PWA manifest screenshot dimensions to match the provided `public/assets/screenshot.png` (`3440x1732`)
- include the updated `public/assets/screenshot.png`

## Notes
- no source code behavior changes beyond metadata/asset updates