### PR TITLE
Simplify helper-heavy component and content utilities

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-import { Chip, chipClassName } from "@/components/Chip";
+import { Chip } from "@/components/Chip";
 
 type BadgeTone = "info" | "success" | "warning";
 
@@ -16,18 +16,10 @@ const toneClasses: Record<BadgeTone, string> = {
   warning: "border-accent-warning/40 bg-accent-warning/15 text-accent-warning",
 };
 
-function badgeClassName({
-  tone = "info",
-  className = "",
-}: {
-  tone?: BadgeTone;
-  className?: string;
-}) {
-  return chipClassName(`${toneClasses[tone]} ${className}`.trim());
-}
-
 export function Badge({ children, tone = "info", className = "" }: BadgeProps) {
   return (
-    <Chip className={badgeClassName({ tone, className })}>{children}</Chip>
+    <Chip className={`${toneClasses[tone]} ${className}`.trim()}>
+      {children}
+    </Chip>
   );
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -7,10 +7,6 @@ export interface CardProps {
   className?: string;
 }
 
-/**
- * Reusable card component with consistent styling
- * @param className - Additional custom classes to apply
- */
 export function Card({ children, className = "" }: CardProps) {
   return (
     <Surface padding="md" className={className}>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,16 +1,16 @@
 import { ReactNode } from "react";
 
-import { Chip, chipClassName } from "@/components/Chip";
+import { Chip } from "@/components/Chip";
 
 type TagProps = {
   children: ReactNode;
   className?: string;
 };
 
-function tagClassName(className = "") {
-  return chipClassName(`border-white/20 text-gray-200 ${className}`.trim());
-}
-
 export function Tag({ children, className = "" }: TagProps) {
-  return <Chip className={tagClassName(className)}>{children}</Chip>;
+  return (
+    <Chip className={`border-white/20 text-gray-200 ${className}`.trim()}>
+      {children}
+    </Chip>
+  );
 }

--- a/src/components/__tests__/Badge.test.tsx
+++ b/src/components/__tests__/Badge.test.tsx
@@ -6,7 +6,14 @@ describe("Badge", () => {
   it("uses default info tone", () => {
     render(<Badge>Status</Badge>);
 
-    expect(screen.getByText("Status")).toHaveClass("text-white");
+    const badge = screen.getByText("Status");
+
+    expect(badge).toHaveClass("text-white");
+    expect(
+      badge.className
+        .split(/\s+/)
+        .filter((className) => className === "inline-flex")
+    ).toHaveLength(1);
   });
 
   it("supports success tone", () => {

--- a/src/components/__tests__/Tag.test.tsx
+++ b/src/components/__tests__/Tag.test.tsx
@@ -8,5 +8,10 @@ describe("Tag", () => {
 
     const tag = screen.getByText("TypeScript");
     expect(tag).toHaveClass("rounded-full", "border", "text-xs");
+    expect(
+      tag.className
+        .split(/\s+/)
+        .filter((className) => className === "inline-flex")
+    ).toHaveLength(1);
   });
 });

--- a/src/lib/coverVariants.ts
+++ b/src/lib/coverVariants.ts
@@ -1,7 +1,7 @@
 import {
   getCoverVariantProfile,
-  getImageVariantPath,
   getImageVariantSourceSet,
+  getLargestImageVariant,
 } from "@/lib/imageVariantManifest";
 
 export type CoverVariant = "card" | "hero";
@@ -18,17 +18,5 @@ export function getCoverVariantPath(
   src: string | undefined,
   variant: CoverVariant
 ): string | undefined {
-  if (!src) {
-    return undefined;
-  }
-
-  const variantNames = getCoverVariantProfile(variant);
-  for (let index = variantNames.length - 1; index >= 0; index -= 1) {
-    const variantPath = getImageVariantPath(src, variantNames[index]);
-    if (variantPath) {
-      return variantPath;
-    }
-  }
-
-  return undefined;
+  return getLargestImageVariant(src, getCoverVariantProfile(variant))?.path;
 }

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -18,15 +18,15 @@ const FEED_DESCRIPTION =
 const FEED_IMAGE_URL = `${BASE_URL}/icon4.png`;
 
 export function buildRssFeedXml(posts: readonly FeedPost[]): string {
-  const lastUpdated =
-    posts.length > 0
-      ? posts.reduce((latest, post) => {
-          const candidate = post.updated || post.date;
-          return new Date(candidate).getTime() > new Date(latest).getTime()
-            ? candidate
-            : latest;
-        }, posts[0].updated || posts[0].date)
-      : new Date().toISOString();
+  const firstPost = posts[0];
+  const lastUpdated = firstPost
+    ? posts.reduce((latest, post) => {
+        const candidate = post.updated ?? post.date;
+        return new Date(candidate).getTime() > new Date(latest).getTime()
+          ? candidate
+          : latest;
+      }, firstPost.updated ?? firstPost.date)
+    : new Date().toISOString();
 
   const feed = new Feed({
     title: FEED_TITLE,
@@ -48,7 +48,7 @@ export function buildRssFeedXml(posts: readonly FeedPost[]): string {
       id: url,
       link: url,
       date: new Date(post.date),
-      category: (post.tags || []).map((tag) => ({ name: tag })),
+      category: post.tags?.map((tag) => ({ name: tag })) ?? [],
       ...(post.excerpt ? { description: post.excerpt } : {}),
     });
   }

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -86,20 +86,14 @@ type HastNode = {
 
 function visitNodes(node: HastNode, visitor: (node: HastNode) => void) {
   visitor(node);
-  for (const child of node.children || []) {
+  for (const child of node.children ?? []) {
     visitNodes(child, visitor);
   }
 }
 
-function getImageSourceSet(src: string) {
-  return getImageVariantSourceSet(src, getInlineContentVariantProfile());
-}
-
-function getPrimaryImageVariant(src: string) {
-  return getLargestImageVariant(src, getInlineContentVariantProfile());
-}
-
 function rehypeResponsiveImages() {
+  const inlineContentVariantProfile = getInlineContentVariantProfile();
+
   return (tree: Root) => {
     visitNodes(tree as unknown as HastNode, (node) => {
       if (node.type !== "element" || node.tagName !== "img") {
@@ -112,7 +106,10 @@ function rehypeResponsiveImages() {
         return;
       }
 
-      const primaryVariant = getPrimaryImageVariant(src);
+      const primaryVariant = getLargestImageVariant(
+        src,
+        inlineContentVariantProfile
+      );
       const primarySrc = primaryVariant?.path || src;
       properties.src = primarySrc;
       properties.loading = "lazy";
@@ -120,7 +117,7 @@ function rehypeResponsiveImages() {
       properties.fetchPriority = "low";
       properties.sizes = "(min-width: 1024px) 896px, 100vw";
 
-      const srcSet = getImageSourceSet(src);
+      const srcSet = getImageVariantSourceSet(src, inlineContentVariantProfile);
       if (srcSet) {
         properties.srcSet = srcSet;
       }

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -8,14 +8,12 @@ const SITE_NAME = "Alex Leung";
 const DEFAULT_LOCALE = "en_CA";
 
 function normalizeImages(images: SeoImage[] | undefined): SeoImage[] {
-  if (!images || images.length === 0) {
-    return [];
-  }
-
-  return images.map((image) => ({
-    ...image,
-    url: toAbsoluteUrl(image.url),
-  }));
+  return (
+    images?.map((image) => ({
+      ...image,
+      url: toAbsoluteUrl(image.url),
+    })) ?? []
+  );
 }
 
 export function buildPageMetadata(input: SeoInput): Metadata {


### PR DESCRIPTION
## Summary
- remove pass-through helpers and duplicated chip class composition in `Tag` and `Badge`
- simplify cover/image/feed/SEO utility code by delegating to existing helpers and collapsing verbose branches
- add regression assertions to confirm chip base classes are only applied once

## Validation
- `yarn test --runInBand src/components/__tests__/Tag.test.tsx src/components/__tests__/Badge.test.tsx src/components/__tests__/Chip.test.tsx src/components/__tests__/Card.test.tsx src/lib/__tests__/coverVariants.test.ts src/lib/__tests__/feed.test.ts src/lib/seo/__tests__/metadata.test.ts`
- `yarn typecheck`
- `yarn lint`