### PR TITLE
Programmatically derive navigation schema from shared nav config

### DIFF
--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -1,12 +1,6 @@
 import Link from "next/link";
 
-const navLinks = [
-  { href: "/", label: "Home" },
-  { href: "/about/", label: "About" },
-  { href: "/now/", label: "Now" },
-  { href: "/blog/", label: "Blog" },
-  { href: "/contact/", label: "Contact" },
-];
+import { NAV_LINKS } from "@/constants/navigation";
 
 type NavItemProps = {
   href: string;
@@ -49,7 +43,7 @@ type DesktopNavProps = {
 export function DesktopNav({ isActive }: DesktopNavProps) {
   return (
     <ul className="hidden gap-8 md:flex">
-      {navLinks.map((link) => (
+      {NAV_LINKS.map((link) => (
         <li key={link.href}>
           <NavItem {...link} active={isActive(link.href)} />
         </li>
@@ -91,7 +85,7 @@ export function MobileNavDrawer({
         aria-hidden={!isOpen}
       >
         <ul className="flex flex-col py-8">
-          {navLinks.map((link, index) => (
+          {NAV_LINKS.map((link, index) => (
             <li
               key={link.href}
               className={`transition-all duration-300 ${

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -1,0 +1,12 @@
+export const NAV_LINKS = [
+  { id: "home", href: "/", canonicalPath: "/", label: "Home" },
+  { id: "about", href: "/about/", canonicalPath: "/about", label: "About" },
+  { id: "now", href: "/now/", canonicalPath: "/now", label: "Now" },
+  { id: "blog", href: "/blog/", canonicalPath: "/blog", label: "Blog" },
+  {
+    id: "contact",
+    href: "/contact/",
+    canonicalPath: "/contact",
+    label: "Contact",
+  },
+] as const;

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -136,15 +136,15 @@ describe("seo jsonld builders", () => {
       },
       {
         "@type": "SiteNavigationElement",
-        "@id": "https://alexleung.ca/#site-navigation-blog",
-        name: "Blog",
-        url: "https://alexleung.ca/blog/",
-      },
-      {
-        "@type": "SiteNavigationElement",
         "@id": "https://alexleung.ca/#site-navigation-now",
         name: "Now",
         url: "https://alexleung.ca/now/",
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "@id": "https://alexleung.ca/#site-navigation-blog",
+        name: "Blog",
+        url: "https://alexleung.ca/blog/",
       },
       {
         "@type": "SiteNavigationElement",

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -14,6 +14,7 @@ import type {
   WithContext,
 } from "schema-dts";
 
+import { NAV_LINKS } from "@/constants/navigation";
 import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
 
 const PERSON_ID = "/#person";
@@ -21,13 +22,6 @@ const WEBSITE_ID = "/#website";
 const SITE_NAVIGATION_ID = "/#site-navigation";
 const ABOUT_PATH = "/about";
 const SITE_ROOT = toAbsoluteUrl("/").replace(/\/$/, "");
-const MAIN_NAV_ITEMS = [
-  { id: "home", name: "Home", path: "/" },
-  { id: "about", name: "About", path: "/about" },
-  { id: "blog", name: "Blog", path: "/blog" },
-  { id: "now", name: "Now", path: "/now" },
-  { id: "contact", name: "Contact", path: "/contact" },
-] as const;
 const SOCIAL_PROFILES = [
   "https://www.linkedin.com/in/aclyx",
   "https://github.com/aclyx",
@@ -475,11 +469,11 @@ export function buildSiteNavigationSchema(): WithContext<SiteNavigationElement> 
       "@type": "WebSite",
       "@id": toAbsoluteUrl(WEBSITE_ID),
     },
-    hasPart: MAIN_NAV_ITEMS.map((item) => ({
+    hasPart: NAV_LINKS.map((item) => ({
       "@type": "SiteNavigationElement" as const,
       "@id": toAbsoluteUrl(`/#site-navigation-${item.id}`),
-      name: item.name,
-      url: toCanonical(item.path),
+      name: item.label,
+      url: toCanonical(item.canonicalPath),
     })),
     inLanguage: "en-CA",
   };


### PR DESCRIPTION
### Motivation

- Remove duplication between the rendered header navigation and the JSON-LD site navigation so updates stay in sync automatically.
- Make the site navigation schema programmatic and maintainable by sourcing it from a single canonical nav definition.
- Ensure the structured-data `url` values use canonical paths (no trailing slash mismatches) and preserve the canonical nav ordering.

### Description

- Add a shared navigation constant `NAV_LINKS` in `src/constants/navigation.ts` that includes `id`, `href`, `canonicalPath`, and `label` for each top-level nav entry.
- Refactor `src/components/NavMenu.tsx` to consume `NAV_LINKS` for both desktop and mobile menus instead of an inline `navLinks` array.
- Update `src/lib/seo/jsonld.ts` so `buildSiteNavigationSchema()` maps `hasPart` from `NAV_LINKS` and uses `canonicalPath`/`label` for schema `url` and `name` respectively.
- Adjust the JSON-LD unit test at `src/lib/seo/__tests__/jsonld.test.ts` to match the canonical nav ordering produced by the shared config.

### Testing

- Ran `yarn lint` which succeeded and reported Prettier formatting matched.
- Ran `yarn typecheck` which completed without errors.
- Ran `yarn test` and all Jest tests passed after updating the expected nav-order in `jsonld.test.ts` (final run: 30 test suites, 121 tests passed).
- Ran `yarn build` which completed successfully and produced the static export.
- `yarn test:e2e` and `yarn test:e2e:visual` were not run in this environment because Docker is not available (`command not found: docker`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3d94e8288323a92a20d61ce2ffbb)