### PR TITLE
Normalize internal links to trailing slashes

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,4 +1,5 @@
-name: Build and Deploy
+name: Build and Deploy to GitHub Pages
+run-name: Build and Deploy to GitHub Pages
 on:
   push:
     branches:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,5 +1,5 @@
-name: Build and Deploy to GitHub Pages
-run-name: Build and Deploy to GitHub Pages
+name: Build and Deploy
+run-name: Build and Deploy
 on:
   push:
     branches:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,5 +1,4 @@
 name: Build and Deploy
-run-name: Build and Deploy
 on:
   push:
     branches:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ yarn deploy           # Build and deploy to GitHub Pages
 - `trailingSlash: true` for GitHub Pages compatibility
 - `.nojekyll` in public/ prevents Jekyll processing of `_next/` assets
 - Images are unoptimized (required for static export)
+- Internal site-route links should use trailing slashes to match the export shape and avoid unnecessary GitHub Pages redirects (for example, `/about/` and `/blog/post-slug/`, not `/about` or `/blog/post-slug`)
+- Do not add trailing slashes to file-like endpoints or assets such as `/feed.xml`, `/robots.txt`, `/sitemap.xml`, or `/assets/...`
 
 ### Component Organization
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ If `profiles.cover` or `profiles.inlineContent` is missing in the manifest, runt
 - **SEO**: centralized metadata + JSON-LD helpers in `src/lib/seo`
 - **Content**: Markdown posts parsed and validated at build time
 
+### URL Convention
+
+- Site routes use trailing slashes to match `trailingSlash: true` and the GitHub Pages static export shape.
+- Prefer `/about/` and `/blog/post-slug/` over slashless internal links.
+- Keep internal links, canonical URLs, sitemap entries, and tests aligned with that convention.
+- Do not add trailing slashes to file-like endpoints or assets such as `/feed.xml`, `/robots.txt`, `/sitemap.xml`, or `/assets/...`.
+
 ### High-level Structure
 
 ```bash

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -201,7 +201,7 @@ export default async function Post({ params }: Props) {
                   {relatedPosts.map((relatedPost) => (
                     <Link
                       key={relatedPost.slug}
-                      href={`/blog/${relatedPost.slug}`}
+                      href={`/blog/${relatedPost.slug}/`}
                       className="block"
                     >
                       <Surface

--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -30,7 +30,7 @@ export function BlogPostCard({
 
   return (
     <Link
-      href={`/blog/${post.slug}`}
+      href={`/blog/${post.slug}/`}
       className={surfaceClassNames({
         interactive: true,
         className: `group mb-8 block p-6 ${className}`.trim(),

--- a/src/components/LatestWritingSection.tsx
+++ b/src/components/LatestWritingSection.tsx
@@ -33,7 +33,11 @@ export function LatestWritingSection({
       <SectionBlock title={title} spacing="lg">
         <div className="grid gap-4 md:grid-cols-3">
           {posts.map((post) => (
-            <Link key={post.slug} href={`/blog/${post.slug}`} className="block">
+            <Link
+              key={post.slug}
+              href={`/blog/${post.slug}/`}
+              className="block"
+            >
               <Surface
                 className="h-full p-4 transition-colors hover:border-white/30"
                 interactive

--- a/src/components/__tests__/BlogPostCard.test.tsx
+++ b/src/components/__tests__/BlogPostCard.test.tsx
@@ -2,6 +2,20 @@ import { render, screen } from "@testing-library/react";
 
 import { BlogPostCard } from "../BlogPostCard";
 
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
 describe("BlogPostCard", () => {
   it("renders title, excerpt, and link", () => {
     render(
@@ -19,7 +33,7 @@ describe("BlogPostCard", () => {
 
     expect(screen.getByRole("link", { name: "Test Post" })).toHaveAttribute(
       "href",
-      "/blog/test-post"
+      "/blog/test-post/"
     );
     expect(screen.getByText("A short summary")).toBeInTheDocument();
     expect(screen.getByText("January 1, 2026")).toBeInTheDocument();

--- a/src/components/__tests__/LatestWritingSection.test.tsx
+++ b/src/components/__tests__/LatestWritingSection.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+
+import { LatestWritingSection } from "../LatestWritingSection";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+describe("LatestWritingSection", () => {
+  it("renders post links with trailing slashes", () => {
+    render(
+      <LatestWritingSection
+        posts={[
+          {
+            slug: "test-post",
+            title: "Test Post",
+            date: "2026-01-01T00:00:00.000Z",
+            excerpt: "A short summary",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: /test post/i })).toHaveAttribute(
+      "href",
+      "/blog/test-post/"
+    );
+    expect(screen.getByRole("link", { name: /see all posts/i })).toHaveAttribute(
+      "href",
+      "/blog/"
+    );
+  });
+});

--- a/src/components/__tests__/LatestWritingSection.test.tsx
+++ b/src/components/__tests__/LatestWritingSection.test.tsx
@@ -35,9 +35,8 @@ describe("LatestWritingSection", () => {
       "href",
       "/blog/test-post/"
     );
-    expect(screen.getByRole("link", { name: /see all posts/i })).toHaveAttribute(
-      "href",
-      "/blog/"
-    );
+    expect(
+      screen.getByRole("link", { name: /see all posts/i })
+    ).toHaveAttribute("href", "/blog/");
   });
 });


### PR DESCRIPTION
## Summary
- Normalize internal blog links to trailing slashes
- Add coverage for the shared latest-writing links and the blog post card link shape
- Document the URL convention in AGENTS.md and README.md
- Fix the CI lint formatting miss

## Verification
- `yarn lint`
- `yarn test --runInBand src/components/__tests__/BlogPostCard.test.tsx src/components/__tests__/LatestWritingSection.test.tsx`
- `./node_modules/.bin/next build`