### PR TITLE
Close mobile menu on pathname changes

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,6 +40,11 @@ export default function Header() {
     return () => mediaQuery.removeEventListener("change", handleResize);
   }, [isMenuOpen]);
 
+  // Close mobile menu on route changes (including browser back/forward)
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
+
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
   const closeMenu = () => setIsMenuOpen(false);
 

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -98,7 +98,6 @@ describe("Header", () => {
 
       expect(button).toHaveAttribute("aria-expanded", "false");
     });
-
   });
 
   describe("Active Link Detection", () => {

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -82,6 +82,23 @@ describe("Header", () => {
 
       expect(button).toHaveAttribute("aria-expanded", "false");
     });
+
+    it("should close menu when pathname changes", () => {
+      let pathname = "/";
+      (usePathname as jest.Mock).mockImplementation(() => pathname);
+
+      const { rerender } = render(<Header />);
+      const button = screen.getByLabelText("Toggle menu");
+
+      fireEvent.click(button);
+      expect(button).toHaveAttribute("aria-expanded", "true");
+
+      pathname = "/about/";
+      rerender(<Header />);
+
+      expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+
   });
 
   describe("Active Link Detection", () => {


### PR DESCRIPTION
### Motivation
- Fix a bug where the mobile menu could remain open after client-side navigations (including browser back/forward), leaving a stale overlay and scroll-lock on the next page.

### Description
- Add a pathname-driven `useEffect` in `src/components/Header.tsx` that calls `setIsMenuOpen(false)` whenever `usePathname()` changes to ensure the menu and scroll-lock are cleared on route changes.
- Add a regression test in `src/components/__tests__/Header.test.tsx` that opens the mobile menu, updates the mocked pathname, rerenders the component, and verifies the menu closes (`aria-expanded` becomes `false`).

### Testing
- Ran `corepack enable && corepack install` successfully to ensure the pinned Yarn is used.
- Ran `yarn test src/components/__tests__/Header.test.tsx` and observed all tests passing (`14 passed, 14 total`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad23392ec8323a3892696d8f3b9cd)