### PR TITLE
Fix blog social links layout

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
   {
     ignores: [
       ".next/**",
+      "coverage/**",
       "out/**",
       "node_modules/**",
       "*.config.js",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -154,7 +154,7 @@ export default async function Post({ params }: Props) {
         <ResponsiveContainer
           element="article"
           variant="prose"
-          className="mb-12"
+          className="mb-12 lg:pl-24 xl:pl-28"
         >
           <Surface className="mx-auto" padding="sm">
             <div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-lg text-gray-300">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -54,7 +54,7 @@ export default function BlogIndex() {
   return (
     <>
       <PageShell title="Blog">
-        <ResponsiveContainer variant="wide">
+        <ResponsiveContainer variant="wide" className="lg:pl-24 xl:pl-28">
           <div className="mb-16 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
             {firstPost ? (
               <BlogPostCard

--- a/src/app/contact/_components/SocialMediaList.tsx
+++ b/src/app/contact/_components/SocialMediaList.tsx
@@ -1,32 +1,25 @@
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
+import { SocialLinkList } from "@/components/SocialLinkList";
 import { Subtitle } from "@/components/Subtitle";
 import { surfaceClassNames } from "@/components/Surface";
-import { data } from "@/constants/socialLinks";
 
 export function SocialMediaList() {
   return (
     <ResponsiveContainer element="section">
       <Subtitle title="Connect" id="social" />
-      <div className="mt-8 flex flex-wrap justify-center gap-6">
-        {data.map((link) => (
-          <a
-            key={link.id}
-            href={link.url}
-            target="_blank"
-            rel="noopener noreferrer me"
-            aria-label={link.label}
-            className={surfaceClassNames({
-              interactive: true,
-              className: "flex items-center gap-3 px-6 py-4",
-            })}
-          >
-            <span className="text-2xl">{link.icon}</span>
-            <span className="text-body">
-              {link.label.replace(" Profile", "")}
-            </span>
-          </a>
-        ))}
-      </div>
+      <SocialLinkList
+        className="mt-8 flex flex-wrap justify-center gap-6"
+        itemClassName="list-none"
+        linkClassName={surfaceClassNames({
+          interactive: true,
+          className: "flex items-center gap-3 px-6 py-4",
+        })}
+        iconClassName="text-2xl"
+        labelClassName="text-body"
+        rel="noopener noreferrer me"
+        showLabel
+        labelFormatter={(label) => label.replace(" Profile", "")}
+      />
     </ResponsiveContainer>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,31 +1,17 @@
 import { FaRss } from "react-icons/fa6";
 
 import { LinkText } from "@/components/LinkText";
-import { data } from "@/constants/socialLinks";
+import { SocialLinkList } from "@/components/SocialLinkList";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
     <section className="section-center py-4 text-center">
-      <ul>
-        {data.map((link) => (
-          <li
-            key={link.id}
-            className="mx-2 mb-4 inline-block list-none lg:hidden"
-          >
-            <a
-              href={link.url}
-              className="text-xl text-white"
-              rel="me noopener"
-              target="_blank"
-              aria-label={link.label}
-            >
-              {link.icon}
-            </a>
-          </li>
-        ))}
-      </ul>
+      <SocialLinkList
+        itemClassName="mx-2 mb-4 inline-block list-none lg:hidden"
+        linkClassName="text-xl text-white"
+      />
       <p className="text-body-sm pb-1">
         <LinkText href="/feed.xml" className="inline-flex items-center gap-2">
           <FaRss aria-hidden="true" />

--- a/src/components/SocialLinkList.tsx
+++ b/src/components/SocialLinkList.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from "react";
+
+import { data } from "@/constants/socialLinks";
+
+type SocialLinkListProps = {
+  className?: string;
+  itemClassName?: string;
+  linkClassName?: string;
+  labelClassName?: string;
+  iconClassName?: string;
+  rel?: string;
+  showLabel?: boolean;
+  labelFormatter?: (label: string) => ReactNode;
+};
+
+export function SocialLinkList({
+  className,
+  itemClassName,
+  linkClassName,
+  labelClassName,
+  iconClassName,
+  rel = "me noopener",
+  showLabel = false,
+  labelFormatter = (label) => label,
+}: SocialLinkListProps) {
+  return (
+    <ul className={className}>
+      {data.map((link) => (
+        <li key={link.id} className={itemClassName}>
+          <a
+            href={link.url}
+            className={linkClassName}
+            rel={rel}
+            target="_blank"
+            aria-label={link.label}
+          >
+            <span className={iconClassName}>{link.icon}</span>
+            {showLabel ? (
+              <span className={labelClassName}>
+                {labelFormatter(link.label)}
+              </span>
+            ) : null}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -1,23 +1,12 @@
-import { data } from "@/constants/socialLinks";
+import { SocialLinkList } from "@/components/SocialLinkList";
 
 export default function SocialLinks() {
   return (
     <aside className="fixed bottom-[12%] left-12 z-[99] hidden translate-y-1/2 after:relative after:top-2.5 after:ml-2.5 after:block after:h-[150px] after:w-px after:bg-gray-300 after:content-[''] lg:block">
-      <ul>
-        {data.map((link) => (
-          <li key={link.id} className="my-2 list-none">
-            <a
-              href={link.url}
-              className="text-xl text-hover"
-              rel="me noopener"
-              target="_blank"
-              aria-label={link.label}
-            >
-              {link.icon}
-            </a>
-          </li>
-        ))}
-      </ul>
+      <SocialLinkList
+        itemClassName="my-2 list-none"
+        linkClassName="text-xl text-hover"
+      />
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- add desktop gutter spacing on blog pages so the fixed social rail no longer overlaps content
- consolidate repeated social link rendering into a shared SocialLinkList component while preserving the rail, footer, and contact variants
- ignore coverage/ in ESLint so generated coverage reports do not break lint

## Validation
- yarn lint
- yarn test
- yarn build