### PR TITLE
[codex] Add site navigation schema and fix nav smoke test

### DIFF
--- a/playwright/tests/smoke/navigation.spec.ts
+++ b/playwright/tests/smoke/navigation.spec.ts
@@ -8,21 +8,21 @@ import {
 } from "../../fixtures/stableRendering";
 
 async function clickPrimaryNavLink(page: Page, label: string) {
-  const menuButton = page.getByRole("button", { name: /Open menu|Close menu/ });
+  const desktopLink = page
+    .locator("header")
+    .getByRole("link", { name: label, exact: true });
 
-  if (await menuButton.isVisible().catch(() => false)) {
-    await menuButton.click();
-    await page
-      .locator("#mobile-nav-drawer")
-      .getByRole("link", { name: label })
-      .click();
+  if (await desktopLink.isVisible().catch(() => false)) {
+    await desktopLink.click();
     return;
   }
 
-  await page
-    .locator("header")
-    .getByRole("link", { name: label, exact: true })
-    .click();
+  const menuButton = page.getByRole("button", { name: /Open menu|Close menu/ });
+  await menuButton.click();
+
+  const mobileNavDrawer = page.locator("#mobile-nav-drawer");
+  await expect(mobileNavDrawer).toBeVisible();
+  await mobileNavDrawer.getByRole("link", { name: label, exact: true }).click();
 }
 
 test("home page renders the hero content", async ({ page }) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { BASE_URL } from "@/constants";
 import {
   buildPersonSchema,
   buildProfessionalServiceSchema,
+  buildSiteNavigationSchema,
   buildWebsiteSchema,
 } from "@/lib/seo";
 
@@ -103,6 +104,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
         <JsonLd item={buildPersonSchema({ description })} />
         <JsonLd item={buildWebsiteSchema({ description })} />
         <JsonLd item={buildProfessionalServiceSchema({ description })} />
+        <JsonLd item={buildSiteNavigationSchema()} />
       </body>
       {googleAnalyticsId ? <GoogleAnalytics gaId={googleAnalyticsId} /> : null}
     </html>

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -8,6 +8,7 @@ import {
   buildPersonSchema,
   buildProfessionalServiceSchema,
   buildProfilePageSchema,
+  buildSiteNavigationSchema,
   buildWebPageSchema,
   buildWebsiteSchema,
 } from "@/lib/seo";
@@ -104,6 +105,54 @@ describe("seo jsonld builders", () => {
       "@type": "WebPage",
       "@id": "https://alexleung.ca/about/",
     });
+  });
+
+  it("builds site navigation schema with canonical nav entry urls", () => {
+    const navigation = buildSiteNavigationSchema();
+    const hasPart = expectSchemaArray<{
+      "@type"?: string;
+      "@id"?: string;
+      name?: string;
+      url?: string;
+    }>(navigation.hasPart);
+
+    expect(navigation["@id"]).toBe("https://alexleung.ca/#site-navigation");
+    expect(navigation.isPartOf).toEqual({
+      "@type": "WebSite",
+      "@id": "https://alexleung.ca/#website",
+    });
+    expect(hasPart).toEqual([
+      {
+        "@type": "SiteNavigationElement",
+        "@id": "https://alexleung.ca/#site-navigation-home",
+        name: "Home",
+        url: "https://alexleung.ca/",
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "@id": "https://alexleung.ca/#site-navigation-about",
+        name: "About",
+        url: "https://alexleung.ca/about/",
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "@id": "https://alexleung.ca/#site-navigation-blog",
+        name: "Blog",
+        url: "https://alexleung.ca/blog/",
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "@id": "https://alexleung.ca/#site-navigation-now",
+        name: "Now",
+        url: "https://alexleung.ca/now/",
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "@id": "https://alexleung.ca/#site-navigation-contact",
+        name: "Contact",
+        url: "https://alexleung.ca/contact/",
+      },
+    ]);
   });
 
   it("builds person schema with richer identity metadata", () => {

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -9,6 +9,7 @@ export {
   buildPersonSchema,
   buildProfessionalServiceSchema,
   buildProfilePageSchema,
+  buildSiteNavigationSchema,
   buildWebPageSchema,
   buildWebsiteSchema,
 } from "./jsonld";

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -8,6 +8,7 @@ import type {
   Person,
   ProfilePage,
   Service,
+  SiteNavigationElement,
   WebPage,
   WebSite,
   WithContext,
@@ -17,8 +18,16 @@ import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
 
 const PERSON_ID = "/#person";
 const WEBSITE_ID = "/#website";
+const SITE_NAVIGATION_ID = "/#site-navigation";
 const ABOUT_PATH = "/about";
 const SITE_ROOT = toAbsoluteUrl("/").replace(/\/$/, "");
+const MAIN_NAV_ITEMS = [
+  { id: "home", name: "Home", path: "/" },
+  { id: "about", name: "About", path: "/about" },
+  { id: "blog", name: "Blog", path: "/blog" },
+  { id: "now", name: "Now", path: "/now" },
+  { id: "contact", name: "Contact", path: "/contact" },
+] as const;
 const SOCIAL_PROFILES = [
   "https://www.linkedin.com/in/aclyx",
   "https://github.com/aclyx",
@@ -451,6 +460,27 @@ export function buildWebsiteSchema(input: {
         "@id": toCanonical("/now"),
       },
     ],
+    inLanguage: "en-CA",
+  };
+}
+
+export function buildSiteNavigationSchema(): WithContext<SiteNavigationElement> {
+  return {
+    "@context": "https://schema.org" as const,
+    "@type": "SiteNavigationElement",
+    "@id": toAbsoluteUrl(SITE_NAVIGATION_ID),
+    name: "Main navigation",
+    url: SITE_ROOT,
+    isPartOf: {
+      "@type": "WebSite",
+      "@id": toAbsoluteUrl(WEBSITE_ID),
+    },
+    hasPart: MAIN_NAV_ITEMS.map((item) => ({
+      "@type": "SiteNavigationElement" as const,
+      "@id": toAbsoluteUrl(`/#site-navigation-${item.id}`),
+      name: item.name,
+      url: toCanonical(item.path),
+    })),
     inLanguage: "en-CA",
   };
 }


### PR DESCRIPTION
## Summary
- add a `SiteNavigationElement` JSON-LD builder for the main site navigation and render it from the root layout
- cover the new schema output in the JSON-LD unit tests
- harden the Playwright navigation smoke helper so desktop runs use visible header links before falling back to the mobile drawer

## Why
- expose canonical navigation URLs as structured data in the site shell
- keep the required smoke suite stable across desktop and mobile layouts so the publish gate reflects real regressions

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn test:e2e`
- `yarn test:e2e:visual`