### PR TITLE
Add /load-flow route shell and initial load-flow model scaffolding

### DIFF
--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -26,6 +26,7 @@ Completed in this slice (PR 1 scope):
 - ✅ Added `/load-flow` route shell and placeholder workspace component.
 - ✅ Added initial domain model contracts under `src/features/load-flow/model/` (`types.ts`, `defaults.ts`, `validation.ts`).
 - ✅ Added validator unit tests covering baseline pre-solve checks.
+- ✅ Follow-up review hardening: added duplicate bus-ID validation and route coverage tests for the `/load-flow/` shell.
 
 Next recommended slice:
 

--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -27,6 +27,7 @@ Completed in this slice (PR 1 scope):
 - ✅ Added initial domain model contracts under `src/features/load-flow/model/` (`types.ts`, `defaults.ts`, `validation.ts`).
 - ✅ Added validator unit tests covering baseline pre-solve checks.
 - ✅ Follow-up review hardening: added duplicate bus-ID validation and route coverage tests for the `/load-flow/` shell.
+- ✅ PR #191 review follow-up: reject non-finite `baseMVA` values and non-finite branch impedance inputs.
 
 Next recommended slice:
 

--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -19,6 +19,20 @@ This plan is intentionally modular so the solver can be extracted into a separat
 
 ---
 
+## Progress Update (March 31, 2026)
+
+Completed in this slice (PR 1 scope):
+
+- ✅ Added `/load-flow` route shell and placeholder workspace component.
+- ✅ Added initial domain model contracts under `src/features/load-flow/model/` (`types.ts`, `defaults.ts`, `validation.ts`).
+- ✅ Added validator unit tests covering baseline pre-solve checks.
+
+Next recommended slice:
+
+- Build the canvas editor foundation (palette, bus/line placement, and normalized store) as described in PR 2.
+
+---
+
 ## Non-Goals (Initial Scope)
 
 - Real-time transient simulation
@@ -244,11 +258,11 @@ Below are bite-sized slices designed for clean review. They can be run as stacke
 
 ### MVP Track
 
-#### PR 1 — Route shell + domain model contracts
+#### PR 1 — Route shell + domain model contracts _(Completed March 31, 2026)_
 
-- Add `/load-flow` route with placeholder workspace layout
-- Introduce `model/types.ts`, defaults, and validation scaffolding
-- Add documentation for sign conventions and bus types
+- ✅ Add `/load-flow` route with placeholder workspace layout
+- ✅ Introduce `model/types.ts`, defaults, and validation scaffolding
+- ✅ Add documentation for sign conventions and bus types
 
 **Acceptance:** route renders; type contracts compile; unit tests for validators pass.
 

--- a/src/app/load-flow/__tests__/page.test.tsx
+++ b/src/app/load-flow/__tests__/page.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+
+import LoadFlowPage from "../page";
+
+describe("LoadFlowPage", () => {
+  it("renders the load-flow workspace shell", () => {
+    render(<LoadFlowPage />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Load Flow" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Workspace (MVP)")).toBeInTheDocument();
+    expect(
+      screen.getByText(/foundation for an in-browser AC power flow tool/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -1,0 +1,28 @@
+export function LoadFlowWorkspace() {
+  return (
+    <section className="rounded-xl border border-gray-700 bg-gray-900/60 p-6 shadow-sm">
+      <h2 className="text-heading-sm text-white">Workspace (MVP)</h2>
+      <p className="text-body mt-2 text-gray-300">
+        The interactive one-line diagram editor and solver controls will land in
+        the next implementation slices.
+      </p>
+
+      <div className="mt-6 grid gap-3 text-sm text-gray-300 md:grid-cols-3">
+        <div className="rounded-lg border border-gray-700 p-4">
+          <h3 className="font-semibold text-white">Canvas Panel</h3>
+          <p className="mt-1">Node and branch editing placeholder.</p>
+        </div>
+
+        <div className="rounded-lg border border-gray-700 p-4">
+          <h3 className="font-semibold text-white">Properties Panel</h3>
+          <p className="mt-1">Element property form placeholder.</p>
+        </div>
+
+        <div className="rounded-lg border border-gray-700 p-4">
+          <h3 className="font-semibold text-white">Solve + Results</h3>
+          <p className="mt-1">Solver controls and results placeholder.</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/load-flow/page.tsx
+++ b/src/app/load-flow/page.tsx
@@ -14,7 +14,7 @@ import { LoadFlowWorkspace } from "./_components/LoadFlowWorkspace";
 const title = "Load Flow | Alex Leung";
 const description =
   "A browser-based AC load flow workspace for building one-line models and solving bus voltages and power flows.";
-const path = "/load-flow";
+const path = "/load-flow/";
 
 export const metadata: Metadata = buildPageMetadata({
   title,
@@ -28,7 +28,7 @@ export default function LoadFlowPage() {
       <JsonLdBreadcrumbs
         items={[
           { name: "Home", item: "/" },
-          { name: "Load Flow", item: "/load-flow" },
+          { name: "Load Flow", item: "/load-flow/" },
         ]}
       />
       <JsonLd<WebPage>

--- a/src/app/load-flow/page.tsx
+++ b/src/app/load-flow/page.tsx
@@ -1,0 +1,55 @@
+import { JsonLd } from "react-schemaorg";
+
+import { Metadata } from "next";
+
+import { WebPage } from "schema-dts";
+
+import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
+import { PageShell } from "@/components/PageShell";
+import { ResponsiveContainer } from "@/components/ResponsiveContainer";
+import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
+
+import { LoadFlowWorkspace } from "./_components/LoadFlowWorkspace";
+
+const title = "Load Flow | Alex Leung";
+const description =
+  "A browser-based AC load flow workspace for building one-line models and solving bus voltages and power flows.";
+const path = "/load-flow";
+
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+});
+
+export default function LoadFlowPage() {
+  return (
+    <>
+      <JsonLdBreadcrumbs
+        items={[
+          { name: "Home", item: "/" },
+          { name: "Load Flow", item: "/load-flow" },
+        ]}
+      />
+      <JsonLd<WebPage>
+        item={buildWebPageSchema({
+          path,
+          title,
+          description,
+        })}
+      />
+
+      <PageShell title="Load Flow" titleId="load-flow">
+        <ResponsiveContainer element="section" className="space-y-6">
+          <p className="text-body text-gray-300">
+            This page is the foundation for an in-browser AC power flow tool.
+            The current milestone establishes route structure and domain
+            contracts, with graph editing and Newton-Raphson solving coming in
+            subsequent slices.
+          </p>
+          <LoadFlowWorkspace />
+        </ResponsiveContainer>
+      </PageShell>
+    </>
+  );
+}

--- a/src/features/load-flow/model/__tests__/validation.test.ts
+++ b/src/features/load-flow/model/__tests__/validation.test.ts
@@ -31,6 +31,26 @@ describe("validateLoadFlowCase", () => {
     expect(result.errors).toContain("Exactly one slack bus is required.");
   });
 
+  it("rejects non-finite base MVA values", () => {
+    const nanResult = validateLoadFlowCase(
+      createCase({
+        baseMVA: Number.NaN,
+      })
+    );
+    const infinityResult = validateLoadFlowCase(
+      createCase({
+        baseMVA: Number.POSITIVE_INFINITY,
+      })
+    );
+
+    expect(nanResult.errors).toContain(
+      "Base MVA must be a finite number greater than zero."
+    );
+    expect(infinityResult.errors).toContain(
+      "Base MVA must be a finite number greater than zero."
+    );
+  });
+
   it("flags branches that reference missing buses", () => {
     const result = validateLoadFlowCase(
       createCase({
@@ -68,6 +88,26 @@ describe("validateLoadFlowCase", () => {
 
     expect(result.errors).toContain(
       "Branch branch-1 has invalid impedance (r and x cannot both be zero)."
+    );
+  });
+
+  it("flags branches with non-finite impedance values", () => {
+    const result = validateLoadFlowCase(
+      createCase({
+        branches: [
+          {
+            id: "branch-1",
+            fromBusId: "bus-1",
+            toBusId: "bus-1",
+            r: Number.NaN,
+            x: 0.03,
+          },
+        ],
+      })
+    );
+
+    expect(result.errors).toContain(
+      "Branch branch-1 has invalid impedance (r and x must be finite numbers)."
     );
   });
 

--- a/src/features/load-flow/model/__tests__/validation.test.ts
+++ b/src/features/load-flow/model/__tests__/validation.test.ts
@@ -1,0 +1,109 @@
+import { DEFAULT_LOAD_FLOW_CASE } from "@/features/load-flow/model/defaults";
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+import { validateLoadFlowCase } from "@/features/load-flow/model/validation";
+
+const createCase = (overrides: Partial<LoadFlowCase>): LoadFlowCase => ({
+  ...DEFAULT_LOAD_FLOW_CASE,
+  ...overrides,
+});
+
+describe("validateLoadFlowCase", () => {
+  it("accepts a minimal valid case", () => {
+    const result = validateLoadFlowCase(DEFAULT_LOAD_FLOW_CASE);
+
+    expect(result.errors).toEqual([]);
+  });
+
+  it("requires exactly one slack bus", () => {
+    const result = validateLoadFlowCase(
+      createCase({
+        buses: [
+          {
+            id: "bus-1",
+            name: "Bus 1",
+            baseKV: 230,
+            type: "PQ",
+          },
+        ],
+      })
+    );
+
+    expect(result.errors).toContain("Exactly one slack bus is required.");
+  });
+
+  it("flags branches that reference missing buses", () => {
+    const result = validateLoadFlowCase(
+      createCase({
+        branches: [
+          {
+            id: "branch-1",
+            fromBusId: "bus-1",
+            toBusId: "bus-2",
+            r: 0.01,
+            x: 0.03,
+          },
+        ],
+      })
+    );
+
+    expect(result.errors).toContain(
+      "Branch branch-1 references a bus that does not exist in the case."
+    );
+  });
+
+  it("flags branches with zero impedance", () => {
+    const result = validateLoadFlowCase(
+      createCase({
+        branches: [
+          {
+            id: "branch-1",
+            fromBusId: "bus-1",
+            toBusId: "bus-1",
+            r: 0,
+            x: 0,
+          },
+        ],
+      })
+    );
+
+    expect(result.errors).toContain(
+      "Branch branch-1 has invalid impedance (r and x cannot both be zero)."
+    );
+  });
+
+  it("requires PV buses to have online generator associations", () => {
+    const result = validateLoadFlowCase(
+      createCase({
+        buses: [
+          {
+            id: "bus-1",
+            name: "Bus 1",
+            baseKV: 230,
+            type: "SLACK",
+          },
+          {
+            id: "bus-2",
+            name: "Bus 2",
+            baseKV: 230,
+            type: "PV",
+          },
+        ],
+        generators: [
+          {
+            id: "gen-1",
+            busId: "bus-2",
+            pSet: 1,
+            vSet: 1,
+            qMin: -0.5,
+            qMax: 0.5,
+            status: "OFF",
+          },
+        ],
+      })
+    );
+
+    expect(result.errors).toContain(
+      "PV bus bus-2 must be associated with an online generator."
+    );
+  });
+});

--- a/src/features/load-flow/model/__tests__/validation.test.ts
+++ b/src/features/load-flow/model/__tests__/validation.test.ts
@@ -71,6 +71,29 @@ describe("validateLoadFlowCase", () => {
     );
   });
 
+  it("flags duplicate bus identifiers", () => {
+    const result = validateLoadFlowCase(
+      createCase({
+        buses: [
+          {
+            id: "bus-1",
+            name: "Bus 1",
+            baseKV: 230,
+            type: "SLACK",
+          },
+          {
+            id: "bus-1",
+            name: "Bus 1 Duplicate",
+            baseKV: 230,
+            type: "PQ",
+          },
+        ],
+      })
+    );
+
+    expect(result.errors).toContain("Duplicate bus id detected: bus-1.");
+  });
+
   it("requires PV buses to have online generator associations", () => {
     const result = validateLoadFlowCase(
       createCase({

--- a/src/features/load-flow/model/defaults.ts
+++ b/src/features/load-flow/model/defaults.ts
@@ -1,0 +1,19 @@
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+
+export const DEFAULT_LOAD_FLOW_CASE: LoadFlowCase = {
+  baseMVA: 100,
+  buses: [
+    {
+      id: "bus-1",
+      name: "Bus 1",
+      baseKV: 230,
+      type: "SLACK",
+      voltageMagnitudeSetpoint: 1,
+      voltageAngleSetpointDeg: 0,
+    },
+  ],
+  branches: [],
+  generators: [],
+  loads: [],
+  shunts: [],
+};

--- a/src/features/load-flow/model/types.ts
+++ b/src/features/load-flow/model/types.ts
@@ -1,0 +1,65 @@
+export type BusType = "SLACK" | "PV" | "PQ";
+
+export type ShuntDeviceKind = "REACTOR" | "INDUCTOR" | "CAPACITOR";
+
+export interface Bus {
+  id: string;
+  name: string;
+  baseKV: number;
+  type: BusType;
+  voltageMagnitudeSetpoint?: number;
+  voltageAngleSetpointDeg?: number;
+  voltageMagnitudeMin?: number;
+  voltageMagnitudeMax?: number;
+}
+
+export interface Branch {
+  id: string;
+  fromBusId: string;
+  toBusId: string;
+  r: number;
+  x: number;
+  bHalf?: number;
+  thermalLimitMVA?: number;
+  status?: "IN_SERVICE" | "OUT_OF_SERVICE";
+}
+
+export interface Generator {
+  id: string;
+  busId: string;
+  pSet: number;
+  vSet: number;
+  qMin: number;
+  qMax: number;
+  status: "ON" | "OFF";
+}
+
+export interface Load {
+  id: string;
+  busId: string;
+  p: number;
+  q: number;
+  status: "ON" | "OFF";
+}
+
+/**
+ * Sign convention:
+ * - Capacitors inject reactive power (positive Q injection at the bus).
+ * - Reactors and inductors absorb reactive power (negative Q injection at the bus).
+ */
+export interface ShuntDevice {
+  id: string;
+  busId: string;
+  kind: ShuntDeviceKind;
+  bPu: number;
+  status: "ON" | "OFF";
+}
+
+export interface LoadFlowCase {
+  baseMVA: number;
+  buses: Bus[];
+  branches: Branch[];
+  generators: Generator[];
+  loads: Load[];
+  shunts: ShuntDevice[];
+}

--- a/src/features/load-flow/model/validation.ts
+++ b/src/features/load-flow/model/validation.ts
@@ -7,6 +7,10 @@ export interface LoadFlowValidationResult {
 const hasInvalidBranchImpedance = (r: number, x: number): boolean =>
   Math.abs(r) < Number.EPSILON && Math.abs(x) < Number.EPSILON;
 
+const getDuplicateIds = (ids: string[]): string[] => [
+  ...new Set(ids.filter((id, index) => ids.indexOf(id) !== index)),
+];
+
 export const validateLoadFlowCase = (
   loadFlowCase: LoadFlowCase
 ): LoadFlowValidationResult => {
@@ -23,6 +27,13 @@ export const validateLoadFlowCase = (
   }
 
   const busIds = new Set(loadFlowCase.buses.map((bus) => bus.id));
+  const duplicateBusIds = getDuplicateIds(
+    loadFlowCase.buses.map((bus) => bus.id)
+  );
+
+  for (const duplicateBusId of duplicateBusIds) {
+    errors.push(`Duplicate bus id detected: ${duplicateBusId}.`);
+  }
 
   for (const branch of loadFlowCase.branches) {
     if (!busIds.has(branch.fromBusId) || !busIds.has(branch.toBusId)) {

--- a/src/features/load-flow/model/validation.ts
+++ b/src/features/load-flow/model/validation.ts
@@ -1,0 +1,80 @@
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+
+export interface LoadFlowValidationResult {
+  errors: string[];
+}
+
+const hasInvalidBranchImpedance = (r: number, x: number): boolean =>
+  Math.abs(r) < Number.EPSILON && Math.abs(x) < Number.EPSILON;
+
+export const validateLoadFlowCase = (
+  loadFlowCase: LoadFlowCase
+): LoadFlowValidationResult => {
+  const errors: string[] = [];
+
+  if (loadFlowCase.baseMVA <= 0) {
+    errors.push("Base MVA must be greater than zero.");
+  }
+
+  const slackBuses = loadFlowCase.buses.filter((bus) => bus.type === "SLACK");
+
+  if (slackBuses.length !== 1) {
+    errors.push("Exactly one slack bus is required.");
+  }
+
+  const busIds = new Set(loadFlowCase.buses.map((bus) => bus.id));
+
+  for (const branch of loadFlowCase.branches) {
+    if (!busIds.has(branch.fromBusId) || !busIds.has(branch.toBusId)) {
+      errors.push(
+        `Branch ${branch.id} references a bus that does not exist in the case.`
+      );
+    }
+
+    if (hasInvalidBranchImpedance(branch.r, branch.x)) {
+      errors.push(
+        `Branch ${branch.id} has invalid impedance (r and x cannot both be zero).`
+      );
+    }
+  }
+
+  for (const generator of loadFlowCase.generators) {
+    if (!busIds.has(generator.busId)) {
+      errors.push(
+        `Generator ${generator.id} references a bus that does not exist in the case.`
+      );
+    }
+  }
+
+  const generatorBusIds = new Set(
+    loadFlowCase.generators
+      .filter((generator) => generator.status === "ON")
+      .map((generator) => generator.busId)
+  );
+
+  for (const bus of loadFlowCase.buses) {
+    if (bus.type === "PV" && !generatorBusIds.has(bus.id)) {
+      errors.push(
+        `PV bus ${bus.id} must be associated with an online generator.`
+      );
+    }
+  }
+
+  for (const load of loadFlowCase.loads) {
+    if (!busIds.has(load.busId)) {
+      errors.push(
+        `Load ${load.id} references a bus that does not exist in the case.`
+      );
+    }
+  }
+
+  for (const shunt of loadFlowCase.shunts) {
+    if (!busIds.has(shunt.busId)) {
+      errors.push(
+        `Shunt ${shunt.id} references a bus that does not exist in the case.`
+      );
+    }
+  }
+
+  return { errors };
+};

--- a/src/features/load-flow/model/validation.ts
+++ b/src/features/load-flow/model/validation.ts
@@ -11,13 +11,15 @@ const getDuplicateIds = (ids: string[]): string[] => [
   ...new Set(ids.filter((id, index) => ids.indexOf(id) !== index)),
 ];
 
+const isFiniteNumber = (value: number): boolean => Number.isFinite(value);
+
 export const validateLoadFlowCase = (
   loadFlowCase: LoadFlowCase
 ): LoadFlowValidationResult => {
   const errors: string[] = [];
 
-  if (loadFlowCase.baseMVA <= 0) {
-    errors.push("Base MVA must be greater than zero.");
+  if (!isFiniteNumber(loadFlowCase.baseMVA) || loadFlowCase.baseMVA <= 0) {
+    errors.push("Base MVA must be a finite number greater than zero.");
   }
 
   const slackBuses = loadFlowCase.buses.filter((bus) => bus.type === "SLACK");
@@ -39,6 +41,12 @@ export const validateLoadFlowCase = (
     if (!busIds.has(branch.fromBusId) || !busIds.has(branch.toBusId)) {
       errors.push(
         `Branch ${branch.id} references a bus that does not exist in the case.`
+      );
+    }
+
+    if (!isFiniteNumber(branch.r) || !isFiniteNumber(branch.x)) {
+      errors.push(
+        `Branch ${branch.id} has invalid impedance (r and x must be finite numbers).`
       );
     }
 


### PR DESCRIPTION
### Motivation

- Establish the first incremental slice of the Load Flow feature (PR 1) by creating a visible route and the minimal domain contracts so subsequent work can implement the editor and solver against a stable API. 

### Description

- Add a new `/load-flow` route page with metadata, breadcrumbs, and a placeholder `LoadFlowWorkspace` component that outlines Canvas / Properties / Solve+Results panels via `src/app/load-flow/page.tsx` and `src/app/load-flow/_components/LoadFlowWorkspace.tsx`. 
- Introduce typed domain contracts and defaults under `src/features/load-flow/model/` including `types.ts` (bus/branch/generator/load/shunt shapes and sign conventions) and `defaults.ts` (starter `DEFAULT_LOAD_FLOW_CASE`).
- Add pre-solve validation logic in `src/features/load-flow/model/validation.ts` enforcing rules such as positive `baseMVA`, exactly one slack bus, branch reference integrity and non-zero impedance, and PV bus generator association.
- Add unit tests for the validator at `src/features/load-flow/model/__tests__/validation.test.ts` and update `docs/load-flow-implementation-plan.md` with a dated progress update marking PR 1 as completed and recommending the canvas editor as the next slice.

### Testing

- Ran formatting/linting with `yarn lint` (after applying Prettier fixes) and the checks completed without remaining errors. 
- Ran type checking with `yarn typecheck` and it completed successfully. 
- Ran unit tests with `yarn test` (Jest) and all suites passed (`31` suites, `126` tests). 
- Built the site with `yarn build` and the static export completed successfully. 
- Ran Playwright host-mode smoke and visual suites with `yarn test:e2e:host` and `yarn test:e2e:visual:host` (Docker was not available in this environment), and both host-mode suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc4b9bb6b88323bc797713699228d0)