### PR TITLE
Disable cancel-in-progress for main deploy workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   verify:


### PR DESCRIPTION
### Motivation
- Prevent newer GitHub Actions runs on `main` from canceling prior in-progress CI/CD runs so deployments run sequentially.

### Description
- Updated `.github/workflows/build-deploy.yml` by setting `concurrency` -> `cancel-in-progress` from `true` to `false` so runs are queued instead of canceled.

### Testing
- Ran `yarn lint` (passed), `yarn typecheck` (passed), `yarn test` (30 suites, 121 tests passed), and `yarn build` (static export succeeded); `yarn test:e2e` and `yarn test:e2e:visual` could not run here because `docker` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3dc392ac8323aef15637f42c410b)