### PR TITLE
Add follow.it subscribe form and integrate across blog/contact

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Article, BlogPosting } from "schema-dts";
 
 import { CoverImage } from "@/components/CoverImage";
 import { ExcerptText } from "@/components/ExcerptText";
+import { FollowItSubscribeForm } from "@/components/FollowItSubscribeForm";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ProseContent } from "@/components/ProseContent";
@@ -184,6 +185,7 @@ export default async function Post({ params }: Props) {
                 </div>
               </section>
             )}
+            <FollowItSubscribeForm className="mt-10" />
 
             {relatedPosts.length > 0 && (
               <section

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -5,6 +5,7 @@ import { Metadata } from "next";
 import { CollectionPage, ItemList } from "schema-dts";
 
 import { BlogPostCard } from "@/components/BlogPostCard";
+import { FollowItSubscribeForm } from "@/components/FollowItSubscribeForm";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
@@ -25,7 +26,7 @@ export function generateMetadata(): Metadata {
   const posts = getAllPosts(["coverImage"]);
   const firstCoverImage = posts.find((post) => post.coverImage)?.coverImage;
 
-  return buildPageMetadata({
+  const metadata = buildPageMetadata({
     title,
     description,
     path,
@@ -37,6 +38,13 @@ export function generateMetadata(): Metadata {
         ]
       : undefined,
   });
+
+  return {
+    ...metadata,
+    other: {
+      "follow.it-verification-code": "qQRuRCQt2ltelEDXU602",
+    },
+  };
 }
 
 export default function BlogIndex() {
@@ -54,7 +62,7 @@ export default function BlogIndex() {
     <>
       <PageShell title="Blog">
         <ResponsiveContainer variant="wide">
-          <div className="mb-32 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+          <div className="mb-16 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
             {firstPost ? (
               <BlogPostCard
                 key={firstPost.slug}
@@ -70,6 +78,7 @@ export default function BlogIndex() {
               />
             ))}
           </div>
+          <FollowItSubscribeForm className="my-6" />
         </ResponsiveContainer>
       </PageShell>
       <JsonLdBreadcrumbs

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,8 +4,11 @@ import { Metadata } from "next";
 
 import * as schemadts from "schema-dts";
 
+import { FollowItSubscribeForm } from "@/components/FollowItSubscribeForm";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
+import { ResponsiveContainer } from "@/components/ResponsiveContainer";
+import { Subtitle } from "@/components/Subtitle";
 import { buildContactPageSchema, buildPageMetadata } from "@/lib/seo";
 
 import { EmailMe } from "./_components/EmailMe";
@@ -42,6 +45,10 @@ export default function ContactPage() {
       <PageShell title="Contact" titleId="contact">
         <EmailMe />
         <SocialMediaList />
+        <ResponsiveContainer element="section">
+          <Subtitle title="Subscribe" id="subscribe" />
+          <FollowItSubscribeForm />
+        </ResponsiveContainer>
       </PageShell>
     </>
   );

--- a/src/components/FollowItSubscribeForm.tsx
+++ b/src/components/FollowItSubscribeForm.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+
+import { surfaceClassNames } from "@/components/Surface";
+
+const DEFAULT_FOLLOW_IT_ACTION =
+  "https://api.follow.it/subscription-form/RkY1QllwUjBPUEZhSnNWMnZQVjdlK2tMZWtJOWRrVGlma0xlT09iU0pIUWtPWjVVMWVucTE1WWdNYjZIckhoWGwzTy9yME5WNjJaQUxyUG5oclg2VC9Td2FIRGl5aWZZL3JheTB0UTdHOFZMaXJDV1FXcGlham5lSlFXc013NGl8bTM1Qkt0b1VwU0RNS1Z1Y1EzU0dnUkt1NjFOQ0FBd01wbW5RTFB2dHFHVT0=/8";
+
+type FollowItSubscribeFormProps = {
+  className?: string;
+  title?: string;
+  description?: string;
+  placeholder?: string;
+  buttonLabel?: string;
+  action?: string;
+};
+
+export function FollowItSubscribeForm({
+  className = "",
+  title = "Get new posts by email",
+  description = "Subscribe for occasional updates when I publish something new.",
+  placeholder = "Enter your email",
+  buttonLabel = "Subscribe",
+  action = DEFAULT_FOLLOW_IT_ACTION,
+}: FollowItSubscribeFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  return (
+    <section
+      aria-labelledby="follow-it-subscribe-title"
+      className={surfaceClassNames({
+        className: `mx-auto max-w-xl p-6 md:p-8 ${className}`.trim(),
+      })}
+    >
+      <header className="text-center">
+        <h2
+          id="follow-it-subscribe-title"
+          className="text-heading font-semibold text-white"
+        >
+          {title}
+        </h2>
+        <p className="text-body-sm mt-2 text-gray-300">{description}</p>
+      </header>
+
+      <form
+        action={action}
+        method="post"
+        className="mt-5 space-y-3"
+        aria-busy={isSubmitting}
+        onSubmit={() => {
+          setIsSubmitting(true);
+        }}
+      >
+        <label htmlFor="follow-it-email" className="sr-only">
+          Email address
+        </label>
+        <input
+          id="follow-it-email"
+          type="email"
+          name="email"
+          required
+          autoComplete="email"
+          placeholder={placeholder}
+          disabled={isSubmitting}
+          className="text-body w-full rounded-md border-2 border-white/15 bg-white/5 px-4 py-2.5 text-center text-white placeholder:text-gray-400 focus:border-accent-link focus:placeholder-transparent focus:outline-none"
+        />
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="text-body inline-flex w-full cursor-pointer items-center justify-center rounded-md bg-gradient-to-br from-blue-500 to-accent-primary px-5 py-2.5 font-bold text-white transition-all duration-200 ease-expo-out hover:from-blue-600 hover:to-accent-primary-hover disabled:cursor-progress disabled:opacity-90"
+        >
+          {isSubmitting ? "Subscribing..." : buttonLabel}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/__tests__/FollowItSubscribeForm.test.tsx
+++ b/src/components/__tests__/FollowItSubscribeForm.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { FollowItSubscribeForm } from "../FollowItSubscribeForm";
+
+describe("FollowItSubscribeForm", () => {
+  it("renders default copy and required fields", () => {
+    render(<FollowItSubscribeForm />);
+
+    expect(
+      screen.getByRole("heading", { name: /get new posts by email/i })
+    ).toBeInTheDocument();
+
+    expect(screen.getByPlaceholderText(/enter your email/i)).toHaveAttribute(
+      "required"
+    );
+
+    expect(
+      screen.getByRole("button", { name: /subscribe/i })
+    ).toBeInTheDocument();
+  });
+
+  it("posts to the follow.it action by default", () => {
+    const { container } = render(<FollowItSubscribeForm />);
+    const form = container.querySelector("form");
+
+    expect(form).not.toBeNull();
+    expect(form).toHaveAttribute(
+      "action",
+      "https://api.follow.it/subscription-form/RkY1QllwUjBPUEZhSnNWMnZQVjdlK2tMZWtJOWRrVGlma0xlT09iU0pIUWtPWjVVMWVucTE1WWdNYjZIckhoWGwzTy9yME5WNjJaQUxyUG5oclg2VC9Td2FIRGl5aWZZL3JheTB0UTdHOFZMaXJDV1FXcGlham5lSlFXc013NGl8bTM1Qkt0b1VwU0RNS1Z1Y1EzU0dnUkt1NjFOQ0FBd01wbW5RTFB2dHFHVT0=/8"
+    );
+    expect(form).toHaveAttribute("method", "post");
+  });
+
+  it("supports custom heading and button label", () => {
+    render(
+      <FollowItSubscribeForm
+        title="Join the newsletter"
+        buttonLabel="Join now"
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /join the newsletter/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /join now/i })
+    ).toBeInTheDocument();
+  });
+
+  it("shows submitting affordance after submit", () => {
+    const { container } = render(<FollowItSubscribeForm />);
+    const emailInput = screen.getByPlaceholderText(/enter your email/i);
+    fireEvent.change(emailInput, {
+      target: { value: "alex@example.com" },
+    });
+    const form = container.querySelector("form");
+
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    expect(
+      screen.getByRole("button", { name: /subscribing\.\.\./i })
+    ).toBeDisabled();
+    expect(emailInput).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable FollowItSubscribeForm component for follow.it email subscriptions
- add /blog page verification meta tag: follow.it-verification-code
- place the subscribe form on blog index, blog post pages, and a dedicated Subscribe section on Contact after Connect
- improve form UX: hide placeholder on focus, pointer/progress cursor affordance, and in-flight submit state (Subscribing...)
- add unit tests for form rendering, configuration, and submit-state behavior

## Validation
- yarn lint (passes; existing warnings only in coverage/lcov-report/*)
- yarn test
- yarn build