### PR TITLE
Refactor SEO schema and frontmatter validation

### DIFF
--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -48,60 +48,16 @@ export type Post = {
 
 const PostFrontMatterSchema = z
   .object({
-    title: z
-      .string()
-      .trim()
-      .min(1, "title must be a non-empty string")
-      .describe("Post title displayed in page heading and SEO metadata."),
-    date: z
-      .string()
-      .trim()
-      .min(1, "date must be a non-empty string")
-      .describe("Publish date string parsed and normalized to ISO format."),
-    updated: z
-      .string()
-      .trim()
-      .min(1)
-      .optional()
-      .describe("Optional last-updated date string for sitemap and metadata."),
-    excerpt: z
-      .string()
-      .trim()
-      .min(1)
-      .optional()
-      .describe("Optional short description shown in previews and metadata."),
-    coverImage: z
-      .string()
-      .trim()
-      .min(1)
-      .optional()
-      .describe("Optional public path for the post cover image asset."),
-    tags: z
-      .array(z.string().trim().min(1))
-      .default([])
-      .describe("Optional list of taxonomy tags for post grouping."),
-    series: z
-      .string()
-      .trim()
-      .min(1)
-      .optional()
-      .describe("Optional series name for grouping related posts."),
-    seriesOrder: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .describe("Optional order index for posts within a series."),
-    readingTimeMinutes: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .describe("Optional whole-minute estimate for article reading time."),
-    draft: z
-      .boolean()
-      .default(false)
-      .describe("Optional draft flag; defaults to published (`false`)."),
+    title: z.string().trim().min(1, "title must be a non-empty string"),
+    date: z.string().trim().min(1, "date must be a non-empty string"),
+    updated: z.string().trim().min(1).optional(),
+    excerpt: z.string().trim().min(1).optional(),
+    coverImage: z.string().trim().min(1).optional(),
+    tags: z.array(z.string().trim().min(1)).default([]),
+    series: z.string().trim().min(1).optional(),
+    seriesOrder: z.number().int().positive().optional(),
+    readingTimeMinutes: z.number().int().positive().optional(),
+    draft: z.boolean().default(false),
   })
   .strict();
 

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -12,6 +12,16 @@ import {
   buildWebsiteSchema,
 } from "@/lib/seo";
 
+function expectSchemaArray<T>(value: unknown): readonly T[] {
+  expect(Array.isArray(value)).toBe(true);
+  return value as readonly T[];
+}
+
+function expectSchemaObject<T>(value: T): Exclude<T, string> {
+  expect(typeof value).toBe("object");
+  return value as Exclude<T, string>;
+}
+
 describe("seo jsonld builders", () => {
   it("builds profile/contact/web page schemas with canonical IDs", () => {
     const profile = buildProfilePageSchema({
@@ -54,13 +64,12 @@ describe("seo jsonld builders", () => {
 
     expect(collection.mainEntity).toBeDefined();
 
-    const itemListElement = itemList.itemListElement;
-    expect(Array.isArray(itemListElement)).toBe(true);
+    const itemListElement = expectSchemaArray<{
+      name?: string;
+      position?: number;
+      url?: string;
+    }>(itemList.itemListElement);
     expect(itemList.numberOfItems).toBe(2);
-
-    if (!Array.isArray(itemListElement)) {
-      throw new Error("Expected itemListElement to be an array");
-    }
 
     expect(itemListElement[0]).toMatchObject({
       name: "Post 1",
@@ -84,12 +93,10 @@ describe("seo jsonld builders", () => {
       url: "https://alexleung.ca/assets/alex_vibing.webp",
     });
 
-    const hasPart = website.hasPart;
-    expect(Array.isArray(hasPart)).toBe(true);
-
-    if (!Array.isArray(hasPart)) {
-      throw new Error("Expected hasPart to be an array");
-    }
+    const hasPart = expectSchemaArray<{
+      "@type"?: string;
+      "@id"?: string;
+    }>(website.hasPart);
 
     expect(hasPart).toHaveLength(4);
     expect(hasPart[0]).toEqual({
@@ -99,13 +106,11 @@ describe("seo jsonld builders", () => {
   });
 
   it("builds person schema with richer identity metadata", () => {
-    const person = buildPersonSchema({
-      description: "Person description",
-    });
-
-    if (typeof person === "string") {
-      throw new Error("Expected person schema object");
-    }
+    const person = expectSchemaObject(
+      buildPersonSchema({
+        description: "Person description",
+      })
+    );
 
     expect(person.givenName).toBe("Alex");
     expect(person.familyName).toBe("Leung");
@@ -133,13 +138,11 @@ describe("seo jsonld builders", () => {
   });
 
   it("builds professional service schema with service areas", () => {
-    const service = buildProfessionalServiceSchema({
-      description: "Personal website of Alex Leung",
-    });
-
-    if (typeof service === "string") {
-      throw new Error("Expected service schema to be an object");
-    }
+    const service = expectSchemaObject(
+      buildProfessionalServiceSchema({
+        description: "Personal website of Alex Leung",
+      })
+    );
 
     expect(service["@type"]).toBe("Service");
     expect(service.areaServed).toEqual(

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -18,6 +18,23 @@ import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
 const PERSON_ID = "/#person";
 const WEBSITE_ID = "/#website";
 const ABOUT_PATH = "/about";
+const SITE_ROOT = toAbsoluteUrl("/").replace(/\/$/, "");
+const SOCIAL_PROFILES = [
+  "https://www.linkedin.com/in/aclyx",
+  "https://github.com/aclyx",
+  "https://www.x.com/aclyxpse",
+  "https://bsky.app/profile/alexleung.ca",
+  "https://www.instagram.com/rootpanda",
+  "https://scholar.google.ca/citations?user=NcOOsPIAAAAJ",
+];
+const PERSON_REFERENCE = {
+  "@type": "Person" as const,
+  "@id": toAbsoluteUrl(PERSON_ID),
+  name: "Alex Leung",
+  url: toCanonical(ABOUT_PATH),
+  image: toAbsoluteUrl("/assets/about_portrait.webp"),
+  sameAs: SOCIAL_PROFILES,
+};
 
 const GEO_SERVICE_AREAS = [
   {
@@ -57,28 +74,6 @@ const GEO_SERVICE_AREAS = [
   },
 ];
 
-function getSiteRoot(): string {
-  return toAbsoluteUrl("/").replace(/\/$/, "");
-}
-
-function buildPersonReference() {
-  return {
-    "@type": "Person" as const,
-    "@id": toAbsoluteUrl(PERSON_ID),
-    name: "Alex Leung",
-    url: toCanonical(ABOUT_PATH),
-    image: toAbsoluteUrl("/assets/about_portrait.webp"),
-    sameAs: [
-      "https://www.linkedin.com/in/aclyx",
-      "https://github.com/aclyx",
-      "https://www.x.com/aclyxpse",
-      "https://bsky.app/profile/alexleung.ca",
-      "https://www.instagram.com/rootpanda",
-      "https://scholar.google.ca/citations?user=NcOOsPIAAAAJ",
-    ],
-  };
-}
-
 type PostSchemaInput = {
   coverImage?: string;
   date: string;
@@ -117,7 +112,6 @@ function buildBasePageSchema<TPageType extends string>({
 
 function buildBasePostSchema(input: PostSchemaInput) {
   const canonicalPostUrl = toCanonical(`/blog/${input.slug}`);
-  const personReference = buildPersonReference();
 
   return {
     canonicalPostUrl,
@@ -129,8 +123,8 @@ function buildBasePostSchema(input: PostSchemaInput) {
       image: input.coverImage ? [toAbsoluteUrl(input.coverImage)] : undefined,
       datePublished: new Date(input.date).toISOString(),
       dateModified: new Date(input.updated ?? input.date).toISOString(),
-      author: personReference,
-      publisher: personReference,
+      author: PERSON_REFERENCE,
+      publisher: PERSON_REFERENCE,
       inLanguage: "en-CA",
       mainEntityOfPage: {
         "@type": "WebPage" as const,
@@ -148,7 +142,7 @@ export function buildProfilePageSchema(input: {
   return {
     ...buildBasePageSchema({ ...input, pageType: "ProfilePage" }),
     mainEntity: {
-      ...buildPersonReference(),
+      ...PERSON_REFERENCE,
       description: input.description,
     },
   };
@@ -303,10 +297,10 @@ export function buildPersonSchema(input: {
       "yattaro",
       "rootpanda",
     ],
-    url: getSiteRoot(),
+    url: SITE_ROOT,
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": getSiteRoot(),
+      "@id": SITE_ROOT,
     },
     image: [
       {
@@ -324,14 +318,7 @@ export function buildPersonSchema(input: {
     hasOccupation: currentOccupation,
     description: input.description,
     knowsLanguage: ["en-CA"],
-    sameAs: [
-      "https://www.linkedin.com/in/aclyx",
-      "https://github.com/aclyx",
-      "https://www.x.com/aclyxpse",
-      "https://bsky.app/profile/alexleung.ca",
-      "https://www.instagram.com/rootpanda",
-      "https://scholar.google.ca/citations?user=NcOOsPIAAAAJ",
-    ],
+    sameAs: SOCIAL_PROFILES,
     address: {
       "@type": "PostalAddress",
       addressLocality: "Waterloo",
@@ -434,7 +421,7 @@ export function buildWebsiteSchema(input: {
     "@context": "https://schema.org" as const,
     "@type": "WebSite",
     "@id": toAbsoluteUrl(WEBSITE_ID),
-    url: getSiteRoot(),
+    url: SITE_ROOT,
     name: "Alex Leung",
     description: input.description,
     about: {


### PR DESCRIPTION
## Summary
- remove unused Zod `.describe()` metadata from the post frontmatter schema
- collapse repeated JSON-LD person/site helper indirection into shared constants
- simplify JSON-LD tests by replacing repeated union guards with small typed helpers

## Validation
- yarn test --runInBand src/lib/seo/__tests__/jsonld.test.ts src/lib/__tests__/blogApi.test.ts
- yarn typecheck
- yarn eslint src/lib/blogApi.ts src/lib/seo/jsonld.ts src/lib/seo/__tests__/jsonld.test.ts