### PR TITLE
Simplify blog API and JSON-LD helpers

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-import { Chip, chipClassName } from "@/components/Chip";
+import { Chip } from "@/components/Chip";
 
 type BadgeTone = "info" | "success" | "warning";
 
@@ -16,18 +16,10 @@ const toneClasses: Record<BadgeTone, string> = {
   warning: "border-accent-warning/40 bg-accent-warning/15 text-accent-warning",
 };
 
-function badgeClassName({
-  tone = "info",
-  className = "",
-}: {
-  tone?: BadgeTone;
-  className?: string;
-}) {
-  return chipClassName(`${toneClasses[tone]} ${className}`.trim());
-}
-
 export function Badge({ children, tone = "info", className = "" }: BadgeProps) {
   return (
-    <Chip className={badgeClassName({ tone, className })}>{children}</Chip>
+    <Chip className={`${toneClasses[tone]} ${className}`.trim()}>
+      {children}
+    </Chip>
   );
 }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -7,10 +7,6 @@ export interface CardProps {
   className?: string;
 }
 
-/**
- * Reusable card component with consistent styling
- * @param className - Additional custom classes to apply
- */
 export function Card({ children, className = "" }: CardProps) {
   return (
     <Surface padding="md" className={className}>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,16 +1,16 @@
 import { ReactNode } from "react";
 
-import { Chip, chipClassName } from "@/components/Chip";
+import { Chip } from "@/components/Chip";
 
 type TagProps = {
   children: ReactNode;
   className?: string;
 };
 
-function tagClassName(className = "") {
-  return chipClassName(`border-white/20 text-gray-200 ${className}`.trim());
-}
-
 export function Tag({ children, className = "" }: TagProps) {
-  return <Chip className={tagClassName(className)}>{children}</Chip>;
+  return (
+    <Chip className={`border-white/20 text-gray-200 ${className}`.trim()}>
+      {children}
+    </Chip>
+  );
 }

--- a/src/components/__tests__/Badge.test.tsx
+++ b/src/components/__tests__/Badge.test.tsx
@@ -6,7 +6,14 @@ describe("Badge", () => {
   it("uses default info tone", () => {
     render(<Badge>Status</Badge>);
 
-    expect(screen.getByText("Status")).toHaveClass("text-white");
+    const badge = screen.getByText("Status");
+
+    expect(badge).toHaveClass("text-white");
+    expect(
+      badge.className
+        .split(/\s+/)
+        .filter((className) => className === "inline-flex")
+    ).toHaveLength(1);
   });
 
   it("supports success tone", () => {

--- a/src/components/__tests__/Tag.test.tsx
+++ b/src/components/__tests__/Tag.test.tsx
@@ -8,5 +8,10 @@ describe("Tag", () => {
 
     const tag = screen.getByText("TypeScript");
     expect(tag).toHaveClass("rounded-full", "border", "text-xs");
+    expect(
+      tag.className
+        .split(/\s+/)
+        .filter((className) => className === "inline-flex")
+    ).toHaveLength(1);
   });
 });

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -138,6 +138,18 @@ describe("blogApi front matter validation", () => {
     ).toEqual(["draft"]);
   });
 
+  test("throws when callers request unsupported post fields", async () => {
+    const tempDir = setupTempPosts({
+      published: `---\ntitle: "Published"\ndate: "2026-02-16"\n---\nBody`,
+    });
+
+    const { getAllPosts } = await loadBlogApiAtCwd(tempDir);
+
+    expect(() => getAllPosts(["slug", "notAField" as never])).toThrow(
+      /Unsupported post field requested: notAField/
+    );
+  });
+
   test("throws when seriesOrder duplicates within the same series", async () => {
     const tempDir = setupTempPosts({
       a: `---\ntitle: "A"\ndate: "2026-02-16"\nseries: "s"\nseriesOrder: 1\n---\nBody`,

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -105,18 +105,38 @@ const PostFrontMatterSchema = z
   })
   .strict();
 
-function isPostField(value: string): value is PostField {
-  return POST_FIELDS.includes(value as PostField);
-}
-
-function isPostFieldSelection(value: unknown): value is readonly PostField[] {
-  return Array.isArray(value);
-}
-
 function assertValidDate(date: string, slug: string, key: "date" | "updated") {
   if (Number.isNaN(Date.parse(date))) {
     throw new Error(`Invalid ${key} in post "${slug}": ${date}`);
   }
+}
+
+function resolvePostQuery<T extends PostField>(
+  fieldsOrOptions?: readonly T[] | PostQueryOptions,
+  maybeOptions?: PostQueryOptions
+): {
+  fields: readonly T[] | undefined;
+  options: PostQueryOptions | undefined;
+} {
+  if (!Array.isArray(fieldsOrOptions)) {
+    return {
+      fields: undefined,
+      options: fieldsOrOptions as PostQueryOptions | undefined,
+    };
+  }
+
+  const invalidField = fieldsOrOptions.find(
+    (field) => !POST_FIELDS.includes(field as PostField)
+  );
+
+  if (invalidField) {
+    throw new Error(`Unsupported post field requested: ${invalidField}`);
+  }
+
+  return {
+    fields: fieldsOrOptions,
+    options: maybeOptions,
+  };
 }
 
 function parseFrontMatter(
@@ -260,17 +280,6 @@ type GetRelatedPostsOptions = {
   includeDrafts?: boolean;
 };
 
-function toRelatedPost(post: Post): RelatedPost {
-  return {
-    slug: post.slug,
-    title: post.title,
-    date: post.date,
-    excerpt: post.excerpt,
-    coverImage: post.coverImage,
-    tags: post.tags,
-  };
-}
-
 function getRelatedScore(target: Post, candidate: Post): number {
   const targetTags = new Set(target.tags);
   const sharedTagCount = candidate.tags.filter((tag) =>
@@ -324,12 +333,7 @@ export function getPostBySlug<T extends PostField>(
   maybeOptions?: PostQueryOptions
 ) {
   const post = getCachedPostBySlug(slug);
-  const fields = isPostFieldSelection(fieldsOrOptions)
-    ? (fieldsOrOptions as readonly T[])
-    : undefined;
-  const options = isPostFieldSelection(fieldsOrOptions)
-    ? maybeOptions
-    : fieldsOrOptions;
+  const { fields, options } = resolvePostQuery(fieldsOrOptions, maybeOptions);
 
   const includeDrafts = options?.includeDrafts ?? false;
 
@@ -339,12 +343,6 @@ export function getPostBySlug<T extends PostField>(
 
   if (!fields || fields.length === 0) {
     return post;
-  }
-
-  const invalidField = fields.find((field) => !isPostField(field));
-
-  if (invalidField) {
-    throw new Error(`Unsupported post field requested: ${invalidField}`);
   }
 
   return pickPostFields(post, fields);
@@ -359,13 +357,7 @@ export function getAllPosts<T extends PostField>(
   fieldsOrOptions?: readonly T[] | PostQueryOptions,
   maybeOptions?: PostQueryOptions
 ) {
-  const fields = isPostFieldSelection(fieldsOrOptions)
-    ? (fieldsOrOptions as readonly T[])
-    : undefined;
-  const options = isPostFieldSelection(fieldsOrOptions)
-    ? maybeOptions
-    : fieldsOrOptions;
-
+  const { fields, options } = resolvePostQuery(fieldsOrOptions, maybeOptions);
   const includeDrafts = options?.includeDrafts ?? false;
   const posts = getCachedAllPosts().filter(
     (post) => includeDrafts || !post.draft
@@ -373,12 +365,6 @@ export function getAllPosts<T extends PostField>(
 
   if (!fields || fields.length === 0) {
     return posts;
-  }
-
-  const invalidField = fields.find((field) => !isPostField(field));
-
-  if (invalidField) {
-    throw new Error(`Unsupported post field requested: ${invalidField}`);
   }
 
   return posts.map((post) => pickPostFields(post, fields));
@@ -403,9 +389,8 @@ export function getRelatedPosts(
     return [];
   }
 
-  const candidates = allPosts.filter((post) => post.slug !== slug);
-
-  const scored = candidates
+  const scored = allPosts
+    .filter((post) => post.slug !== slug)
     .map((candidate) => ({
       post: candidate,
       score: getRelatedScore(target, candidate),
@@ -433,5 +418,12 @@ export function getRelatedPosts(
           new Date(b.post.date).getTime() - new Date(a.post.date).getTime()
       );
 
-  return ranked.slice(0, limit).map((entry) => toRelatedPost(entry.post));
+  return ranked.slice(0, limit).map(({ post }) => ({
+    slug: post.slug,
+    title: post.title,
+    date: post.date,
+    excerpt: post.excerpt,
+    coverImage: post.coverImage,
+    tags: post.tags,
+  }));
 }

--- a/src/lib/coverVariants.ts
+++ b/src/lib/coverVariants.ts
@@ -1,7 +1,7 @@
 import {
   getCoverVariantProfile,
-  getImageVariantPath,
   getImageVariantSourceSet,
+  getLargestImageVariant,
 } from "@/lib/imageVariantManifest";
 
 export type CoverVariant = "card" | "hero";
@@ -18,17 +18,5 @@ export function getCoverVariantPath(
   src: string | undefined,
   variant: CoverVariant
 ): string | undefined {
-  if (!src) {
-    return undefined;
-  }
-
-  const variantNames = getCoverVariantProfile(variant);
-  for (let index = variantNames.length - 1; index >= 0; index -= 1) {
-    const variantPath = getImageVariantPath(src, variantNames[index]);
-    if (variantPath) {
-      return variantPath;
-    }
-  }
-
-  return undefined;
+  return getLargestImageVariant(src, getCoverVariantProfile(variant))?.path;
 }

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -18,15 +18,15 @@ const FEED_DESCRIPTION =
 const FEED_IMAGE_URL = `${BASE_URL}/icon4.png`;
 
 export function buildRssFeedXml(posts: readonly FeedPost[]): string {
-  const lastUpdated =
-    posts.length > 0
-      ? posts.reduce((latest, post) => {
-          const candidate = post.updated || post.date;
-          return new Date(candidate).getTime() > new Date(latest).getTime()
-            ? candidate
-            : latest;
-        }, posts[0].updated || posts[0].date)
-      : new Date().toISOString();
+  const firstPost = posts[0];
+  const lastUpdated = firstPost
+    ? posts.reduce((latest, post) => {
+        const candidate = post.updated ?? post.date;
+        return new Date(candidate).getTime() > new Date(latest).getTime()
+          ? candidate
+          : latest;
+      }, firstPost.updated ?? firstPost.date)
+    : new Date().toISOString();
 
   const feed = new Feed({
     title: FEED_TITLE,
@@ -48,7 +48,7 @@ export function buildRssFeedXml(posts: readonly FeedPost[]): string {
       id: url,
       link: url,
       date: new Date(post.date),
-      category: (post.tags || []).map((tag) => ({ name: tag })),
+      category: post.tags?.map((tag) => ({ name: tag })) ?? [],
       ...(post.excerpt ? { description: post.excerpt } : {}),
     });
   }

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -86,20 +86,14 @@ type HastNode = {
 
 function visitNodes(node: HastNode, visitor: (node: HastNode) => void) {
   visitor(node);
-  for (const child of node.children || []) {
+  for (const child of node.children ?? []) {
     visitNodes(child, visitor);
   }
 }
 
-function getImageSourceSet(src: string) {
-  return getImageVariantSourceSet(src, getInlineContentVariantProfile());
-}
-
-function getPrimaryImageVariant(src: string) {
-  return getLargestImageVariant(src, getInlineContentVariantProfile());
-}
-
 function rehypeResponsiveImages() {
+  const inlineContentVariantProfile = getInlineContentVariantProfile();
+
   return (tree: Root) => {
     visitNodes(tree as unknown as HastNode, (node) => {
       if (node.type !== "element" || node.tagName !== "img") {
@@ -112,7 +106,10 @@ function rehypeResponsiveImages() {
         return;
       }
 
-      const primaryVariant = getPrimaryImageVariant(src);
+      const primaryVariant = getLargestImageVariant(
+        src,
+        inlineContentVariantProfile
+      );
       const primarySrc = primaryVariant?.path || src;
       properties.src = primarySrc;
       properties.loading = "lazy";
@@ -120,7 +117,7 @@ function rehypeResponsiveImages() {
       properties.fetchPriority = "low";
       properties.sizes = "(min-width: 1024px) 896px, 100vw";
 
-      const srcSet = getImageSourceSet(src);
+      const srcSet = getImageVariantSourceSet(src, inlineContentVariantProfile);
       if (srcSet) {
         properties.srcSet = srcSet;
       }

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -79,6 +79,16 @@ function buildPersonReference() {
   };
 }
 
+type PostSchemaInput = {
+  coverImage?: string;
+  date: string;
+  description?: string;
+  slug: string;
+  tags: string[];
+  title: string;
+  updated?: string;
+};
+
 function buildBasePageSchema<TPageType extends string>({
   description,
   pageType,
@@ -101,6 +111,31 @@ function buildBasePageSchema<TPageType extends string>({
     isPartOf: {
       "@type": "WebSite" as const,
       "@id": toAbsoluteUrl(WEBSITE_ID),
+    },
+  };
+}
+
+function buildBasePostSchema(input: PostSchemaInput) {
+  const canonicalPostUrl = toCanonical(`/blog/${input.slug}`);
+  const personReference = buildPersonReference();
+
+  return {
+    canonicalPostUrl,
+    schema: {
+      url: canonicalPostUrl,
+      headline: input.title,
+      description: input.description,
+      keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
+      image: input.coverImage ? [toAbsoluteUrl(input.coverImage)] : undefined,
+      datePublished: new Date(input.date).toISOString(),
+      dateModified: new Date(input.updated ?? input.date).toISOString(),
+      author: personReference,
+      publisher: personReference,
+      inLanguage: "en-CA",
+      mainEntityOfPage: {
+        "@type": "WebPage" as const,
+        "@id": canonicalPostUrl,
+      },
     },
   };
 }
@@ -205,39 +240,16 @@ export function buildBlogItemListSchema(
   };
 }
 
-export function buildBlogPostingSchema(input: {
-  coverImage?: string;
-  date: string;
-  description?: string;
-  slug: string;
-  tags: string[];
-  title: string;
-  updated?: string;
-}): WithContext<BlogPosting> {
-  const canonicalPostUrl = toCanonical(`/blog/${input.slug}`);
+export function buildBlogPostingSchema(
+  input: PostSchemaInput
+): WithContext<BlogPosting> {
+  const { canonicalPostUrl, schema } = buildBasePostSchema(input);
 
   return {
     "@context": "https://schema.org" as const,
     "@type": "BlogPosting",
     "@id": `${canonicalPostUrl}#blogposting`,
-    url: canonicalPostUrl,
-    headline: input.title,
-    description: input.description,
-    keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
-    image: input.coverImage ? [toAbsoluteUrl(input.coverImage)] : undefined,
-    datePublished: new Date(input.date).toISOString(),
-    dateModified: new Date(input.updated || input.date).toISOString(),
-    author: {
-      ...buildPersonReference(),
-    },
-    publisher: {
-      ...buildPersonReference(),
-    },
-    inLanguage: "en-CA",
-    mainEntityOfPage: {
-      "@type": "WebPage",
-      "@id": canonicalPostUrl,
-    },
+    ...schema,
     isPartOf: {
       "@type": "Blog",
       "@id": toAbsoluteUrl("/blog/#blog"),
@@ -246,39 +258,16 @@ export function buildBlogPostingSchema(input: {
   };
 }
 
-export function buildArticleSchema(input: {
-  coverImage?: string;
-  date: string;
-  description?: string;
-  slug: string;
-  tags: string[];
-  title: string;
-  updated?: string;
-}): WithContext<Article> {
-  const canonicalPostUrl = toCanonical(`/blog/${input.slug}`);
+export function buildArticleSchema(
+  input: PostSchemaInput
+): WithContext<Article> {
+  const { canonicalPostUrl, schema } = buildBasePostSchema(input);
 
   return {
     "@context": "https://schema.org" as const,
     "@type": "Article",
     "@id": `${canonicalPostUrl}#article`,
-    url: canonicalPostUrl,
-    headline: input.title,
-    description: input.description,
-    keywords: input.tags.length > 0 ? input.tags.join(", ") : undefined,
-    image: input.coverImage ? [toAbsoluteUrl(input.coverImage)] : undefined,
-    datePublished: new Date(input.date).toISOString(),
-    dateModified: new Date(input.updated || input.date).toISOString(),
-    author: {
-      ...buildPersonReference(),
-    },
-    publisher: {
-      ...buildPersonReference(),
-    },
-    inLanguage: "en-CA",
-    mainEntityOfPage: {
-      "@type": "WebPage",
-      "@id": canonicalPostUrl,
-    },
+    ...schema,
   };
 }
 

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -8,14 +8,12 @@ const SITE_NAME = "Alex Leung";
 const DEFAULT_LOCALE = "en_CA";
 
 function normalizeImages(images: SeoImage[] | undefined): SeoImage[] {
-  if (!images || images.length === 0) {
-    return [];
-  }
-
-  return images.map((image) => ({
-    ...image,
-    url: toAbsoluteUrl(image.url),
-  }));
+  return (
+    images?.map((image) => ({
+      ...image,
+      url: toAbsoluteUrl(image.url),
+    })) ?? []
+  );
 }
 
 export function buildPageMetadata(input: SeoInput): Metadata {


### PR DESCRIPTION
## Summary
- collapse duplicated overload parsing and field validation in `src/lib/blogApi.ts`
- inline related-post shaping and simplify the ranking pipeline
- extract shared post schema assembly in `src/lib/seo/jsonld.ts` and add coverage for unsupported field selection

## Validation
- `yarn test --runInBand src/lib/__tests__/blogApi.test.ts src/lib/seo/__tests__/jsonld.test.ts`
- `yarn typecheck`
- `yarn lint`