### PR TITLE
Improve mobile menu keyboard dismissal and focus behavior

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FaBars, FaTimes } from "react-icons/fa";
 
 import Link from "next/link";
@@ -11,6 +11,7 @@ import { DesktopNav, MobileNavDrawer } from "@/components/NavMenu";
 export default function Header() {
   const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   // Prevent body scroll when menu is open
   useEffect(() => {
@@ -30,6 +31,14 @@ export default function Header() {
       return;
     }
 
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+
     const mediaQuery = window.matchMedia("(min-width: 768px)");
     const handleResize = () => {
       if (mediaQuery.matches && isMenuOpen) {
@@ -37,7 +46,17 @@ export default function Header() {
       }
     };
     mediaQuery.addEventListener("change", handleResize);
-    return () => mediaQuery.removeEventListener("change", handleResize);
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      mediaQuery.removeEventListener("change", handleResize);
+    };
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      menuButtonRef.current?.focus();
+    }
   }, [isMenuOpen]);
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
@@ -70,10 +89,12 @@ export default function Header() {
 
           {/* Mobile Menu Button */}
           <button
+            ref={menuButtonRef}
             onClick={toggleMenu}
             className="relative z-50 text-2xl transition-all duration-300 hover:text-gray-300 md:hidden"
-            aria-label="Toggle menu"
+            aria-label={isMenuOpen ? "Close menu" : "Open menu"}
             aria-expanded={isMenuOpen}
+            aria-controls="mobile-nav-drawer"
           >
             <span
               className={`block transition-transform duration-300 ${

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -82,6 +82,7 @@ export function MobileNavDrawer({
       />
 
       <div
+        id="mobile-nav-drawer"
         className={`fixed left-0 right-0 top-[var(--header-height)] z-40 border-b border-white/10 bg-black/95 backdrop-blur-md transition-all duration-300 md:hidden ${
           isOpen
             ? "translate-y-0 opacity-100"

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -30,20 +30,23 @@ describe("Header", () => {
   describe("Mobile Menu", () => {
     it("should toggle menu visibility via aria-expanded", () => {
       render(<Header />);
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
 
       expect(button).toHaveAttribute("aria-expanded", "false");
+      expect(button).toHaveAttribute("aria-controls", "mobile-nav-drawer");
 
       fireEvent.click(button);
       expect(button).toHaveAttribute("aria-expanded", "true");
+      expect(button).toHaveAccessibleName("Close menu");
 
       fireEvent.click(button);
       expect(button).toHaveAttribute("aria-expanded", "false");
+      expect(button).toHaveAccessibleName("Open menu");
     });
 
     it("should mount and unmount mobile menu when toggled", () => {
       const { container } = render(<Header />);
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
 
       expect(
         container.querySelector(".mobile-nav-link")
@@ -63,7 +66,7 @@ describe("Header", () => {
 
     it("should close menu when backdrop is clicked", () => {
       const { container } = render(<Header />);
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
 
       fireEvent.click(button);
       const backdrop = container.querySelector(".fixed.inset-0");
@@ -74,7 +77,7 @@ describe("Header", () => {
 
     it("should close menu when navigation link is clicked", () => {
       render(<Header />);
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
 
       fireEvent.click(button);
       const mobileLink = screen.getAllByText("Home")[1];
@@ -116,7 +119,7 @@ describe("Header", () => {
       (usePathname as jest.Mock).mockReturnValue("/about/");
       render(<Header />);
 
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
       fireEvent.click(button);
 
       const aboutLinks = screen.getAllByText("About");
@@ -132,12 +135,14 @@ describe("Header", () => {
   describe("Accessibility", () => {
     it("should have proper aria-label on menu button", () => {
       render(<Header />);
-      expect(screen.getByLabelText("Toggle menu")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Open menu" })
+      ).toBeInTheDocument();
     });
 
     it("should have aria-expanded attribute on menu button", () => {
       render(<Header />);
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
       expect(button).toHaveAttribute("aria-expanded", "false");
     });
 
@@ -148,12 +153,33 @@ describe("Header", () => {
 
     it("should set tabIndex=0 on mobile links when menu is open", () => {
       render(<Header />);
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
 
       fireEvent.click(button);
 
       const mobileLink = screen.getAllByText("Home")[1];
       expect(mobileLink).toHaveAttribute("tabindex", "0");
+    });
+
+    it("should close the mobile menu when Escape is pressed", () => {
+      render(<Header />);
+      const button = screen.getByRole("button", { name: "Open menu" });
+
+      fireEvent.click(button);
+      expect(button).toHaveAttribute("aria-expanded", "true");
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("should return focus to the menu button when the menu closes", () => {
+      render(<Header />);
+      const button = screen.getByRole("button", { name: "Open menu" });
+
+      fireEvent.click(button);
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(button).toHaveFocus();
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Keyboard and screen-reader users could not dismiss the mobile navigation with the `Escape` key and focus was not restored to the menu trigger after closing, creating an accessibility and UX gap. 

### Description
- Added a button ref and focus-return behavior in `src/components/Header.tsx` so the menu trigger regains focus when the drawer closes. 
- Implemented an `Escape` key listener that closes the mobile drawer and is cleaned up on unmount in `src/components/Header.tsx`. 
- Improved trigger semantics by using dynamic accessible names (`"Open menu"` / `"Close menu"`) and added `aria-controls="mobile-nav-drawer"` to link the button to the drawer. 
- Added `id="mobile-nav-drawer"` to the drawer element in `src/components/NavMenu.tsx` and expanded `src/components/__tests__/Header.test.tsx` to cover `Escape` behavior, focus return, accessible naming, and `aria-controls`.

### Testing
- Ran the header unit tests with `yarn test src/components/__tests__/Header.test.tsx`, and the suite passed (`15 passed`).
- Ran formatting/lint checks with `yarn lint`, which reported success (Prettier formatting matched).
- All updated tests passed locally and no lint issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa640b6dac8323aadb1714ddfc88a8)