### PR TITLE
refactor(typography): make prose sizing explicit

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -174,7 +174,7 @@ export default async function Post({ params }: Props) {
               sizes="(min-width: 1024px) 896px, 100vw"
               className="mb-6 sm:mx-0 md:mb-10"
             />
-            <ProseContent html={content} />
+            <ProseContent html={content} size="lg" />
             {post.tags.length > 0 && (
               <section aria-label="Post tags" className="mt-8 pt-2">
                 <div className="flex flex-wrap gap-2">

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -116,7 +116,7 @@ export default function NowPage() {
               </IconTextRow>
             </div>
 
-            <ProseContent className="prose-sm border-t border-gray-700 pt-8 md:prose-sm">
+            <ProseContent size="sm" className="border-t border-gray-700 pt-8">
               <p>
                 This is a{" "}
                 <ExternalLink href="https://nownownow.com/about">

--- a/src/components/ProseContent.tsx
+++ b/src/components/ProseContent.tsx
@@ -1,29 +1,40 @@
 import { ReactNode } from "react";
 
+type ProseSize = "sm" | "base" | "lg";
+
 type ProseContentProps = {
   className?: string;
   children?: ReactNode;
   html?: string;
+  size?: ProseSize;
 };
 
-const proseClasses =
-  "prose prose-invert max-w-none prose-headings:text-white prose-p:text-gray-300 prose-a:text-accent-link prose-a:no-underline hover:prose-a:text-accent-link-hover hover:prose-a:underline prose-strong:text-white prose-pre:border prose-pre:border-white/10 prose-pre:bg-black/50 md:prose-lg";
+const proseBaseClasses =
+  "prose prose-invert max-w-none prose-headings:text-white prose-p:text-gray-300 prose-a:text-accent-link prose-a:no-underline hover:prose-a:text-accent-link-hover hover:prose-a:underline prose-strong:text-white prose-pre:border prose-pre:border-white/10 prose-pre:bg-black/50";
+
+const proseSizeClasses: Record<ProseSize, string> = {
+  sm: "prose-sm md:prose-sm",
+  base: "",
+  lg: "md:prose-lg",
+};
 
 export function ProseContent({
   className = "",
   children,
   html,
+  size = "base",
 }: ProseContentProps) {
+  const proseClasses =
+    `${proseBaseClasses} ${proseSizeClasses[size]} ${className}`.trim();
+
   if (html) {
     return (
       <div
-        className={`${proseClasses} ${className}`.trim()}
+        className={proseClasses}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     );
   }
 
-  return (
-    <div className={`${proseClasses} ${className}`.trim()}>{children}</div>
-  );
+  return <div className={proseClasses}>{children}</div>;
 }

--- a/src/components/__tests__/ProseContent.test.tsx
+++ b/src/components/__tests__/ProseContent.test.tsx
@@ -18,4 +18,40 @@ describe("ProseContent", () => {
 
     expect(screen.getByText("Rendered HTML")).toBeInTheDocument();
   });
+
+  it("uses base prose sizing by default", () => {
+    render(
+      <ProseContent>
+        <p>Default size</p>
+      </ProseContent>
+    );
+
+    const wrapper = screen.getByText("Default size").closest("div");
+    expect(wrapper).toHaveClass("prose");
+    expect(wrapper).not.toHaveClass("md:prose-lg");
+    expect(wrapper).not.toHaveClass("prose-sm");
+  });
+
+  it("applies small prose sizing when size is sm", () => {
+    render(
+      <ProseContent size="sm">
+        <p>Small size</p>
+      </ProseContent>
+    );
+
+    const wrapper = screen.getByText("Small size").closest("div");
+    expect(wrapper).toHaveClass("prose-sm");
+    expect(wrapper).toHaveClass("md:prose-sm");
+  });
+
+  it("applies large prose sizing when size is lg", () => {
+    render(
+      <ProseContent size="lg">
+        <p>Large size</p>
+      </ProseContent>
+    );
+
+    const wrapper = screen.getByText("Large size").closest("div");
+    expect(wrapper).toHaveClass("md:prose-lg");
+  });
 });


### PR DESCRIPTION
## Summary
- add a typed `size` prop to `ProseContent` (`sm | base | lg`) so prose scale is explicit at call sites
- remove implicit `md:prose-lg` from the default prose class bundle
- set blog post body content to `size="lg"` to preserve intended long-form reading scale
- set the now-page footer note to `size="sm"` to keep fine print consistently small
- extend `ProseContent` tests to lock default/sm/lg class behavior

## Verification
- yarn lint
- yarn test src/components/__tests__/ProseContent.test.tsx
- yarn typecheck
