### PR TITLE
Normalize blog tags for existing posts

### DIFF
--- a/content/posts/deep-learning-part-1-review.md
+++ b/content/posts/deep-learning-part-1-review.md
@@ -7,6 +7,7 @@ coverImage: "/assets/blog/deep-learning-part-1-review/cover.webp"
 tags:
   - "Deep Learning"
   - "Book Notes"
+  - "Review"
 ---
 
 I recently finished Part I of _Deep Learning_ by Goodfellow, Bengio, and Courville. It was a clear and efficient primer on the mathematical preliminaries needed to engage more deeply with the subject. I appreciated the refresher in linear algebra, probability, and numerical computation, which helped reestablish important foundations. In places, I found myself wishing for more proofs—or at least proof sketches—as I often wanted to understand where results came from rather than accept them at face value.

--- a/content/posts/from-coder-to-orchestrator.md
+++ b/content/posts/from-coder-to-orchestrator.md
@@ -5,8 +5,9 @@ updated: "2026-02-14"
 excerpt: "How my AI workflow changed from quick snippets to a practical plan/implement/verify loop."
 coverImage: "/assets/blog/from-coder-to-orchestrator/cover.webp"
 tags:
-  - "AI Engineering"
+  - "AI"
   - "Developer Workflow"
+  - "Future of Work"
 
 ---
 

--- a/content/posts/structural-reasoning-about-deep-networks.md
+++ b/content/posts/structural-reasoning-about-deep-networks.md
@@ -6,8 +6,8 @@ excerpt: "Chapter 6 sharpened how I think about architecture as a structural ass
 coverImage: "/assets/blog/structural-reasoning-about-deep-networks/cover.webp"
 tags:
   - "Deep Learning"
-  - "Neural Networks"
   - "ML Theory"
+  - "Book Notes"
 
 ---
 


### PR DESCRIPTION
## Summary
- add Review to deep-learning-part-1-review for clearer content type labeling
- replace AI Engineering with AI in from-coder-to-orchestrator for better taxonomy reuse
- add Future of Work to from-coder-to-orchestrator to match the post thesis
- replace Neural Networks with Book Notes in structural-reasoning-about-deep-networks for stronger format consistency

## Testing
- not run (frontmatter tag updates only)