### PR TITLE
fix(now): keep now-page footer prose size consistent

### DIFF
--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -116,7 +116,7 @@ export default function NowPage() {
               </IconTextRow>
             </div>
 
-            <ProseContent className="border-t border-gray-700 pt-8 text-sm">
+            <ProseContent className="prose-sm border-t border-gray-700 pt-8 md:prose-sm">
               <p>
                 This is a{" "}
                 <ExternalLink href="https://nownownow.com/about">


### PR DESCRIPTION
## Summary
- keep the now-page footer note typography small at all breakpoints
- replace `text-sm` with `prose-sm md:prose-sm` on the footer `ProseContent` block

## Verification
- yarn lint