### PR TITLE
Fix deploy marker SHA matching in live smoke wait

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -129,7 +129,7 @@ jobs:
           for attempt in $(seq 1 30); do
             deploy_marker="$(curl --fail --silent --show-error --location https://alexleung.ca/deploy-meta.json || true)"
 
-            if printf '%s' "${deploy_marker}" | grep -Fq "\"sha\":\"${GITHUB_SHA}\""; then
+            if printf '%s' "${deploy_marker}" | grep -Eq "\"sha\"[[:space:]]*:[[:space:]]*\"${GITHUB_SHA}\""; then
               exit 0
             fi
 


### PR DESCRIPTION
## Summary
- fix the deploy marker wait condition in the post-deploy Playwright live smoke job
- allow whitespace around the `sha` field so the workflow matches the actual JSON served by `deploy-meta.json`

## Problem
The workflow was checking for `"sha":"<sha>"`, but the generated JSON is formatted with spaces as `"sha": "<sha>"`. That caused the live smoke wait loop to miss the correct deployed revision even when `deploy-meta.json` was already live.

## Validation
- yarn lint