### PR TITLE
Update social links and image loading behavior

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,10 +19,10 @@ He is a licensed Professional Engineer (P.Eng.) through Professional Engineers O
 
 ## Contact and Social
 
-- [LinkedIn](https://www.linkedin.com/in/aclinic)
-- [GitHub](https://www.github.com/aclinic)
+- [LinkedIn](https://www.linkedin.com/in/aclyx)
+- [GitHub](https://www.github.com/aclyx)
 - [X/Twitter](https://www.x.com/aclyxpse)
-- [Bluesky](https://bsky.app/profile/aclinic.bsky.social)
+- [Bluesky](https://bsky.app/profile/aclyx.bsky.social)
 - [Instagram](https://www.instagram.com/rootpanda)
 - [Google Scholar](https://scholar.google.ca/citations?user=NcOOsPIAAAAJ)
 

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -116,8 +116,8 @@ describe("RootLayout", () => {
 
       expect(schema.sameAs).toBeDefined();
       expect(schema.sameAs.length).toBeGreaterThan(0);
-      expect(schema.sameAs).toContain("https://www.linkedin.com/in/aclinic");
-      expect(schema.sameAs).toContain("https://github.com/aclinic");
+      expect(schema.sameAs).toContain("https://www.linkedin.com/in/aclyx");
+      expect(schema.sameAs).toContain("https://github.com/aclyx");
     });
   });
 });

--- a/src/app/contact/_components/__tests__/SocialMediaList.test.tsx
+++ b/src/app/contact/_components/__tests__/SocialMediaList.test.tsx
@@ -21,11 +21,11 @@ describe("SocialMediaList", () => {
     render(<SocialMediaList />);
     expect(screen.getByLabelText("LinkedIn Profile")).toHaveAttribute(
       "href",
-      "https://www.linkedin.com/in/aclinic"
+      "https://www.linkedin.com/in/aclyx"
     );
     expect(screen.getByLabelText("GitHub Profile")).toHaveAttribute(
       "href",
-      "https://www.github.com/aclinic"
+      "https://www.github.com/aclyx"
     );
   });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ const description =
 const lato = Lato({
   subsets: ["latin"],
   weight: ["400", "900"],
-  display: "swap",
+  display: "optional",
 });
 
 export const metadata: Metadata = {

--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -1,9 +1,6 @@
-import Image from "next/image";
-
 type ResponsiveImageProps = {
   src: string;
   srcSet?: string;
-  sourceType?: string;
   alt: string;
   width: number;
   height: number;
@@ -19,7 +16,6 @@ type ResponsiveImageProps = {
 export function ResponsiveImage({
   src,
   srcSet,
-  sourceType = "image/webp",
   alt,
   width,
   height,
@@ -33,20 +29,17 @@ export function ResponsiveImage({
 }: ResponsiveImageProps) {
   return (
     <picture className={pictureClassName}>
-      {srcSet ? (
-        <source type={sourceType} srcSet={srcSet} sizes={sizes} />
-      ) : null}
-      <Image
+      <img
         src={src}
+        srcSet={srcSet}
         alt={alt}
         width={width}
         height={height}
         sizes={sizes}
         className={className}
-        loading={loading}
+        loading={priority ? "eager" : loading}
         fetchPriority={fetchPriority}
         decoding={decoding}
-        priority={priority}
       />
     </picture>
   );

--- a/src/constants/socialLinks.tsx
+++ b/src/constants/socialLinks.tsx
@@ -10,13 +10,13 @@ export const data = [
   {
     id: 1,
     icon: <FaLinkedinIn />,
-    url: "https://www.linkedin.com/in/aclinic",
+    url: "https://www.linkedin.com/in/aclyx",
     label: "LinkedIn Profile",
   },
   {
     id: 2,
     icon: <FaGithub />,
-    url: "https://www.github.com/aclinic",
+    url: "https://www.github.com/aclyx",
     label: "GitHub Profile",
   },
   {
@@ -28,7 +28,7 @@ export const data = [
   {
     id: 4,
     icon: <FaBluesky />,
-    url: "https://bsky.app/profile/aclinic.bsky.social",
+    url: "https://bsky.app/profile/alexleung.ca",
     label: "Bluesky Profile",
   },
   {

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -109,7 +109,7 @@ describe("seo jsonld builders", () => {
       name: "Professional Engineers Ontario",
     });
     expect(person.knowsLanguage).toEqual(["en-CA"]);
-    expect(person.sameAs).toContain("https://github.com/aclinic");
+    expect(person.sameAs).toContain("https://github.com/aclyx");
     expect(person.hasOccupation).toMatchObject({
       "@type": "Occupation",
       name: "Software Engineer",

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -324,10 +324,10 @@ export function buildPersonSchema(input: {
     description: input.description,
     knowsLanguage: ["en-CA"],
     sameAs: [
-      "https://www.linkedin.com/in/aclinic",
-      "https://github.com/aclinic",
+      "https://www.linkedin.com/in/aclyx",
+      "https://github.com/aclyx",
       "https://www.x.com/aclyxpse",
-      "https://bsky.app/profile/aclinic.bsky.social",
+      "https://bsky.app/profile/alexleung.ca",
       "https://www.instagram.com/rootpanda",
       "https://scholar.google.ca/citations?user=NcOOsPIAAAAJ",
     ],


### PR DESCRIPTION
## Summary
- update LinkedIn, GitHub, and Bluesky profile URLs across public copy, social link constants, and SEO schema/tests
- change the Lato font display mode from `swap` to `optional`
- replace `next/image` usage in `ResponsiveImage` with a plain `img` while preserving eager loading for priority images

## Testing
- yarn test --runTestsByPath src/lib/seo/__tests__/jsonld.test.ts src/app/contact/_components/__tests__/SocialMediaList.test.tsx src/app/__tests__/layout.test.tsx
- yarn typecheck
- yarn lint