### PR TITLE
Fix RSS feed discovery/styling warnings and add footer RSS icon

### DIFF
--- a/public/feed.xsl
+++ b/public/feed.xsl
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes" />
+
+  <xsl:template match="/">
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>
+          <xsl:value-of select="rss/channel/title" />
+        </title>
+        <style>
+          body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            line-height: 1.6;
+          }
+          main {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 32px 20px 48px;
+          }
+          h1 {
+            margin: 0 0 8px;
+            font-size: 1.9rem;
+          }
+          p {
+            margin: 8px 0 0;
+          }
+          a {
+            color: #93c5fd;
+            text-decoration: none;
+          }
+          a:hover {
+            text-decoration: underline;
+          }
+          ul {
+            list-style: none;
+            margin: 28px 0 0;
+            padding: 0;
+          }
+          li {
+            padding: 16px 0;
+            border-top: 1px solid #334155;
+          }
+          .meta {
+            color: #94a3b8;
+            font-size: 0.92rem;
+          }
+          .tags {
+            margin-top: 8px;
+            color: #cbd5e1;
+            font-size: 0.9rem;
+          }
+        </style>
+      </head>
+      <body>
+        <main>
+          <h1>
+            <xsl:value-of select="rss/channel/title" />
+          </h1>
+          <p>
+            <xsl:value-of select="rss/channel/description" />
+          </p>
+          <p class="meta">
+            Website:
+            <a href="{rss/channel/link}">
+              <xsl:value-of select="rss/channel/link" />
+            </a>
+          </p>
+          <ul>
+            <xsl:for-each select="rss/channel/item">
+              <li>
+                <h2>
+                  <a href="{link}">
+                    <xsl:value-of select="title" />
+                  </a>
+                </h2>
+                <p class="meta">
+                  <xsl:value-of select="pubDate" />
+                </p>
+                <p>
+                  <xsl:value-of select="description" />
+                </p>
+                <xsl:if test="category">
+                  <p class="tags">
+                    Tags:
+                    <xsl:for-each select="category">
+                      <xsl:if test="position() &gt; 1">, </xsl:if>
+                      <xsl:value-of select="." />
+                    </xsl:for-each>
+                  </p>
+                </xsl:if>
+              </li>
+            </xsl:for-each>
+          </ul>
+        </main>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,4 +1,5 @@
 import { getAllPosts } from "@/lib/blogApi";
+import { BASE_URL } from "@/constants";
 import { buildRssFeedXml } from "@/lib/feed";
 
 export const dynamic = "force-static";
@@ -13,8 +14,12 @@ export function GET() {
     "tags",
   ]);
   const xml = buildRssFeedXml(posts);
+  const stylesheetDeclaration = `<?xml-stylesheet type="text/xsl" href="${BASE_URL}/feed.xsl"?>`;
+  const xmlWithStylesheet = xml.includes("<?xml")
+    ? xml.replace(/^<\?xml[^>]*\?>/, `$&\n${stylesheetDeclaration}`)
+    : `${stylesheetDeclaration}\n${xml}`;
 
-  return new Response(xml, {
+  return new Response(xmlWithStylesheet, {
     headers: {
       "Content-Type": "application/rss+xml; charset=utf-8",
     },

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,5 +1,5 @@
-import { getAllPosts } from "@/lib/blogApi";
 import { BASE_URL } from "@/constants";
+import { getAllPosts } from "@/lib/blogApi";
 import { buildRssFeedXml } from "@/lib/feed";
 
 export const dynamic = "force-static";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,12 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/",
     types: {
-      "application/rss+xml": "/feed.xml",
+      "application/rss+xml": [
+        {
+          url: "/feed.xml",
+          title: "Alex Leung Blog RSS Feed",
+        },
+      ],
     },
   },
   openGraph: {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+import { FaRss } from "react-icons/fa6";
+
 import { LinkText } from "@/components/LinkText";
 import { data } from "@/constants/socialLinks";
 
@@ -25,7 +27,10 @@ export default function Footer() {
         ))}
       </ul>
       <p className="text-body-sm pb-1">
-        <LinkText href="/feed.xml">Subscribe via RSS</LinkText>
+        <LinkText href="/feed.xml" className="inline-flex items-center gap-2">
+          <FaRss aria-hidden="true" />
+          <span>Subscribe via RSS</span>
+        </LinkText>
       </p>
       <p>Copyright &copy; 2020 - {currentYear} Alex Leung</p>
     </section>

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,6 +1,6 @@
 import { usePathname } from "next/navigation";
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import Header from "../Header";
 
@@ -86,12 +86,12 @@ describe("Header", () => {
       expect(button).toHaveAttribute("aria-expanded", "false");
     });
 
-    it("should close menu when pathname changes", () => {
+    it("should close menu when pathname changes", async () => {
       let pathname = "/";
       (usePathname as jest.Mock).mockImplementation(() => pathname);
 
       const { rerender } = render(<Header />);
-      const button = screen.getByLabelText("Toggle menu");
+      const button = screen.getByRole("button", { name: "Open menu" });
 
       fireEvent.click(button);
       expect(button).toHaveAttribute("aria-expanded", "true");
@@ -99,7 +99,9 @@ describe("Header", () => {
       pathname = "/about/";
       rerender(<Header />);
 
-      expect(button).toHaveAttribute("aria-expanded", "false");
+      await waitFor(() => {
+        expect(button).toHaveAttribute("aria-expanded", "false");
+      });
     });
   });
 

--- a/src/lib/__tests__/feed.test.ts
+++ b/src/lib/__tests__/feed.test.ts
@@ -43,6 +43,7 @@ describe("buildRssFeedXml", () => {
           "Notes on software engineering, distributed systems, AI engineering, and practical product development.",
         id: "https://alexleung.ca/blog/",
         link: "https://alexleung.ca/blog/",
+        image: "https://alexleung.ca/icon4.png",
         language: "en-CA",
         feedLinks: { rss: "https://alexleung.ca/feed.xml" },
       })

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -15,6 +15,7 @@ type FeedPost = {
 const FEED_TITLE = "Alex Leung's Blog";
 const FEED_DESCRIPTION =
   "Notes on software engineering, distributed systems, AI engineering, and practical product development.";
+const FEED_IMAGE_URL = `${BASE_URL}/icon4.png`;
 
 export function buildRssFeedXml(posts: readonly FeedPost[]): string {
   const lastUpdated =
@@ -32,6 +33,7 @@ export function buildRssFeedXml(posts: readonly FeedPost[]): string {
     description: FEED_DESCRIPTION,
     id: toCanonical("/blog"),
     link: toCanonical("/blog"),
+    image: FEED_IMAGE_URL,
     language: "en-CA",
     feedLinks: {
       rss: `${BASE_URL}/feed.xml`,

--- a/src/lib/seo/__tests__/metadata.test.ts
+++ b/src/lib/seo/__tests__/metadata.test.ts
@@ -12,6 +12,14 @@ describe("buildPageMetadata", () => {
     const twitter = metadata.twitter;
 
     expect(metadata.alternates?.canonical).toBe("https://alexleung.ca/about/");
+    expect(metadata.alternates?.types).toEqual({
+      "application/rss+xml": [
+        {
+          url: "https://alexleung.ca/feed.xml",
+          title: "Alex Leung Blog RSS Feed",
+        },
+      ],
+    });
     expect(openGraph?.url).toBe("https://alexleung.ca/about/");
 
     expect(openGraph).toMatchObject({ type: "website" });

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -24,6 +24,7 @@ export function buildPageMetadata(input: SeoInput): Metadata {
   const hasImages = normalizedImages.length > 0;
   const twitterCard =
     input.twitterCard || (hasImages ? "summary_large_image" : "summary");
+  const rssFeedUrl = toAbsoluteUrl("/feed.xml");
 
   return {
     title: input.title,
@@ -31,6 +32,14 @@ export function buildPageMetadata(input: SeoInput): Metadata {
     keywords: input.keywords,
     alternates: {
       canonical: canonicalUrl,
+      types: {
+        "application/rss+xml": [
+          {
+            url: rssFeedUrl,
+            title: "Alex Leung Blog RSS Feed",
+          },
+        ],
+      },
     },
     openGraph: {
       title: input.title,


### PR DESCRIPTION
## Summary
- add explicit RSS alternate metadata (with title) so feed discovery appears consistently across pages
- include a channel image in generated RSS and prepend an XML stylesheet declaration
- add `public/feed.xsl` for browser-friendly feed rendering
- add an RSS icon next to the footer subscription link
- update metadata/feed unit tests for the new feed metadata fields

## Validation
- `yarn test src/lib/seo/__tests__/metadata.test.ts src/lib/__tests__/feed.test.ts src/components/__tests__/Footer.test.tsx`
- `yarn typecheck`