### PR TITLE
Improve homepage hero density and content accessibility

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,57 +6,69 @@ export function Hero() {
   return (
     <section
       id="home"
-      className="flex flex-grow items-center justify-center pb-12 pt-[calc(var(--header-height)+1.5rem)] md:pb-12 md:pt-[calc(var(--header-height)+3rem)]"
+      className="pb-8 pt-[calc(var(--header-height)+1.25rem)] md:pb-10 md:pt-[calc(var(--header-height)+2rem)]"
     >
       <div className="section-center">
-        <div className="max-w-3xl">
-          <p className="text-hero-subtitle mb-4 tracking-wider">
-            Hi, my name is
-          </p>
-          <h1 className="text-hero-title mb-4 inline-block font-black uppercase leading-[0.9] tracking-[0.2rem] md:pb-4">
-            Alex Leung
-          </h1>
+        <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:gap-8">
+          <div className="max-w-3xl">
+            <p className="text-hero-subtitle mb-3 tracking-wider">
+              Hi, my name is
+            </p>
+            <h1 className="text-hero-title mb-3 inline-block font-black uppercase leading-[0.9] tracking-[0.2rem] md:pb-2">
+              Alex Leung
+            </h1>
 
-          <h2 className="text-hero-description">
-            Software engineer and writer.
-          </h2>
-          <p className="mt-3 text-sm italic text-gray-200 md:text-gray-300">
-            I build software and write about systems, AI, and learning in
-            public.
-          </p>
+            <h2 className="text-hero-description">
+              Software engineer and writer.
+            </h2>
+            <p className="text-body mt-3 text-gray-200 md:text-gray-300">
+              I build software and write about systems, AI, and learning in
+              public.
+            </p>
 
-          <div className="mt-8 flex flex-wrap gap-4">
-            <CTAButton href="/blog/">
-              Read My Writing <HiOutlineArrowRight className="text-lg" />
-            </CTAButton>
-            <CTAButton href="/about/" variant="secondary">
-              <HiOutlineUser className="text-lg" /> About Me
-            </CTAButton>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <CTAButton href="/blog/">
+                Read My Writing <HiOutlineArrowRight className="text-lg" />
+              </CTAButton>
+              <CTAButton href="/about/" variant="secondary">
+                <HiOutlineUser className="text-lg" /> About Me
+              </CTAButton>
+            </div>
           </div>
 
-          <div className="mt-10">
-            <section
-              aria-labelledby="positioning-heading"
-              className="surface-static p-5 md:p-6"
-            >
-              <h2
-                id="positioning-heading"
-                className="text-heading font-semibold"
-              >
-                What you&apos;ll find here
-              </h2>
-              <p className="text-body mt-4 text-gray-200">
-                You&apos;ll find essays, notes, and personal reflections on
-                software engineering, system design, AI, product work, and
-                learning.
-              </p>
-              <p className="text-body mt-3 text-gray-200">
-                I care about the practical edge of those topics: how products
-                get built, how systems hold up, and how new AI capabilities fit
-                into real software.
-              </p>
-            </section>
-          </div>
+          <section
+            aria-labelledby="positioning-heading"
+            className="surface-static p-5 md:p-6"
+          >
+            <h2 id="positioning-heading" className="text-heading font-semibold">
+              What you&apos;ll find here
+            </h2>
+            <ul className="mt-4 space-y-3 text-gray-200">
+              <li className="text-body">
+                Essays and notes on software engineering, architecture, and
+                product decisions.
+              </li>
+              <li className="text-body">
+                Practical breakdowns of how AI fits into real systems and
+                day-to-day work.
+              </li>
+              <li className="text-body">
+                Reflections on learning, writing, and improving as a builder.
+              </li>
+            </ul>
+          </section>
+        </div>
+        <div className="mt-5">
+          <p className="text-body-sm text-gray-300">
+            Start with the latest posts below, or explore the full blog archive.
+          </p>
+          <a
+            href="#latest-writing"
+            className="text-body-sm mt-2 inline-flex items-center gap-2 font-semibold text-accent-link transition-colors hover:text-accent-link-hover"
+          >
+            Jump to latest writing
+            <HiOutlineArrowRight aria-hidden="true" className="text-base" />
+          </a>
         </div>
       </div>
     </section>

--- a/src/components/LatestWritingSection.tsx
+++ b/src/components/LatestWritingSection.tsx
@@ -31,7 +31,11 @@ export function LatestWritingSection({
   }
 
   return (
-    <ResponsiveContainer element="section" className="pb-12">
+    <ResponsiveContainer
+      element="section"
+      id="latest-writing"
+      className="pb-12"
+    >
       <SectionBlock title={title} spacing="lg">
         <div className="grid gap-4 md:grid-cols-3">
           {posts.map((post) => (

--- a/src/components/ResponsiveContainer.tsx
+++ b/src/components/ResponsiveContainer.tsx
@@ -1,4 +1,4 @@
-import { ElementType, ReactNode } from "react";
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
 
 type ContainerVariant = "content" | "wide" | "prose";
 
@@ -7,7 +7,7 @@ type ResponsiveContainerProps<T extends ElementType = "div"> = {
   children: ReactNode;
   className?: string;
   variant?: ContainerVariant;
-};
+} & Omit<ComponentPropsWithoutRef<T>, "children" | "className">;
 
 const variantClasses: Record<ContainerVariant, string> = {
   content: "section-center",
@@ -20,11 +20,15 @@ export function ResponsiveContainer<T extends ElementType = "div">({
   children,
   className = "",
   variant = "content",
+  ...rest
 }: ResponsiveContainerProps<T>) {
   const Component = element ?? "div";
 
   return (
-    <Component className={`${variantClasses[variant]} ${className}`.trim()}>
+    <Component
+      {...rest}
+      className={`${variantClasses[variant]} ${className}`.trim()}
+    >
       {children}
     </Component>
   );


### PR DESCRIPTION
### Motivation
- Reduce above-the-fold dead space so visitors see more substantive content immediately. 
- Improve scanability and perceived value of the hero by surfacing concise, semantic information instead of a long prose block. 
- Provide a quick in-page navigation affordance to jump straight to recent writing. 

### Description
- Reworked the homepage `Hero` into a denser layout with reduced top/bottom spacing and a responsive two-column grid on large screens so core CTAs and supporting content appear earlier. 
- Replaced the long supporting paragraph with a semantic bullet list under “What you’ll find here” to improve readability and accessibility while keeping CTAs prominent. 
- Added a “Jump to latest writing” anchor link in the hero and added `id="latest-writing"` to the latest writing section for reliable in-page navigation. 
- Extended `ResponsiveContainer` to forward native element props (and added appropriate TypeScript typing) so callers can pass attributes like `id` to the rendered container. 

### Testing
- Ran `yarn lint` which completed successfully. 
- Ran `yarn typecheck` which completed successfully. 
- Ran `yarn test` which initially surfaced a text-matcher failure during iteration, then passed after the fix; final test run shows all tests passing. 
- Ran `yarn build` which completed successfully and produced the static export. 
- Attempted `yarn test:e2e` and `yarn test:e2e:visual` but both could not run in this environment because the `docker` command is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98a5fc6548323ae547154822a4b49)