### PR TITLE
Add dependency/framework upgrade planner agent skill

### DIFF
--- a/.agents/skills/dependency-framework-upgrade-planner/SKILL.md
+++ b/.agents/skills/dependency-framework-upgrade-planner/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: dependency-framework-upgrade-planner
+description: Audit repository dependencies and framework usage, identify outdated or deprecated packages/APIs, and produce an upgrade/migration plan with concrete code modifications. Use when asked to review libraries, suggest compatible upgrades, replace deprecated APIs, or highlight breaking changes.
+---
+
+# Dependency & Framework Upgrade Planner
+
+Use this skill to evaluate dependency health in a codebase and produce a practical modernization plan.
+
+## Goals
+
+1. Identify outdated libraries and framework versions.
+2. Suggest upgrade targets compatible with the current architecture and tooling.
+3. Detect deprecated APIs and recommend modern replacements.
+4. Call out likely breaking changes and required migration work.
+5. Return a concise implementation plan with required code changes.
+
+## Workflow
+
+1. Inventory dependencies and framework usage.
+- Detect package manager and lockfile.
+- Read `package.json` (and workspace manifests when present).
+- Identify primary frameworks (runtime, build tools, test tools, lint/format).
+- Map versions currently used in source code (for example via imports and config files).
+
+2. Detect outdated and risky dependencies.
+- Use package-manager-native commands first (for example `yarn outdated`).
+- Classify updates by severity:
+  - patch/minor (low migration risk)
+  - major (needs migration review)
+  - deprecated/unmaintained (highest priority)
+- Distinguish direct dependencies from transitive dependencies.
+
+3. Check deprecations and API usage.
+- Search code for APIs known to be deprecated in the target major versions.
+- For each deprecated API found, propose replacement syntax/patterns.
+- Include file-level locations for likely edits.
+
+4. Evaluate compatibility and migration scope.
+- For each proposed upgrade, note:
+  - target version range
+  - compatibility with current framework/tooling
+  - potential breaking changes
+  - estimated migration effort (small/medium/large)
+- Flag sequencing constraints (for example upgrade TypeScript before ESLint plugins, or framework before adapter package).
+
+5. Produce the final deliverables.
+- Output `Upgrade plan` using phased steps.
+- Output `Required code modifications` as a file-by-file checklist.
+- Prefer actionable bullets over long narrative.
+
+## Command Guidance
+
+Use the repository's package manager and scripts. For JavaScript/TypeScript repos, typical commands include:
+
+- `corepack enable`
+- `corepack install`
+- `yarn outdated`
+- `yarn npm info <package> versions --json`
+- `yarn why <package>`
+- `yarn lint`
+- `yarn typecheck`
+- `yarn test`
+
+If a command fails due to environment constraints, report that limitation and continue with best-effort analysis.
+
+## Output Format
+
+Follow this structure unless the user asks for a different format:
+
+1. **Upgrade plan**
+- Phase 1: low-risk upgrades
+- Phase 2: framework/toolchain majors
+- Phase 3: deprecations and cleanup
+- Include why each phase is ordered this way.
+
+2. **Required code modifications**
+- Group by package/framework.
+- For each item include:
+  - files/components likely affected
+  - API/config changes needed
+  - validation steps (`lint`, `typecheck`, tests/build)
+
+Use [upgrade-plan-template](references/upgrade-plan-template.md) when helpful.
+
+## Quality Checklist
+
+- Outdated packages were verified via command output, not assumptions.
+- Recommendations match the repo's actual framework versions.
+- Deprecated API replacements include concrete code-level guidance.
+- Breaking changes are explicitly listed per major upgrade.
+- Migration plan is sequenced, testable, and minimally disruptive.

--- a/.agents/skills/dependency-framework-upgrade-planner/agents/openai.yaml
+++ b/.agents/skills/dependency-framework-upgrade-planner/agents/openai.yaml
@@ -1,0 +1,2 @@
+name: dependency-framework-upgrade-planner
+entry: SKILL.md

--- a/.agents/skills/dependency-framework-upgrade-planner/references/upgrade-plan-template.md
+++ b/.agents/skills/dependency-framework-upgrade-planner/references/upgrade-plan-template.md
@@ -1,0 +1,36 @@
+# Upgrade plan
+
+## Phase 1 — Safe updates (patch/minor)
+- [ ] Package: `<name>` → `<target version>`
+  - Reason: `<security/fixes/perf>`
+  - Notes: `<low-risk migration notes>`
+
+## Phase 2 — Coordinated major upgrades
+- [ ] Package/Framework: `<name>` → `<target major>`
+  - Breaking changes: `<summary>`
+  - Required prep: `<prerequisites>`
+  - Validation: `yarn lint && yarn typecheck && yarn test && yarn build`
+
+## Phase 3 — Deprecation removal and cleanup
+- [ ] Replace deprecated API: `<old API>` → `<new API>`
+  - Files: `<file paths>`
+  - Example migration: `<before/after guidance>`
+
+---
+
+# Required code modifications
+
+## `<package or framework>`
+- Files to edit:
+  - `<path 1>`
+  - `<path 2>`
+- Changes required:
+  - `<config/code change 1>`
+  - `<config/code change 2>`
+- Breaking-change risk: `<low|medium|high>`
+- Estimated effort: `<small|medium|large>`
+- Validation commands:
+  - `yarn lint`
+  - `yarn typecheck`
+  - `yarn test`
+  - `yarn build`


### PR DESCRIPTION
### Motivation
- Provide a reusable agent skill to audit repository dependencies and framework usage, identify outdated or deprecated packages/APIs, and produce a phased upgrade and migration plan.
- Standardize how dependency reviews are executed so future audits yield actionable upgrade steps and file-level modification checklists.

### Description
- Add `dependency-framework-upgrade-planner` skill at `.agents/skills/dependency-framework-upgrade-planner/` with the main workflow and output format defined in `SKILL.md`.
- Add an `upgrade-plan-template.md` reference at `.agents/skills/dependency-framework-upgrade-planner/references/` to standardize phased plans and code-mod checklists.
- Add agent registration metadata at `.agents/skills/dependency-framework-upgrade-planner/agents/openai.yaml` so the skill can be discovered by the agent tooling.
- The skill recommends using repository-native commands such as `corepack enable`, `corepack install`, `yarn outdated`, `yarn why`, `yarn lint`, `yarn typecheck`, and `yarn test` for verification and sequencing.

### Testing
- Ran repository linting via `yarn lint` and formatting checks, which completed successfully.
- No other automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadd3689c083238cf98e4423bc5806)