### PR TITLE
Fix header focus behavior on initial render

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,7 @@ export default function Header() {
   const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const hasMountedRef = useRef(false);
 
   // Prevent body scroll when menu is open
   useEffect(() => {
@@ -54,6 +55,11 @@ export default function Header() {
   }, [isMenuOpen]);
 
   useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
     if (!isMenuOpen) {
       menuButtonRef.current?.focus();
     }

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -151,6 +151,14 @@ describe("Header", () => {
   });
 
   describe("Accessibility", () => {
+    it("should not move focus to the menu button on initial render", () => {
+      render(<Header />);
+
+      const button = screen.getByRole("button", { name: "Open menu" });
+
+      expect(button).not.toHaveFocus();
+    });
+
     it("should have proper aria-label on menu button", () => {
       render(<Header />);
       expect(


### PR DESCRIPTION
### Motivation
- The mobile menu button was being focused on initial mount because the focus-restoration `useEffect` ran when `isMenuOpen` was `false`, which can steal focus and harm accessibility.
- The change aims to prevent unintended focus shifts while preserving the existing behavior that returns focus to the menu button when the menu closes.

### Description
- Add a mount guard `hasMountedRef` in `src/components/Header.tsx` so the focus-restoration effect only runs after the first render cycle.  
- Keep the existing behavior of focusing the menu button when the menu closes (e.g., after Escape or programmatic close).  
- Add a regression test `it("should not move focus to the menu button on initial render")` in `src/components/__tests__/Header.test.tsx` to assert the button does not receive focus on initial render.

### Testing
- Ran the focused test file with `yarn test src/components/__tests__/Header.test.tsx --runInBand` and it passed (`17 tests` in that suite passed).  
- Ran the full test suite with `yarn test --runInBand` and all suites passed (`29 test suites`, `116 tests` passed).  
- No automated test failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7dc2e3ba08323868f764962d313cc)