### PR TITLE
chore: adopt Next.js Google Analytics integration

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -15,3 +15,10 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: jest.fn(),
   })),
 });
+
+if (!window.performance.mark) {
+  Object.defineProperty(window.performance, "mark", {
+    writable: true,
+    value: jest.fn(),
+  });
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -17,6 +17,8 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 if (!window.performance.mark) {
+  // `@next/third-parties` records feature usage on mount, but JSDOM doesn't
+  // implement `performance.mark`, so layout tests need a lightweight shim.
   Object.defineProperty(window.performance, "mark", {
     writable: true,
     value: jest.fn(),

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "deploy": "gh-pages -d out"
   },
   "dependencies": {
+    "@next/third-parties": "^16.1.6",
     "feed": "^5.2.0",
     "next": "^16.1.6",
     "react": "^19.2.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -90,7 +90,6 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
       <body className={`${lato.className} flex min-h-screen flex-col`}>
-        <GoogleAnalytics gaId="G-KJXZVT8X1E" />
         <AppBackground />
         <Header />
         <SocialLinks />
@@ -100,6 +99,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
         <JsonLd item={buildWebsiteSchema({ description })} />
         <JsonLd item={buildProfessionalServiceSchema({ description })} />
       </body>
+      <GoogleAnalytics gaId="G-KJXZVT8X1E" />
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { JsonLd } from "react-schemaorg";
 import type { Metadata, Viewport } from "next";
 import { Lato } from "next/font/google";
 
+import { GoogleAnalytics } from "@next/third-parties/google";
+
 import { AppBackground } from "@/components/AppBackground";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
@@ -88,6 +90,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
       <body className={`${lato.className} flex min-h-screen flex-col`}>
+        <GoogleAnalytics gaId="G-KJXZVT8X1E" />
         <AppBackground />
         <Header />
         <SocialLinks />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,6 +1524,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/third-parties@npm:^16.1.6":
+  version: 16.1.6
+  resolution: "@next/third-parties@npm:16.1.6"
+  dependencies:
+    third-party-capital: "npm:1.0.20"
+  peerDependencies:
+    next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+  checksum: 10c0/51a00685d1d1762e20da30409b231e2f043e4fb208e743c2a48b7035ad6f81f06d315162276d85464f431fc37d055b4870e662ac3d715ea91b23c62783b71f6e
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -2606,6 +2618,7 @@ __metadata:
   dependencies:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.7.1"
     "@lhci/cli": "npm:^0.15.1"
+    "@next/third-parties": "npm:^16.1.6"
     "@tailwindcss/postcss": "npm:^4.2.1"
     "@tailwindcss/typography": "npm:^0.5.19"
     "@testing-library/dom": "npm:^10.4.1"
@@ -8896,6 +8909,13 @@ __metadata:
   dependencies:
     b4a: "npm:^1.6.4"
   checksum: 10c0/929938ed154fbadb660a7f3d1aca30b7e53649a731af7583168fcfba0c158046325d35d945926e2a512bb62d1a49a7818151c987ea38b48853f01e1615722fc5
+  languageName: node
+  linkType: hard
+
+"third-party-capital@npm:1.0.20":
+  version: 1.0.20
+  resolution: "third-party-capital@npm:1.0.20"
+  checksum: 10c0/7f45ff156ec9d7e2957a5b39061be22b780ffbd2d93c127252d908e2bff6cdd09f827a95909d457c8096e036f155006a38e355a06ee11cb6d63c7f4b150bbfb0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- replace the manual GA snippet with Next.js' `GoogleAnalytics` integration from `@next/third-parties/google`
- place the analytics component in the root layout using the documented app-router pattern
- add the dependency and Jest `performance.mark` shim needed for the integration to pass tests in CI

## Testing
- yarn test --runInBand
- yarn lint
- yarn typecheck
- yarn build