### PR TITLE
Remove temporary follow.it verification metadata

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,5 @@
 import { JsonLd } from "react-schemaorg";
 
-import type { Metadata } from "next";
-
 import type { WebPage } from "schema-dts";
 
 import { Hero } from "@/components/Hero";
@@ -11,12 +9,6 @@ const title = "Alex Leung | Syntropy Engineer and Programmer, P.Eng.";
 const description =
   "Alex Leung is a Syntropy Engineer and Programmer writing about software systems, AI engineering, and learning in public.";
 const path = "/";
-
-export const metadata: Metadata = {
-  other: {
-    "follow.it-verification-code": "qQRuRCQt2ltelEDXU602",
-  },
-};
 
 export default function Page() {
   return (


### PR DESCRIPTION
## Summary
- remove temporary `follow.it-verification-code` metadata from the homepage
- keep home page JSON-LD and existing global SEO metadata unchanged

## Validation
- yarn eslint src/app/page.tsx
- yarn typecheck
