### PR TITLE
ci: enable Yarn dependency caching in GitHub Actions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -17,26 +17,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |
           corepack enable
           corepack install
 
-      - name: ♻️ Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.yarn/berry/cache
-            .yarn/cache
-            .yarn/unplugged
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: 🏗️ Install Dependencies
         run: |

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -20,13 +20,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: yarn
-          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |
           corepack enable
           corepack install
+
+      - name: ♻️ Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.yarn/berry/cache
+            .yarn/cache
+            .yarn/unplugged
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: 🏗️ Install Dependencies
         run: |

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -16,6 +16,9 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v4
 
+      - name: 🧰 Enable Corepack
+        run: corepack enable
+
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -27,7 +30,6 @@ jobs:
         run: |
           corepack enable
           corepack install
-
 
       - name: 🏗️ Install Dependencies
         run: |

--- a/.github/workflows/perf-checks.yml
+++ b/.github/workflows/perf-checks.yml
@@ -20,26 +20,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |
           corepack enable
           corepack install
 
-      - name: ♻️ Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.yarn/berry/cache
-            .yarn/cache
-            .yarn/unplugged
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: 🏗️ Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/perf-checks.yml
+++ b/.github/workflows/perf-checks.yml
@@ -23,13 +23,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: yarn
-          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |
           corepack enable
           corepack install
+
+      - name: ♻️ Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.yarn/berry/cache
+            .yarn/cache
+            .yarn/unplugged
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: 🏗️ Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/perf-checks.yml
+++ b/.github/workflows/perf-checks.yml
@@ -19,6 +19,9 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v4
 
+      - name: 🧰 Enable Corepack
+        run: corepack enable
+
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -30,7 +33,6 @@ jobs:
         run: |
           corepack enable
           corepack install
-
 
       - name: 🏗️ Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/perf-checks.yml
+++ b/.github/workflows/perf-checks.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,13 +22,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: yarn
-          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |
           corepack enable
           corepack install
+
+      - name: ♻️ Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.yarn/berry/cache
+            .yarn/cache
+            .yarn/unplugged
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: 🏗️ Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,6 +18,9 @@ jobs:
       - name: 📦 Checkout
         uses: actions/checkout@v4
 
+      - name: 🧰 Enable Corepack
+        run: corepack enable
+
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -29,7 +32,6 @@ jobs:
         run: |
           corepack enable
           corepack install
-
 
       - name: 🏗️ Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,26 +19,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🔧 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: 🧰 Enable Corepack (Yarn v4)
         run: |
           corepack enable
           corepack install
 
-      - name: ♻️ Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.yarn/berry/cache
-            .yarn/cache
-            .yarn/unplugged
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: 🏗️ Install Dependencies
         run: yarn install --immutable


### PR DESCRIPTION
## Summary
- upgrade `actions/setup-node` from `@v4` to `@v6` in all workflows
- enable native Yarn caching via `cache: yarn` and `cache-dependency-path: yarn.lock`
- remove explicit `actions/cache` steps
- add a minimal pre-step (`corepack enable`) before `setup-node` so Yarn cache resolution works with Yarn 4 projects that declare `packageManager`

## Why
The direct `setup-node` cache flow was failing because the action tried to query cache paths via global Yarn 1 before Corepack/Yarn 4 was active. Enabling Corepack before `setup-node` keeps the workflow minimal and allows native cache support to work without custom cache steps.

## Validation
- PR Checks: pass (1m7s)
  - https://github.com/aclyx/alexleung.ca/actions/runs/23034865488/job/66900614053
- Performance Checks (Lighthouse Baseline): pass (4m58s)
  - https://github.com/aclyx/alexleung.ca/actions/runs/23034865482/job/66900614047

## References
- https://github.com/actions/setup-node/issues/899
- https://github.com/actions/setup-node/issues/904
