### PR TITLE
Update llms.txt Bluesky profile URL

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -22,7 +22,7 @@ He is a licensed Professional Engineer (P.Eng.) through Professional Engineers O
 - [LinkedIn](https://www.linkedin.com/in/aclyx)
 - [GitHub](https://www.github.com/aclyx)
 - [X/Twitter](https://www.x.com/aclyxpse)
-- [Bluesky](https://bsky.app/profile/aclyx.bsky.social)
+- [Bluesky](https://bsky.app/profile/alexleung.ca)
 - [Instagram](https://www.instagram.com/rootpanda)
 - [Google Scholar](https://scholar.google.ca/citations?user=NcOOsPIAAAAJ)
 


### PR DESCRIPTION
## Summary
- update the Bluesky link in `public/llms.txt` to the current `alexleung.ca` profile
- keep the machine-readable social links aligned with the site's active social profile data

## Testing
- not run (content-only change)