### PR TITLE
Run Lighthouse CI for both mobile and desktop presets

### DIFF
--- a/.lighthouserc.desktop.json
+++ b/.lighthouserc.desktop.json
@@ -12,7 +12,8 @@
         "http://localhost/blog/from-coder-to-orchestrator/"
       ],
       "settings": {
-        "chromeFlags": "--headless=new --no-sandbox --disable-dev-shm-usage"
+        "chromeFlags": "--headless=new --no-sandbox --disable-dev-shm-usage",
+        "preset": "desktop"
       }
     },
     "assert": {

--- a/.lighthouserc.mobile.json
+++ b/.lighthouserc.mobile.json
@@ -1,0 +1,52 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3,
+      "staticDistDir": "./out",
+      "url": [
+        "http://localhost/",
+        "http://localhost/blog/",
+        "http://localhost/about/",
+        "http://localhost/now/",
+        "http://localhost/contact/",
+        "http://localhost/blog/from-coder-to-orchestrator/"
+      ],
+      "settings": {
+        "chromeFlags": "--headless=new --no-sandbox --disable-dev-shm-usage",
+        "preset": "mobile"
+      }
+    },
+    "assert": {
+      "aggregationMethod": "median",
+      "assertions": {
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.8
+          }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:best-practices": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:seo": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "perf:lighthouse": "lhci autorun --config=.lighthouserc.json",
+    "perf:lighthouse": "yarn perf:lighthouse:mobile && yarn perf:lighthouse:desktop",
     "lint": "eslint . && prettier --check '{src,app,components}/**/*.{js,jsx,ts,tsx,css,md,json,yml}'",
     "lint:fix": "eslint --fix . && prettier --write '{src,app,components}/**/*.{js,jsx,ts,tsx,css,md,json,yml}'",
     "predeploy": "yarn build",
-    "deploy": "gh-pages -d out"
+    "deploy": "gh-pages -d out",
+    "perf:lighthouse:mobile": "lhci autorun --config=.lighthouserc.mobile.json",
+    "perf:lighthouse:desktop": "lhci autorun --config=.lighthouserc.desktop.json"
   },
   "dependencies": {
     "date-fns": "^4.1.0",


### PR DESCRIPTION
### Motivation
- Ensure Lighthouse CI runs using both mobile and desktop presets instead of a single, unspecified preset to catch device-specific regressions.

### Description
- Updated `scripts.perf:lighthouse` in `package.json` to run `yarn perf:lighthouse:mobile && yarn perf:lighthouse:desktop` so both presets run sequentially.
- Added `perf:lighthouse:mobile` and `perf:lighthouse:desktop` scripts that call `lhci autorun` with `.lighthouserc.mobile.json` and `.lighthouserc.desktop.json` respectively.
- Renamed the original `.lighthouserc.json` to `.lighthouserc.mobile.json` and created a new `.lighthouserc.desktop.json` file, and set `collect.settings.preset` to `mobile` and `desktop` in the respective configs.

### Testing
- Ran `corepack enable && corepack install` successfully to ensure the pinned Yarn is available.
- Ran `yarn build` successfully to validate the static export builds without issues.
- Ran `yarn perf:lighthouse` which attempted both LHCI runs; LHCI configuration loading succeeded but the run failed due to `Chrome installation not found` in this environment (healthcheck failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa4ffe8e6883238efaf5f155d49f12)