### PR TITLE
Update PEO credential subtitle to "Since 2017"

### DIFF
--- a/src/app/about/_components/Credentials.tsx
+++ b/src/app/about/_components/Credentials.tsx
@@ -23,7 +23,7 @@ export function Credentials() {
               <p className="text-lg font-medium text-white">
                 Professional Engineer (P.Eng.)
               </p>
-              <p className="text-gray-300">Licensed in Ontario</p>
+              <p className="text-gray-300">Since 2017</p>
             </div>
             <div>
               <p className="text-sm text-gray-300">


### PR DESCRIPTION
### Motivation
- Make the PEO credential wording consistent with other credential blocks by showing the date of the credential rather than the organization’s jurisdiction.

### Description
- Replace the subtitle text in `src/app/about/_components/Credentials.tsx` from "Licensed in Ontario" to "Since 2017".

### Testing
- Ran `yarn lint` and `yarn test --runInBand`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82ed76c5c8323bbb36c2ef0eac2f3)