### PR TITLE
perf: cache parsed blog posts in blogApi

### DIFF
--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -148,6 +148,33 @@ describe("blogApi front matter validation", () => {
 
     expect(() => getAllPosts()).toThrow(/Duplicate seriesOrder/);
   });
+
+  test("reuses cached post parsing between repeated API calls", async () => {
+    const tempDir = setupTempPosts({
+      first: `---
+title: "First"
+date: "2026-02-16"
+---
+Body`,
+      second: `---
+title: "Second"
+date: "2026-02-15"
+---
+Body`,
+    });
+
+    const readFileSpy = jest.spyOn(fs, "readFileSync");
+    const { getAllPosts, getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+
+    getAllPosts();
+    getAllPosts(["slug"]);
+    getPostBySlug("first");
+    getPostBySlug("second", ["slug"]);
+
+    expect(readFileSpy).toHaveBeenCalledTimes(2);
+
+    readFileSpy.mockRestore();
+  });
 });
 
 describe("getRelatedPosts", () => {

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -4,6 +4,9 @@ import { join } from "path";
 import { z } from "zod";
 
 const postsDirectory = join(process.cwd(), "content/posts");
+const postBySlugCache = new Map<string, Post | null>();
+
+let allPostsCache: Post[] | null = null;
 
 const POST_FIELDS = [
   "slug",
@@ -181,6 +184,40 @@ function parsePostBySlug(slug: string): Post | null {
   };
 }
 
+function getCachedPostBySlug(slug: string): Post | null {
+  const realSlug = slug.replace(/\.md$/, "");
+
+  if (postBySlugCache.has(realSlug)) {
+    return postBySlugCache.get(realSlug) ?? null;
+  }
+
+  const post = parsePostBySlug(realSlug);
+
+  postBySlugCache.set(realSlug, post);
+
+  return post;
+}
+
+function getCachedAllPosts(): Post[] {
+  if (allPostsCache) {
+    return allPostsCache;
+  }
+
+  const posts = getPostSlugs()
+    .map((slug) => getCachedPostBySlug(slug))
+    .filter((post): post is Post => post !== null)
+    .sort(
+      (post1, post2) =>
+        new Date(post2.date).getTime() - new Date(post1.date).getTime()
+    );
+
+  assertUniqueSeriesOrder(posts);
+
+  allPostsCache = posts;
+
+  return allPostsCache;
+}
+
 function assertUniqueSeriesOrder(posts: readonly Post[]) {
   const seen = new Map<string, Set<number>>();
 
@@ -275,7 +312,7 @@ export function getPostBySlug<T extends PostField>(
   fieldsOrOptions?: readonly T[] | PostQueryOptions,
   maybeOptions?: PostQueryOptions
 ) {
-  const post = parsePostBySlug(slug);
+  const post = getCachedPostBySlug(slug);
   const fields = isPostFieldSelection(fieldsOrOptions)
     ? (fieldsOrOptions as readonly T[])
     : undefined;
@@ -319,18 +356,9 @@ export function getAllPosts<T extends PostField>(
     : fieldsOrOptions;
 
   const includeDrafts = options?.includeDrafts ?? false;
-  const allPosts = getPostSlugs()
-    .map((slug) => parsePostBySlug(slug))
-    .filter((post): post is Post => post !== null);
-
-  assertUniqueSeriesOrder(allPosts);
-
-  const posts = allPosts
-    .filter((post) => includeDrafts || !post.draft)
-    .sort(
-      (post1, post2) =>
-        new Date(post2.date).getTime() - new Date(post1.date).getTime()
-    );
+  const posts = getCachedAllPosts().filter(
+    (post) => includeDrafts || !post.draft
+  );
 
   if (!fields || fields.length === 0) {
     return posts;


### PR DESCRIPTION
### Motivation
- Reduce redundant filesystem reads and front-matter parsing when `getPostBySlug` and `getAllPosts` are called multiple times during a single runtime.

### Description
- Add an in-memory per-slug cache `postBySlugCache` and an aggregated sorted cache `allPostsCache` in `src/lib/blogApi.ts` and route `getPostBySlug` / `getAllPosts` through `getCachedPostBySlug` / `getCachedAllPosts`.
- Preserve existing validation and behavior including strict front-matter parsing, date validation, `seriesOrder` uniqueness, draft filtering, and field projection.
- Add a regression test in `src/lib/__tests__/blogApi.test.ts` that asserts repeated API calls only read markdown files once per slug.

### Testing
- Ran `yarn test src/lib/__tests__/blogApi.test.ts` and the suite passed (all tests green).
- Ran `yarn lint` which initially flagged formatting, then `yarn lint:fix` was applied and `yarn lint` completed with no issues.
- The updated tests assert both correctness and the caching optimization (the new test verifies filesystem reads are minimized).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa63c11a708323849f6f7b956d5e99)