### PR TITLE
Normalize canonical URLs in sitemap and JSON-LD

### DIFF
--- a/src/app/__tests__/sitemap.test.ts
+++ b/src/app/__tests__/sitemap.test.ts
@@ -15,8 +15,18 @@ jest.mock("@/lib/blogApi", () => ({
 }));
 
 describe("sitemap", () => {
-  it("emits canonical trailing-slash blog post URLs", () => {
+  it("emits canonical trailing-slash URLs", () => {
     const entries = sitemap();
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ url: "https://alexleung.ca/" }),
+        expect.objectContaining({ url: "https://alexleung.ca/about/" }),
+        expect.objectContaining({ url: "https://alexleung.ca/now/" }),
+        expect.objectContaining({ url: "https://alexleung.ca/blog/" }),
+        expect.objectContaining({ url: "https://alexleung.ca/contact/" }),
+      ])
+    );
+
     const blogPostEntry = entries.find(
       (entry) => entry.url === "https://alexleung.ca/blog/my-post/"
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -103,10 +103,8 @@ export default function RootLayout({ children }: PropsWithChildren) {
         <JsonLd item={buildPersonSchema({ description })} />
         <JsonLd item={buildWebsiteSchema({ description })} />
         <JsonLd item={buildProfessionalServiceSchema({ description })} />
-        {googleAnalyticsId ? (
-          <GoogleAnalytics gaId={googleAnalyticsId} />
-        ) : null}
       </body>
+      {googleAnalyticsId ? <GoogleAnalytics gaId={googleAnalyticsId} /> : null}
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -103,8 +103,10 @@ export default function RootLayout({ children }: PropsWithChildren) {
         <JsonLd item={buildPersonSchema({ description })} />
         <JsonLd item={buildWebsiteSchema({ description })} />
         <JsonLd item={buildProfessionalServiceSchema({ description })} />
+        {googleAnalyticsId ? (
+          <GoogleAnalytics gaId={googleAnalyticsId} />
+        ) : null}
       </body>
-      {googleAnalyticsId ? <GoogleAnalytics gaId={googleAnalyticsId} /> : null}
     </html>
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -38,31 +38,31 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     {
-      url: "https://alexleung.ca",
+      url: toCanonical("/"),
       lastModified: new Date(PAGE_LAST_MODIFIED.home),
       changeFrequency: "monthly",
       priority: 1,
     },
     {
-      url: "https://alexleung.ca/about/",
+      url: toCanonical("/about"),
       lastModified: new Date(PAGE_LAST_MODIFIED.about),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
-      url: "https://alexleung.ca/now/",
+      url: toCanonical("/now"),
       lastModified: new Date(PAGE_LAST_MODIFIED.now),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
-      url: "https://alexleung.ca/blog/",
+      url: toCanonical("/blog"),
       lastModified: latestPostUpdate,
       changeFrequency: "weekly",
       priority: 0.8,
     },
     {
-      url: "https://alexleung.ca/contact/",
+      url: toCanonical("/contact"),
       lastModified: new Date(PAGE_LAST_MODIFIED.contact),
       changeFrequency: "yearly",
       priority: 0.5,

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -65,7 +65,7 @@ describe("seo jsonld builders", () => {
     expect(itemListElement[0]).toMatchObject({
       name: "Post 1",
       position: 1,
-      url: "https://alexleung.ca/blog/post-1",
+      url: "https://alexleung.ca/blog/post-1/",
     });
   });
 

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -233,7 +233,7 @@ export function buildBlogItemListSchema(
     itemListElement: posts.map((post, index) => ({
       "@type": "ListItem",
       position: index + 1,
-      url: toAbsoluteUrl(`/blog/${post.slug}`),
+      url: toCanonical(`/blog/${post.slug}`),
       name: post.title,
     })),
     numberOfItems: posts.length,


### PR DESCRIPTION
## Summary
- normalize blog item list JSON-LD URLs to the site canonical trailing-slash form
- route sitemap static page URLs through `toCanonical`
- expand sitemap coverage to assert canonical trailing-slash URLs for the static pages

## Validation
- yarn test --runInBand src/app/__tests__/layout.test.tsx src/app/__tests__/sitemap.test.ts src/lib/seo/__tests__/jsonld.test.ts
- yarn lint
- yarn typecheck