### PR TITLE
Add parallel PR review skill

### DIFF
--- a/.agents/skills/pr-parallel-review/SKILL.md
+++ b/.agents/skills/pr-parallel-review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pr-parallel-review
+description: Review a pull request or current branch against main by spawning one sub-agent per review dimension, waiting for all of them, and summarizing the result for each dimension. Use when the user wants a parallel branch-vs-main audit covering security issues, code quality, bugs, race conditions, test flakiness, and maintainability.
+---
+
+# Parallel PR Review
+
+Use this skill when the user explicitly wants parallel agent work for a PR or branch review.
+
+Load [references/review-dimensions.md](references/review-dimensions.md) before writing agent prompts.
+
+## Workflow
+
+1. Establish the review target.
+   - Default to comparing `HEAD` against `main`.
+   - If `main` is unavailable locally, use `origin/main`.
+   - State the exact base you used.
+   - Collect shared context once before delegating:
+     - current branch name
+     - merge base
+     - `git diff --stat` summary
+     - changed-file list
+     - any obvious hotspots from the diff
+
+2. Spawn exactly one sub-agent per review dimension.
+   - Prefer `explorer` agents for read-only review.
+   - Give every agent the same base context and changed files.
+   - Change only the review dimension and checklist.
+   - Keep the prompts concrete. Ask for evidence-backed findings only, not general advice.
+   - Require explicit `no findings` when the agent does not find a real issue.
+
+3. Wait for all agents together.
+   - Start all six agents first.
+   - Use a single wait over all agent ids instead of serial waits.
+   - If an agent times out, note that explicitly in the summary instead of silently omitting it.
+
+4. Summarize by dimension.
+   - Preserve the six original headings:
+     1. Security issue
+     2. Code quality
+     3. Bugs
+     4. Race
+     5. Test flakiness
+     6. Maintainability of the code
+   - For each heading, report one of:
+     - `No findings`
+     - `Findings` with the top issues, severity, and file references
+     - `Incomplete` with the reason
+   - Deduplicate overlapping issues across sections, but still mention them where relevant.
+
+## Output Contract
+
+Return findings first. Keep each section short and evidence-based.
+
+- `Security issue`: confirmed or likely vulnerabilities in the diff
+- `Code quality`: harmful complexity, duplication, or poor abstractions
+- `Bugs`: functional regressions or correctness defects
+- `Race`: race conditions, ordering hazards, stale async state, concurrency risks
+- `Test flakiness`: nondeterministic tests or code patterns likely to cause flaky tests
+- `Maintainability of the code`: long-term readability, coupling, and change-cost concerns
+
+After the six sections, add a short `Cross-cutting notes` section only if multiple agents reported the same root problem.
+
+## Quality Bar
+
+- Review the actual diff, not the whole repository in the abstract.
+- Prefer changed files first, but inspect adjacent code when needed to confirm impact.
+- Distinguish confirmed issues from plausible risks.
+- Avoid style-only feedback unless it affects correctness, reviewability, or maintenance cost.
+- If you did not run tests or static checks, say so.

--- a/.agents/skills/pr-parallel-review/SKILL.md
+++ b/.agents/skills/pr-parallel-review/SKILL.md
@@ -12,8 +12,10 @@ Load [references/review-dimensions.md](references/review-dimensions.md) before w
 ## Workflow
 
 1. Establish the review target.
-   - Default to comparing `HEAD` against `main`.
-   - If `main` is unavailable locally, use `origin/main`.
+   - If reviewing an open PR, detect the actual base branch from PR metadata first (for example `gh pr view --json baseRefName`).
+   - Otherwise default to comparing `HEAD` against `main`.
+   - If the chosen base branch is unavailable locally, use its remote-tracking equivalent (for example `origin/<base>`).
+   - If no PR base is available and `main` is unavailable locally, use `origin/main`.
    - State the exact base you used.
    - Collect shared context once before delegating:
      - current branch name
@@ -22,16 +24,18 @@ Load [references/review-dimensions.md](references/review-dimensions.md) before w
      - changed-file list
      - any obvious hotspots from the diff
 
-2. Spawn exactly one sub-agent per review dimension.
-   - Prefer `explorer` agents for read-only review.
-   - Give every agent the same base context and changed files.
+2. Choose the review execution mode.
+   - If sub-agent delegation is available, spawn exactly one sub-agent per review dimension.
+   - Prefer `explorer` agents for read-only review when that agent type exists; otherwise use the closest available read-only agent type.
+   - Give every delegated agent the same base context and changed files.
    - Change only the review dimension and checklist.
    - Keep the prompts concrete. Ask for evidence-backed findings only, not general advice.
    - Require explicit `no findings` when the agent does not find a real issue.
+   - If sub-agent delegation is unavailable, run the same six review dimensions sequentially in the main agent and state that the result is a non-parallel fallback.
 
-3. Wait for all agents together.
-   - Start all six agents first.
-   - Use a single wait over all agent ids instead of serial waits.
+3. Collect delegated results completely.
+   - Start all six delegated agents before waiting on results.
+   - Do not rely on a single `wait_agent` call over all ids; keep collecting results until every delegated agent reaches a terminal status or the run times out.
    - If an agent times out, note that explicitly in the summary instead of silently omitting it.
 
 4. Summarize by dimension.
@@ -51,6 +55,8 @@ Load [references/review-dimensions.md](references/review-dimensions.md) before w
 ## Output Contract
 
 Return findings first. Keep each section short and evidence-based.
+
+If you had to fall back to a non-parallel review because delegation was unavailable, say so before the six sections.
 
 - `Security issue`: confirmed or likely vulnerabilities in the diff
 - `Code quality`: harmful complexity, duplication, or poor abstractions

--- a/.agents/skills/pr-parallel-review/agents/openai.yaml
+++ b/.agents/skills/pr-parallel-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Parallel PR Review"
+  short_description: "Six-agent branch-vs-main review summary"
+  default_prompt: "Use $pr-parallel-review to review this branch against main by spawning one agent for security, code quality, bugs, race conditions, test flakiness, and maintainability, then summarize each result."

--- a/.agents/skills/pr-parallel-review/agents/openai.yaml
+++ b/.agents/skills/pr-parallel-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Parallel PR Review"
-  short_description: "Six-agent branch-vs-main review summary"
-  default_prompt: "Use $pr-parallel-review to review this branch against main by spawning one agent for security, code quality, bugs, race conditions, test flakiness, and maintainability, then summarize each result."
+  short_description: "Review a PR or branch across six dimensions"
+  default_prompt: "Use $pr-parallel-review to review this PR or branch against its actual base branch, running one reviewer per dimension when delegation is available and otherwise falling back to a sequential six-section summary."

--- a/.agents/skills/pr-parallel-review/references/review-dimensions.md
+++ b/.agents/skills/pr-parallel-review/references/review-dimensions.md
@@ -1,0 +1,131 @@
+# Review Dimensions
+
+Use this file to build the six sub-agent prompts and to keep the review output consistent.
+
+## Refined Prompt
+
+Use this when the user asks for a six-way PR review:
+
+```text
+Review this branch against main. Spawn one agent per review dimension, wait for all of them, and summarize each result separately.
+
+Review dimensions:
+1. Security issue
+2. Code quality
+3. Bugs
+4. Race
+5. Test flakiness
+6. Maintainability of the code
+
+Requirements:
+- Compare the current branch against `main` or `origin/main`, and state which base was used.
+- Give each agent the same diff context and changed-file list, but a different review focus.
+- Ask each agent for evidence-backed findings only, with `No findings` if clean.
+- Summarize the result for each dimension with severity and file references where applicable.
+- Call out incomplete coverage if any agent times out or lacks enough evidence.
+```
+
+## Shared Agent Prompt Frame
+
+Every agent should receive:
+
+- the base branch used
+- the current branch name
+- merge-base or diff range
+- changed-file list
+- diff summary or key hotspots
+- instruction to focus on the assigned dimension only
+
+Ask each agent to produce:
+
+1. `Status`: `No findings`, `Findings`, or `Incomplete`
+2. `Top items`: short bullets with severity and evidence
+3. `Files`: direct file references
+4. `Confidence`: `High`, `Medium`, or `Low`
+
+## Dimension Checklists
+
+### 1. Security issue
+
+Focus on concrete vulnerabilities introduced or exposed by the diff:
+
+- authn/authz regressions
+- secrets exposure
+- injection risks
+- XSS
+- SSRF
+- path traversal
+- insecure redirects
+- unsafe deserialization
+- missing validation at trust boundaries
+- sensitive data leakage
+
+Reject vague best-practice advice. Prefer exploitability and impact.
+
+### 2. Code quality
+
+Focus on reviewability and engineering quality problems:
+
+- unnecessary complexity
+- weak naming or structure that obscures intent
+- duplication introduced by the PR
+- over-abstraction or under-abstraction
+- dead branches or inconsistent patterns
+- error handling that is hard to reason about
+
+Ignore pure style preferences unless they materially hurt clarity.
+
+### 3. Bugs
+
+Focus on correctness and behavioral regressions:
+
+- broken control flow
+- wrong assumptions about nullability or data shape
+- off-by-one or boundary handling
+- missed error states
+- invalid state transitions
+- mismatches between caller and callee expectations
+
+Prefer issues that can be tied to specific paths in the changed code.
+
+### 4. Race
+
+Interpret `Race` as race conditions and ordering hazards:
+
+- async ordering bugs
+- shared mutable state
+- stale closure/state usage
+- duplicate in-flight requests
+- cache invalidation timing
+- non-atomic read/modify/write behavior
+- build-time or runtime concurrency hazards
+
+Mark items clearly as confirmed or plausible.
+
+### 5. Test flakiness
+
+Focus on test nondeterminism and patterns that create flaky tests:
+
+- timing-dependent assertions
+- reliance on real clocks or random values
+- order dependence
+- shared mutable fixtures
+- environment leakage
+- network or filesystem assumptions
+- async tests that do not fully await stabilization
+
+If the PR changes production code in a way that is likely to destabilize tests, report that too.
+
+### 6. Maintainability of the code
+
+Focus on change cost over time:
+
+- tightly coupled code paths
+- hidden assumptions
+- long functions or mixed concerns
+- difficult extension points
+- unclear ownership boundaries
+- missing local documentation where logic is non-obvious
+- changes that make future refactors riskier
+
+Keep this distinct from code quality by emphasizing long-term evolution cost.

--- a/.agents/skills/pr-parallel-review/references/review-dimensions.md
+++ b/.agents/skills/pr-parallel-review/references/review-dimensions.md
@@ -7,7 +7,7 @@ Use this file to build the six sub-agent prompts and to keep the review output c
 Use this when the user asks for a six-way PR review:
 
 ```text
-Review this branch against main. Spawn one agent per review dimension, wait for all of them, and summarize each result separately.
+Review this PR or branch against its true base branch. Use parallel sub-agents when the toolset supports them; otherwise run the same six review dimensions sequentially yourself and say that parallel mode was unavailable.
 
 Review dimensions:
 1. Security issue
@@ -18,8 +18,10 @@ Review dimensions:
 6. Maintainability of the code
 
 Requirements:
-- Compare the current branch against `main` or `origin/main`, and state which base was used.
-- Give each agent the same diff context and changed-file list, but a different review focus.
+- Detect the actual PR base branch when PR metadata is available; otherwise fall back to `main`, then `origin/main`, and state which base was used.
+- If sub-agents are available, give each agent the same diff context and changed-file list, but a different review focus.
+- If sub-agents are unavailable, keep the same six review dimensions and produce them sequentially in one response.
+- If delegated agents are used, keep collecting results until every agent reaches a terminal status or times out; do not assume one wait over multiple ids returns all results.
 - Ask each agent for evidence-backed findings only, with `No findings` if clean.
 - Summarize the result for each dimension with severity and file references where applicable.
 - Call out incomplete coverage if any agent times out or lacks enough evidence.
@@ -27,7 +29,7 @@ Requirements:
 
 ## Shared Agent Prompt Frame
 
-Every agent should receive:
+When sub-agents are used, every agent should receive:
 
 - the base branch used
 - the current branch name


### PR DESCRIPTION
## Summary
- add a reusable `pr-parallel-review` skill for six-dimension branch-vs-main reviews
- include a refined reusable prompt and per-dimension review checklists
- add skill metadata for UI discovery and invocation

## Validation
- parsed `SKILL.md` frontmatter with Ruby YAML
- parsed `agents/openai.yaml` with Ruby YAML
- bundled Python validator could not run because `PyYAML` is not installed in the environment