### PR TITLE
Refine blog writing skill and post corpus

### DIFF
--- a/.agents/skills/blog-post-creator/SKILL.md
+++ b/.agents/skills/blog-post-creator/SKILL.md
@@ -13,10 +13,12 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Keep tone warm but understated: confident, relationship-aware, and forward-looking.
 - Keep prose professional with emotional intelligence.
 - Avoid theatrics, hype language, and performative emphasis.
+- When the piece is intentionally reflective or artistic, allow a more lyrical register, but keep it anchored in concrete observation, personal judgment, or a clearly stated tension.
 
 ## Hard Constraints
 
 1. Do not use repeated one-sentence paragraphs as the dominant cadence.
+   Exception: in intentionally reflective/artistic pieces, a few short paragraphs are acceptable if they create rhythm and the overall piece still carries a coherent argument or emotional throughline.
 2. Default to cohesive paragraphs that carry one clear claim with supporting detail.
 3. Prefer specific trade-offs, mechanisms, and implications over slogans.
 4. Keep writing concise: remove filler, throat-clearing, and redundant qualifiers.
@@ -24,6 +26,8 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 6. Default to concise titles; prefer short, plain phrasing unless the user asks for a longer or more stylized title.
 7. Use section headings that are specific and neutral; avoid cute, rhetorical, or parenthetical framing.
 8. When drafting a new post from notes, include cover prompts by default; only skip prompts if the user explicitly asks for post-only output.
+9. Do not imply hands-on practice the user did not claim. If the input is about reading, reflection, or conceptual learning, keep claims at the level of understanding, interpretation, or future curiosity unless the user explicitly said they build, tune, deploy, or regularly use the systems being discussed.
+10. Avoid formulaic heading scaffolds as a dominant pattern. Do not default multiple sections in a post to `What`, `How`, `Why`, `When`, `Where`, `The Goal`, `The Implementation`, or similar organizational labels when a more specific idea-title is available.
 
 ## Workflow
 
@@ -32,18 +36,32 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Collect concrete examples, decisions, and trade-offs from user input.
 - Avoid inventing anecdotes, metrics, or timeline claims.
 - Lock key facts before drafting: actor/ownership details, product/version details, and scope boundaries.
+- Identify whether the post should read as an essay, a learning note, or a compact reflection before choosing headings or structure.
 
 2. Select a post shape.
 - Open with context and a clear point of view in the first paragraph.
 - Use 2-4 `##` sections that progress by reasoning.
-- Keep section headings plain and descriptive (for example, "Why We Chose This Setup"), not rhetorical.
+- Keep section headings plain and descriptive (for example, "Scope Before Specs"), not rhetorical.
+- Prefer headings that name the actual idea of the section, not just its question type or document role.
 - End with a concrete synthesis or forward-looking close.
+- For learning/review posts, default the close to what changed in the author's understanding; only end on operational practice if the user explicitly described a change in what they do.
+  Exception: short reflective/artistic posts may be written without headings if the piece is intentionally compact and the movement is still clear from paragraph to paragraph.
+
+### Post Calibration
+
+- `Learning note`: emphasize changed understanding, bounded claims, and a modest close.
+- `Technical explainer`: emphasize mechanism, precision, and explicit trade-offs.
+- `Reflection`: emphasize tension, judgment, and implications without drifting into slogans.
+- `Reflective/artistic short form`: allow more atmosphere, compression, and rhetorical movement, but anchor the piece in a concrete scene, tension, or observation within the first paragraph and keep the close earned rather than vague.
+- When a draft sits between categories, bias toward the less grand version; prefer a narrower, more grounded post over a more ambitious one.
 
 3. Draft in house voice.
 - Write in first person singular.
 - Keep paragraphs mostly multi-sentence.
 - Prefer mechanism, constraints, and implications over slogans.
+- Prefer plain analytical phrasing over polished summary language; if a sentence sounds like a slogan, flatten it.
 - Use lists only when scanning value is clearly better than prose.
+- In reflective/artistic mode, do not flatten every rhetorical sentence. Preserve some texture when it is doing real tonal work, but trim lines that sound ornamental without adding meaning.
 
 4. Apply repo format.
 - Follow frontmatter and skeleton in [post-template](references/post-template.md).
@@ -61,8 +79,13 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Ensure the argument is cohesive from opening to close.
 - Remove hype language and repeated one-sentence paragraph cadence.
 - Verify section headings are specific and reflect actual content.
+- Run a heading-shape audit: if several headings in the same draft begin with `What`, `How`, `Why`, `When`, `Where`, or generic labels like `The Goal`, rewrite them unless that repetition is clearly intentional.
 - Keep claims bounded and testable; mark assumptions when needed.
 - Run an assumption audit: check that agency/ownership wording matches the user's input and that title/heading tone matches the user's preference for directness.
+- Run a practice audit: remove any implication that the author builds, tunes, deploys, or routinely uses systems unless the user explicitly stated that.
+- Run a vagueness audit: replace underspecified abstractions like "shift", "this", "that", "result", or "it" when the referent would be unclear in isolation.
+- Run a transition audit: make sure each section clearly connects to the one before it; add a bridging sentence when the relationship is not obvious.
+- For reflective/artistic posts, run an anchoring audit: make sure abstract lines are grounded by at least one concrete image, scene, tool, or tension so the piece does not drift into generic musing.
 - Confirm output completeness: if this is a new-post draft, include both `Cover Prompt (Primary)` and `Cover Prompt (Backup)` blocks unless explicitly waived.
 
 ## Style References
@@ -77,9 +100,14 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Ensure paragraphs are mostly multi-sentence and logically connected.
 - Ensure claims are backed by context, not assertion alone.
 - Ensure trade-offs and limitations are explicit.
-- Ensure the close is forward-looking and concrete.
+- Ensure the close fits the post type: for learning notes, usually land on changed understanding before changed practice.
 - Ensure title length and phrasing are intentionally concise by default.
 - Ensure heading language is functional, not performative.
+- Ensure heading variety is healthy across the piece; avoid making all sections sound like reusable template labels.
+- Ensure transitions are explicit when moving between conceptually different sections.
+- Ensure no underspecified abstractions remain where the noun can be stated directly.
+- Ensure polished or slogan-like phrasing has been flattened into plain analytical prose.
+- For reflective/artistic pieces, ensure the abstraction is earned by concrete setup and not sustained for too long without grounding.
 - Ensure no inferred facts were introduced around who did what.
 
 ## Quick Rewrite Patterns
@@ -89,6 +117,14 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Replace broad praise or critique with specific criteria.
 - Turn hot-take phrasing into observation plus evidence plus implication.
 
+## Voice Anti-Patterns
+
+- Avoid vague evaluative phrasing like "this was a big shift" when the object of the shift can be named directly.
+- Avoid "this changes how I use X" unless the user explicitly said they use or build with `X`.
+- Avoid polished summary phrases like "clear statistical story" or "substantial result" when plainer analytical language would do.
+- Avoid endings that merely restate the thesis in more elevated language.
+- In reflective/artistic mode, avoid abstract language stacking for more than a sentence or two without returning to something observable or personal.
+
 ## Output Modes
 
 - Default mode selection: for new-post creation requests, use `Draft + cover prompt` unless the user explicitly requests another mode.
@@ -96,3 +132,11 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Revision pass: Return edited markdown that preserves existing facts and improves flow.
 - Outline-first: Return frontmatter plus a sectioned outline before writing the full draft.
 - Draft + cover prompt: Return post markdown plus one primary image prompt and one backup prompt.
+
+## Ending Test
+
+Before finalizing, ask:
+- Does the ending add a new synthesis, implication, or forward point?
+- Or does it only restate the thesis in cleaner language?
+
+If it only restates, revise the close so it advances the piece by at least one step.

--- a/content/posts/boring-blog-architecture.md
+++ b/content/posts/boring-blog-architecture.md
@@ -12,7 +12,7 @@ tags:
 
 I recently finished implementing the blog section of this personal website. Rather than reaching for a complex CMS, I decided to build it directly into my existing Next.js application using standard tools.
 
-## The Goal
+## Low-Maintenance Publishing
 
 I wanted a place to share technical thoughts without adding maintenance overhead. The requirements were simple:
 
@@ -20,7 +20,7 @@ I wanted a place to share technical thoughts without adding maintenance overhead
 2.  **Zero Runtime Cost**: The blog should be statically generated.
 3.  **Fast**: It should feel instant.
 
-## The Implementation
+## Static by Default
 
 ### 1. Filesystem as the Database
 
@@ -28,7 +28,7 @@ I created a simple utility, `blogApi.ts`, that reads directly from the file syst
 
 ### 2. Static Routing
 
-Next.js makes it incredibly easy to turn a folder of markdown files into routes. I used `generateStaticParams` to tell Next.js which paths to build at compile time:
+Next.js makes it straightforward to turn a folder of markdown files into routes. I used `generateStaticParams` to tell Next.js which paths to build at compile time:
 
 ```typescript
 export async function generateStaticParams() {
@@ -41,7 +41,7 @@ export async function generateStaticParams() {
 
 This ensures that `alexleung.ca/blog/boring-blog-architecture` is just a simple HTML file on the server, not a dynamic Node.js request.
 
-### 3. The Polish
+### 3. Details That Mattered
 
 To make it feel professional, I spent time on the details:
 
@@ -50,4 +50,4 @@ To make it feel professional, I spent time on the details:
 - **Syntax Highlighting**: I chose `rehype-pretty-code` (powered by Shiki). It uses the same TextMate grammars as VS Code, meaning the highlighting is extremely accurate. Because it generates inline styles, there's no brittle CSS to import from `node_modules`.
 - **Sitemap**: A dynamic script crawls my posts directory to keep `sitemap.xml` up to date automatically.
 
-This "boring" architecture allows me to focus entirely on writing, knowing the rendering is rock-solid and fast.
+This "boring" architecture lets me focus on writing, with a rendering path that is predictable and fast.

--- a/content/posts/deep-learning-part-1-review.md
+++ b/content/posts/deep-learning-part-1-review.md
@@ -10,6 +10,18 @@ tags:
   - "Review"
 ---
 
-I recently finished Part I of _Deep Learning_ by Goodfellow, Bengio, and Courville. It was a clear and efficient primer on the mathematical preliminaries needed to engage more deeply with the subject. I appreciated the refresher in linear algebra, probability, and numerical computation, which helped reestablish important foundations. In places, I found myself wishing for more proofs—or at least proof sketches—as I often wanted to understand where results came from rather than accept them at face value.
+I recently finished Part I of _Deep Learning_ by Goodfellow, Bengio, and Courville. As an introduction to the mathematical foundations behind the rest of the book, I thought it worked well. It is clear, compact, and direct about what background the reader is expected to carry forward. At the same time, it also clarified what I still want from the later chapters: not just results and terminology, but more of the reasoning behind them.
 
-The book is refreshingly direct and avoids unnecessary digressions. Chapter 5, in particular, served as a solid recap of core machine learning ideas. Overall, this section left me motivated to continue further into the theoretical side of deep learning, complementing the more application-focused perspective I’ve gained elsewhere.
+## Useful Foundations
+
+The strongest part of this section was the refresh on core tools that can get fuzzy over time. Linear algebra, probability, and numerical computation all came back into focus in a way that felt practical rather than ornamental. I also appreciated that the text moved quickly. It does not spend much time trying to dramatize the material; it mostly tells you what matters and moves on.
+
+Chapter 5 was especially useful in that respect. It served as a compact recap of core machine learning ideas and helped reconnect the mathematical preliminaries to the actual modeling problems they support. For me, that made Part I feel less like a detached prerequisite section and more like a reset of conceptual vocabulary before the book becomes more specialized.
+
+## Limits of the Exposition
+
+The main limitation for me was the level of mathematical exposition. In several places, I wanted more proofs, or at least proof sketches, to show where the results were coming from. Without that, some ideas felt more like statements to absorb than arguments to evaluate, and I noticed my skepticism kick in.
+
+That is not necessarily a flaw in the book so much as a limit of what this section is trying to do. As a foundation, Part I is effective. As a fully satisfying treatment of the math, it still left me wanting supplementation in the places where I was not yet convinced. That is probably the frame I will carry into the rest of the book. I can use it as a clear guide to the landscape, then dig deeper when I want stronger justification for a claim.
+
+Overall, this section made me more interested in continuing, but with sharper expectations. I came away with a stronger foundation and a better sense of where I still want more depth.

--- a/content/posts/everyone-is-a-builder.md
+++ b/content/posts/everyone-is-a-builder.md
@@ -9,8 +9,12 @@ tags:
   - "Reflection"
 ---
 
-Over cocktails recently, a few colleagues and I kept circling the same idea: AI is making everyone a builder. You still get leverage from software engineering skill, but you no longer need a formal engineering background to prototype, automate, and ship something useful.
+Over cocktails recently, a few colleagues and I kept circling the same idea: AI is making everyone a builder. Software engineering skill still gives you leverage, but you no longer need a formal engineering background to prototype, automate, and ship something useful.
 
-We agreed that automating ourselves out of work is generally a good thing. If repetitive tasks can be delegated to tools, we should delegate them and move our effort toward harder problems, better judgment, and more original thinking.
+Part of what feels different is how much cheaper the first draft has become. A rough internal tool, a workflow automation, or a small product idea no longer has to wait for someone with enough spare time to write everything from scratch. More people can test an idea while it is still cheap to change. That seems like a real change in who gets to participate.
 
-That changes the center of gravity of work from execution to direction, from "how do I write this function?" to "what should we build, and why?" It can feel uncomfortable, but it is also progressive: building is less gatekept, capability is more widely distributed, and human taste, curiosity, and clarity matter even more.
+We agreed that automating ourselves out of work is generally a good thing. If repetitive tasks can be delegated to tools, we should delegate them and move our effort toward harder problems, better judgment, and more original thinking. That does not mean implementation stops mattering. It means the bottleneck moves. The harder part becomes choosing the right problem, setting useful constraints, and deciding whether the output is actually any good.
+
+That changes the center of gravity of work from execution to direction, from "how do I write this function?" to "what should we build, and why?" It can feel uncomfortable, especially in professions that used to treat execution skill as the main gate. I still think it is a net positive. Building is less restricted, capability is more widely distributed, and human taste, curiosity, and clarity matter more once the cost of producing something drops.
+
+What stayed with me from that conversation was not the idea that everyone is suddenly an engineer. I already believed that more people were gaining access to the building layer of software. What felt useful was hearing that intuition echoed so clearly. That still seems good for experimentation, good for agency, and likely good for the range of ideas that get tested in the first place.

--- a/content/posts/from-coder-to-orchestrator.md
+++ b/content/posts/from-coder-to-orchestrator.md
@@ -19,27 +19,13 @@ This post summarizes what changed, what improved, and what remains unreliable in
 
 ## 2024: Useful, but limited
 
-I started experimenting with **Cline** for straightforward tasks:
-
-- boilerplate,
-- test scaffolding,
-- repetitive refactors.
-
-I avoided giving it larger tasks for two reasons:
-
-- It was easy to get code that looked fine but was wrong in non-obvious ways.
-- Anything non-trivial took too much prompt back-and-forth.
+I started experimenting with **Cline** for straightforward tasks such as boilerplate, test scaffolding, and repetitive refactors. I avoided giving it larger tasks for two reasons. First, it was easy to get code that looked fine but was wrong in non-obvious ways. Second, anything non-trivial took too much prompt back-and-forth.
 
 ## 2025: Better plans, same failure modes
 
 I switched to **Claude Code** and stopped asking for immediate implementation. Instead, I asked for a plan first and reviewed it.
 
-That improved outcomes, but two problems were persistent:
-
-- Plans were often overbuilt for the actual problem.
-- The agent would report "done" before handling edge cases.
-
-So the bottleneck moved from writing code to verification.
+That improved outcomes, but two problems stayed persistent. Plans were often overbuilt for the actual problem, and the agent would report "done" before handling edge cases. The bottleneck moved from writing code to verification.
 
 ## Late 2025 onward: what actually helped
 
@@ -68,12 +54,7 @@ The biggest improvement was switching from one-pass execution to a repeatable lo
 
 ## Current workflow
 
-I usually run a planner and an implementer in parallel.
-
-1. Write a short feature brief with constraints and non-goals.
-2. Turn that into checkpoints.
-3. Let the implementer run the loop per checkpoint.
-4. Review design and risk, not just syntax.
+I usually run a planner and an implementer in parallel. In practice, that means I write a short feature brief with constraints and non-goals, turn that into checkpoints, let the implementer run the loop per checkpoint, and then review design and risk rather than just syntax.
 
 Example brief:
 
@@ -88,7 +69,7 @@ This workflow is productive, but it has clear costs:
 - **Personal skill drift:** I type less code directly than I used to.
 - **Attention overhead:** Running multiple agents sounds parallel, but review and coordination still funnel through one person. Human attention is limited, and I still don't have a great system for managing that bottleneck consistently.
 
-## What this changes about the job
+## The Job Shifts Upward
 
 The useful part of my work has shifted upward: clearer requirements, tighter constraints, and stronger review discipline.
 

--- a/content/posts/ipad-air-m3-11-inch-first-impressions.md
+++ b/content/posts/ipad-air-m3-11-inch-first-impressions.md
@@ -11,19 +11,19 @@ tags:
 
 My wife and I bought the 11-inch iPad Air M3, and the first thing we both noticed was the weight. It feels noticeably lighter than carrying a full laptop, and that one difference has already changed how often she reaches for it. We bought last year's model because it was the right value for what she actually needs, not because we were trying to optimize for top-end specs.
 
-## Why We Chose This Setup
+## Scope Before Specs
 
 Her main use case is studying, including prep for an upcoming machine learning course at Stanford. For that kind of work, she needs something fast to open, easy to carry, and comfortable for long reading and note-taking sessions. She does not need local active development on the device, so paying for a full laptop workflow would have been unnecessary overhead.
 
 When she wants to experiment with OpenClaw, she can still do that through a remote machine running on a DigitalOcean droplet. That split works well: the iPad handles interface, reading, writing, and navigation, while heavier compute or tooling stays remote.
 
-## How the Setup Came Together
+## Accessories Mattered More Than Expected
 
 The accessories ended up mattering more than I expected. A Bluetooth keyboard and an inexpensive $20 case with a built-in stand made it stable for longer desk sessions. The setup is still simple, but it now covers the basics without friction.
 
 The Apple Pencil Pro also worked better than expected for her. Compared with an e-reader stylus, writing feels smoother and more responsive, and the higher refresh rate reduces the slight lag she notices during note-taking. On paper that difference sounds minor, but in daily use it makes handwriting feel more natural.
 
-## Where It Fits Her Workflow
+## A Narrow but Practical Fit
 
 For her current workflow, the iPad Air covers the core tasks: reading, annotating, writing, joining calls, and light remote workflows. The key trade-off is that it is not trying to be a local development machine, and that boundary is what makes it practical day to day. By being explicit about scope, we avoided overbuying and ended up with a tool she uses every day.
 

--- a/content/posts/making-responsive-images-just-work.md
+++ b/content/posts/making-responsive-images-just-work.md
@@ -19,33 +19,20 @@ Image behavior was spread across scripts and components with repeated convention
 
 That made drift easy, and small changes in one place could quietly break expectations elsewhere. I replaced that with a simpler pattern: generate one manifest at build time (`src/generated/imageVariantManifest.json`) and resolve variants from it at runtime.
 
-## What got simpler
+## Simpler Operating Model
 
-Three things became simpler:
+Three things became simpler. First, there is now one canonical workflow: `yarn image:variants`. Second, rendering logic is less duplicated because a shared `ResponsiveImage` component replaced repeated `<picture>` patterns. Third, static assets became data-driven, so background and portrait `srcSet` values now come from manifest-backed metadata rather than JSX literals.
 
-1. One canonical workflow:
-   - `yarn image:variants`
-2. Less duplicated rendering logic:
-   - shared `ResponsiveImage` component instead of repeated `<picture>` patterns
-3. Static assets became data-driven:
-   - background and portrait `srcSet` values now come from manifest-backed metadata, not JSX literals
-
-## Human constraint: it should just work
+## Authoring Constraint: It Should Just Work
 
 This was an important constraint for me: I do not want to manually create `-sm`, `-md`, `-lg` files every time I add an image.
 
-The workflow is now:
-
-1. Add the source image.
-2. Reference it in frontmatter or markdown.
-3. Run `yarn image:variants`.
-
-That keeps authoring simple while still making outputs consistent.
+The workflow is now simple: add the source image, reference it in frontmatter or markdown, then run `yarn image:variants`. That keeps authoring lightweight while still making outputs consistent.
 
 ## Reliability and Performance as Outcomes
 
 Once maintainability improved, reliability and performance improved with it. I also removed silent fallback for required profiles (`cover.card`, `cover.hero`, `inlineContent`). If a required variant is missing, it now fails fast instead of shipping a hidden regression.
 
-## Takeaway
+## Durable Lesson
 
 I started by chasing LCP. The durable fix was maintainability: fewer scattered conventions, one source of truth, and clearer build/runtime boundaries. For this site, performance improvements became much easier once the image system became easier to reason about.

--- a/content/posts/medium-and-meaning.md
+++ b/content/posts/medium-and-meaning.md
@@ -9,14 +9,12 @@ tags:
   - "Reflection"
 ---
 
-Lately, I've been using Codex a lot to improve this site, often from my phone — fixing a layout bug, tweaking copy, adjusting spacing by a few pixels.
+Lately, I have been using Codex a lot to improve this site, often from my phone: fixing a layout bug, tweaking copy, adjusting spacing by a few pixels. There is something satisfying about shipping tiny upgrades while standing in line, on a train, or in between errands. It makes the whole project feel less like a formal build and more like an ongoing conversation with myself.
 
-There is something strangely satisfying about shipping tiny upgrades while standing in line, on a train, or in between errands. It makes the whole project feel less like a formal "build" and more like an ongoing conversation with myself.
+That has changed how I think about the boundary between making and living with a project. The site no longer feels like something I only work on when I sit down for a dedicated session. It feels more permeable than that, as if the medium has become light enough to stay close to me throughout the day.
 
-At the same time, I've been trying to express myself more through content creation with Sora. I'm still learning how to use these tools well; most of what I make feels exploratory rather than polished.
+At the same time, I have been trying to express myself more through content creation with Sora. I am still learning how to use these tools well, and most of what I make feels exploratory rather than polished. That difference matters to me. With Codex, the intention is usually narrow and practical. With Sora, I am often trying to figure out what I even want to say.
 
-I keep circling around the same tension: the cultural shorthand of “AI slop” and the fear that using these tools somehow disqualifies the work — and the counterpoint that they are simply new creative mediums.
+I keep circling around the same tension: the cultural shorthand of “AI slop,” the suspicion that using these tools somehow disqualifies the work, and the counterpoint that they may simply be new creative mediums. I do not think that question is settled yet. But I also do not think authorship disappears just because the interface changes. The intention is still mine. The judgment, the taste, and the direction still sit with me.
 
-Maybe that label matters. Maybe it doesn't. I don't know yet. What I do know is that the intention is still mine. The judgment, the taste, the direction — those remain with me.
-
-If art is art, perhaps the medium matters less than whether something real is being expressed through it — and whether that expression is intentional.
+Maybe the medium matters somewhat. It shapes texture, pace, and what kinds of mistakes are easy to make. But I am less interested in defending the tools in the abstract than in asking whether something real is being worked out through them. For me, that is the more useful question.

--- a/content/posts/structural-reasoning-about-deep-networks.md
+++ b/content/posts/structural-reasoning-about-deep-networks.md
@@ -25,9 +25,7 @@ The most useful refinement was separating topology from optimization. The archit
 
 ## Linear Layers, Factorization, and Parameter Efficiency
 
-One result I had not internalized before is what happens when we stack linear layers without nonlinearities between them. Two consecutive linear transformations collapse into a single linear transformation. Functionally, nothing changes.
-
-But parameterization changes.
+One result I had not internalized before is what happens when we stack linear layers without nonlinearities between them. Two consecutive linear transformations collapse into a single linear transformation. Functionally, nothing changes, but the parameterization does.
 
 If a weight matrix $W \in \mathbb{R}^{m \times n}$ is factored as $W = AB$ with $A \in \mathbb{R}^{m \times r}$ and $B \in \mathbb{R}^{r \times n}$, we have expressed the same linear map with a rank constraint and potentially far fewer parameters when $r \ll \min(m, n)$. In other words, depth without nonlinearity induces a low-rank factorization.
 


### PR DESCRIPTION
## Summary
- refine the blog-post-creator skill for reflective posts, heading variety, and stronger closing checks
- revise several existing posts for tone, flow, and less template-like section framing
- expand "Everyone Is a Builder Now" into a fuller reflection with a cleaner close

## Testing
- yarn build