### PR TITLE
Fix getPostBySlug crash when slug points to a directory

### DIFF
--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -176,7 +176,6 @@ Body`,
     readFileSpy.mockRestore();
   });
 
-
   test("returns null when slug resolves to a directory", async () => {
     const tempDir = setupTempPosts({
       published: `---

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -176,6 +176,23 @@ Body`,
     readFileSpy.mockRestore();
   });
 
+
+  test("returns null when slug resolves to a directory", async () => {
+    const tempDir = setupTempPosts({
+      published: `---
+title: "Published"
+date: "2026-02-16"
+---
+Body`,
+    });
+
+    fs.mkdirSync(path.join(tempDir, "content", "posts", "folder.md"));
+
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+
+    expect(getPostBySlug("folder")).toBeNull();
+  });
+
   test("returns null for traversal-like slugs outside content/posts", async () => {
     const tempDir = setupTempPosts({
       published: `---\ntitle: "Published"\ndate: "2026-02-16"\n---\nBody`,

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -164,6 +164,11 @@ function parsePostBySlug(slug: string): Post | null {
     return null;
   }
 
+  const stat = fs.statSync(fullPath);
+  if (!stat.isFile()) {
+    return null;
+  }
+
   const fileContents = fs.readFileSync(fullPath, "utf8");
   const { data, content } = matter(fileContents);
   const frontMatter = parseFrontMatter(

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -160,11 +160,14 @@ function parsePostBySlug(slug: string): Post | null {
     return null;
   }
 
-  if (!fs.existsSync(fullPath)) {
+  let stat: fs.Stats;
+
+  try {
+    stat = fs.statSync(fullPath);
+  } catch {
     return null;
   }
 
-  const stat = fs.statSync(fullPath);
   if (!stat.isFile()) {
     return null;
   }


### PR DESCRIPTION
### Motivation
- `parsePostBySlug` called `readFileSync` after `existsSync`, which caused `EISDIR` when `<slug>.md` resolved to a directory instead of a regular file. 
- The intent is for `getPostBySlug` to safely return `null` for non-file paths under `content/posts` rather than throwing.

### Description
- Added an `fs.statSync(fullPath)` check and return `null` when `stat.isFile()` is false to prevent reading directories. 
- Added a regression test that creates `content/posts/folder.md/` (a directory) and asserts `getPostBySlug("folder")` returns `null`. 
- Kept existing front-matter validation and behavior unchanged for normal file posts.

### Testing
- Ran the targeted tests with `yarn test src/lib/__tests__/blogApi.test.ts`, which passed. 
- Ran the full test suite with `yarn test`, and all test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2bc03bc10832380207b357e7b3915)