### PR TITLE
test: rename Jest config to cjs

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,18 +1,14 @@
-import type { Config } from 'jest';
-import nextJest from 'next/jest.js';
+const nextJest = require('next/jest.js');
 
 const createJestConfig = nextJest({
-  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
   dir: './',
 });
 
-// Add any custom config to be passed to Jest
-const customJestConfig: Config = {
-  // Add more setup options before each test is run
+/** @type {import('jest').Config} */
+const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    // Handle module aliases (this will be automatically configured for you soon)
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   collectCoverageFrom: [
@@ -35,5 +31,4 @@ const customJestConfig: Config = {
   },
 };
 
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-export default createJestConfig(customJestConfig);
+module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary
- rename the Jest config from `jest.config.ts` to `jest.config.cjs`
- avoid Jest 30 requiring `ts-node` just to load the config
- keep the existing Next/Jest settings unchanged

## Verification
- yarn test