### PR TITLE
Move follow.it verification meta to homepage and preserve submit forwarding

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -26,7 +26,7 @@ export function generateMetadata(): Metadata {
   const posts = getAllPosts(["coverImage"]);
   const firstCoverImage = posts.find((post) => post.coverImage)?.coverImage;
 
-  const metadata = buildPageMetadata({
+  return buildPageMetadata({
     title,
     description,
     path,
@@ -38,13 +38,6 @@ export function generateMetadata(): Metadata {
         ]
       : undefined,
   });
-
-  return {
-    ...metadata,
-    other: {
-      "follow.it-verification-code": "qQRuRCQt2ltelEDXU602",
-    },
-  };
 }
 
 export default function BlogIndex() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { JsonLd } from "react-schemaorg";
 
+import type { Metadata } from "next";
+
 import type { WebPage } from "schema-dts";
 
 import { Hero } from "@/components/Hero";
@@ -9,6 +11,12 @@ const title = "Alex Leung | Syntropy Engineer and Programmer, P.Eng.";
 const description =
   "Alex Leung is a Syntropy Engineer and Programmer writing about software systems, AI engineering, and learning in public.";
 const path = "/";
+
+export const metadata: Metadata = {
+  other: {
+    "follow.it-verification-code": "qQRuRCQt2ltelEDXU602",
+  },
+};
 
 export default function Page() {
   return (

--- a/src/components/FollowItSubscribeForm.tsx
+++ b/src/components/FollowItSubscribeForm.tsx
@@ -25,6 +25,12 @@ export function FollowItSubscribeForm({
   action = DEFAULT_FOLLOW_IT_ACTION,
 }: FollowItSubscribeFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const buttonClassName = [
+    "text-body inline-flex w-full items-center justify-center rounded-md bg-gradient-to-br from-blue-500 to-accent-primary px-5 py-2.5 font-bold text-white transition-all duration-200 ease-expo-out",
+    isSubmitting
+      ? "cursor-progress opacity-90"
+      : "cursor-pointer hover:from-blue-600 hover:to-accent-primary-hover",
+  ].join(" ");
 
   return (
     <section
@@ -62,13 +68,13 @@ export function FollowItSubscribeForm({
           required
           autoComplete="email"
           placeholder={placeholder}
-          disabled={isSubmitting}
+          readOnly={isSubmitting}
           className="text-body w-full rounded-md border-2 border-white/15 bg-white/5 px-4 py-2.5 text-center text-white placeholder:text-gray-400 focus:border-accent-link focus:placeholder-transparent focus:outline-none"
         />
         <button
           type="submit"
-          disabled={isSubmitting}
-          className="text-body inline-flex w-full cursor-pointer items-center justify-center rounded-md bg-gradient-to-br from-blue-500 to-accent-primary px-5 py-2.5 font-bold text-white transition-all duration-200 ease-expo-out hover:from-blue-600 hover:to-accent-primary-hover disabled:cursor-progress disabled:opacity-90"
+          aria-disabled={isSubmitting}
+          className={buttonClassName}
         >
           {isSubmitting ? "Subscribing..." : buttonLabel}
         </button>

--- a/src/components/__tests__/FollowItSubscribeForm.test.tsx
+++ b/src/components/__tests__/FollowItSubscribeForm.test.tsx
@@ -60,7 +60,8 @@ describe("FollowItSubscribeForm", () => {
 
     expect(
       screen.getByRole("button", { name: /subscribing\.\.\./i })
-    ).toBeDisabled();
-    expect(emailInput).toBeDisabled();
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(emailInput).toHaveAttribute("readonly");
+    expect(form).toHaveAttribute("aria-busy", "true");
   });
 });


### PR DESCRIPTION
## Summary
- move follow.it verification meta tag from `/blog` to homepage metadata on `/`
- keep blog page metadata generation focused on SEO image/canonical only
- fix subscription submit UX to preserve email forwarding by avoiding disabled fields during submit
- keep loading affordance by switching to `readOnly` input + `aria-disabled` button state
- update FollowIt form tests for submit-state behavior

## Validation
- yarn eslint src/app/page.tsx src/app/blog/page.tsx src/components/FollowItSubscribeForm.tsx src/components/__tests__/FollowItSubscribeForm.test.tsx
- yarn test FollowItSubscribeForm --watch=false
- yarn typecheck
