### PR TITLE
Fix canonical URL normalization for file-like paths

### DIFF
--- a/src/lib/seo/__tests__/url.test.ts
+++ b/src/lib/seo/__tests__/url.test.ts
@@ -22,4 +22,11 @@ describe("seo url helpers", () => {
       toCanonical("https://alexleung.ca/blog?utm_source=test#section")
     ).toBe("https://alexleung.ca/blog/");
   });
+
+  it("does not append trailing slash to file-like paths", () => {
+    expect(toCanonical("/feed.xml")).toBe("https://alexleung.ca/feed.xml");
+    expect(toCanonical("/assets/logo.svg")).toBe(
+      "https://alexleung.ca/assets/logo.svg"
+    );
+  });
 });

--- a/src/lib/seo/url.ts
+++ b/src/lib/seo/url.ts
@@ -9,6 +9,10 @@ function ensureTrailingSlash(path: string): string {
     return path;
   }
 
+  if (path.split("/").at(-1)?.includes(".")) {
+    return path;
+  }
+
   return path.endsWith("/") ? path : `${path}/`;
 }
 


### PR DESCRIPTION
### Motivation
- The canonical URL helper `toCanonical()` normalized all non-root paths to include a trailing slash which produced incorrect canonical URLs for file-like endpoints and static assets (for example `/feed.xml` became `/feed.xml/`).

### Description
- Update `src/lib/seo/url.ts` to skip trailing-slash normalization in `ensureTrailingSlash()` when the final path segment looks file-like (contains a `.`). 
- Add a unit test in `src/lib/seo/__tests__/url.test.ts` that verifies file-like paths such as `/feed.xml` and `/assets/logo.svg` are preserved while route paths still receive a trailing slash. 
- Preserve existing behavior for page route paths and absolute URLs handled by `toAbsoluteUrl()` and `toCanonical()`.

### Testing
- Ran `yarn lint` which reported Prettier formatting checks passed. 
- Ran `yarn typecheck` which completed without errors. 
- Ran `yarn test` and all unit tests passed (`120` tests passed). 
- Ran `yarn build` and the Next.js static export build completed successfully. 
- `yarn test:e2e` and `yarn test:e2e:visual` were not executed in this environment because `docker` is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6fce3f474832380ec395e7615ead3)