### PR TITLE
Fix sitemap blog URLs to use canonical trailing slashes

### DIFF
--- a/src/app/__tests__/sitemap.test.ts
+++ b/src/app/__tests__/sitemap.test.ts
@@ -1,0 +1,26 @@
+import sitemap from "@/app/sitemap";
+
+jest.mock("@/app/now/page", () => ({
+  NOW_PAGE_LAST_UPDATED_ISO: "2026-01-15",
+}));
+
+jest.mock("@/lib/blogApi", () => ({
+  getAllPosts: jest.fn(() => [
+    {
+      slug: "my-post",
+      date: "2026-01-10T00:00:00.000Z",
+      updated: "2026-01-20T00:00:00.000Z",
+    },
+  ]),
+}));
+
+describe("sitemap", () => {
+  it("emits canonical trailing-slash blog post URLs", () => {
+    const entries = sitemap();
+    const blogPostEntry = entries.find(
+      (entry) => entry.url === "https://alexleung.ca/blog/my-post/"
+    );
+
+    expect(blogPostEntry).toBeDefined();
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import { MetadataRoute } from "next";
 
 import { NOW_PAGE_LAST_UPDATED_ISO } from "@/app/now/page";
 import { getAllPosts } from "@/lib/blogApi";
+import { toCanonical } from "@/lib/seo/url";
 
 export const dynamic = "force-static";
 
@@ -16,7 +17,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPosts(["slug", "date", "updated"]);
 
   const blogPosts = posts.map((post) => ({
-    url: `https://alexleung.ca/blog/${post.slug}`,
+    url: toCanonical(`/blog/${post.slug}`),
     lastModified: new Date(
       post.updated || post.date || PAGE_LAST_MODIFIED.home
     ),


### PR DESCRIPTION
### Motivation
- Ensure sitemap emits canonical trailing-slash blog post URLs to match the site's static-export routing (`trailingSlash: true`) and avoid inconsistent/mismatched URLs.

### Description
- Use `toCanonical(`/blog/${post.slug}`)` when generating blog post `url` entries in `src/app/sitemap.ts` and import `toCanonical` from `@/lib/seo/url`.
- Add `src/app/__tests__/sitemap.test.ts` which mocks blog data and asserts sitemap includes the canonical trailing-slash blog post URL.

### Testing
- Ran `yarn test src/app/__tests__/sitemap.test.ts` and the new test passed.
- Ran the full test suite with `yarn test` and all test suites passed (`28` suites, all green).
- Ran `yarn lint` (formatting/lint checks) and `yarn typecheck`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa63e217c483238f87b0010502704b)