### PR TITLE
Use CSS background layer to avoid crawlable background image

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,25 @@
 }
 
 @layer components {
+  .app-background-image {
+    background-image: url("/assets/background-mobile.webp");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+  }
+
+  @media (min-width: 768px) {
+    .app-background-image {
+      background-image: url("/assets/background-tablet.webp");
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .app-background-image {
+      background-image: url("/assets/background-desktop.webp");
+    }
+  }
+
   .section-center {
     @apply max-w-content mx-auto w-[90vw];
   }

--- a/src/components/AppBackground.tsx
+++ b/src/components/AppBackground.tsx
@@ -1,31 +1,10 @@
-import { ResponsiveImage } from "@/components/ResponsiveImage";
-import {
-  getStaticImageFallback,
-  getStaticImageSourceSet,
-} from "@/lib/localImageMetadata";
-
 export function AppBackground() {
-  const backgroundSrcSet = getStaticImageSourceSet("background");
-  const backgroundFallback = getStaticImageFallback("background");
-
   return (
     <div
       aria-hidden="true"
       className="fixed inset-0 -z-10 h-screen overflow-hidden"
     >
-      <ResponsiveImage
-        src={backgroundFallback.path}
-        srcSet={backgroundSrcSet}
-        alt=""
-        width={backgroundFallback.width}
-        height={backgroundFallback.height}
-        sizes="100vw"
-        loading="lazy"
-        fetchPriority="low"
-        decoding="async"
-        pictureClassName="absolute inset-0 block h-full w-full"
-        className="h-full w-full object-cover object-center"
-      />
+      <div className="app-background-image absolute inset-0" />
       <div className="absolute inset-0 bg-slate-700/50" />
     </div>
   );

--- a/src/components/__tests__/AppBackground.test.tsx
+++ b/src/components/__tests__/AppBackground.test.tsx
@@ -3,14 +3,12 @@ import { render } from "@testing-library/react";
 import { AppBackground } from "../AppBackground";
 
 describe("AppBackground", () => {
-  it("renders responsive background sources and overlay treatment", () => {
+  it("renders CSS background container and overlay treatment", () => {
     const { container } = render(<AppBackground />);
 
     expect(container.firstChild).toHaveClass("fixed");
-    expect(container.querySelector("source")).toHaveAttribute(
-      "srcset",
-      "/assets/background-mobile.webp 768w, /assets/background-tablet.webp 1280w, /assets/background-desktop.webp 1600w"
-    );
-    expect(container.querySelector("img")).toHaveAttribute("sizes", "100vw");
+    expect(container.querySelector(".app-background-image")).toBeInTheDocument();
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+    expect(container.querySelector("source")).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/AppBackground.test.tsx
+++ b/src/components/__tests__/AppBackground.test.tsx
@@ -7,7 +7,9 @@ describe("AppBackground", () => {
     const { container } = render(<AppBackground />);
 
     expect(container.firstChild).toHaveClass("fixed");
-    expect(container.querySelector(".app-background-image")).toBeInTheDocument();
+    expect(
+      container.querySelector(".app-background-image")
+    ).toBeInTheDocument();
     expect(container.querySelector("img")).not.toBeInTheDocument();
     expect(container.querySelector("source")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- replace AppBackground image/picture markup with a CSS background layer
- keep responsive mobile/tablet/desktop background variants through media queries
- update AppBackground test to assert no img/source nodes are rendered

## Why
Google was selecting the crawlable background image for snippets even though OG metadata points to alex_vibing.webp.

## Validation
- yarn test src/components/__tests__/AppBackground.test.tsx
- yarn build
