### PR TITLE
Implement load-flow canvas foundation and normalized editor state

### DIFF
--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -19,19 +19,23 @@ This plan is intentionally modular so the solver can be extracted into a separat
 
 ---
 
-## Progress Update (March 31, 2026)
+## Progress Update (April 1, 2026)
 
-Completed in this slice (PR 1 scope):
+Completed across the first two slices (PR 1 + PR 2 scope):
 
-- ✅ Added `/load-flow` route shell and placeholder workspace component.
+- ✅ Added `/load-flow` route shell and initial workspace layout.
 - ✅ Added initial domain model contracts under `src/features/load-flow/model/` (`types.ts`, `defaults.ts`, `validation.ts`).
 - ✅ Added validator unit tests covering baseline pre-solve checks.
 - ✅ Follow-up review hardening: added duplicate bus-ID validation and route coverage tests for the `/load-flow/` shell.
 - ✅ PR #191 review follow-up: reject non-finite `baseMVA` values and non-finite branch impedance inputs.
+- ✅ Implemented a first-pass canvas editor foundation with palette actions for bus/line creation.
+- ✅ Added normalized editor store helpers under `src/features/load-flow/state/loadFlowStore.ts`.
+- ✅ Added serialization path from editor graph state to `LoadFlowCase` shape (`toLoadFlowCase`).
+- ✅ Added store unit tests for deterministic bus defaults and bus/line serialization behavior.
 
 Next recommended slice:
 
-- Build the canvas editor foundation (palette, bus/line placement, and normalized store) as described in PR 2.
+- Build PR 3 solver skeleton: add `graphToCase.ts`, Ybus assembly, and first Newton-Raphson solve loop with deterministic mini-case tests.
 
 ---
 
@@ -268,11 +272,11 @@ Below are bite-sized slices designed for clean review. They can be run as stacke
 
 **Acceptance:** route renders; type contracts compile; unit tests for validators pass.
 
-#### PR 2 — Canvas editor foundation
+#### PR 2 — Canvas editor foundation _(Completed April 1, 2026)_
 
-- Introduce graph editor (palette + node placement + edge wiring)
-- Add normalized state store and selection/edit panel basics
-- Support buses and lines first
+- ✅ Introduced first-pass graph editor UX (palette actions, bus list/canvas snapshot, line wiring via initial connect action).
+- ✅ Added normalized state store and selection/edit panel basics.
+- ✅ Added bus and line creation/editing foundation with serialized case preview.
 
 **Acceptance:** users can create/edit buses and lines; state serializes correctly.
 

--- a/src/app/load-flow/__tests__/page.test.tsx
+++ b/src/app/load-flow/__tests__/page.test.tsx
@@ -9,7 +9,7 @@ describe("LoadFlowPage", () => {
     expect(
       screen.getByRole("heading", { level: 1, name: "Load Flow" })
     ).toBeInTheDocument();
-    expect(screen.getByText("Workspace (MVP)")).toBeInTheDocument();
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
     expect(
       screen.getByText(/foundation for an in-browser AC power flow tool/i)
     ).toBeInTheDocument();

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -15,7 +15,13 @@ import {
 
 const BUS_TYPE_OPTIONS: BusType[] = ["SLACK", "PV", "PQ"];
 
-const numberFromInput = (value: string): number => Number.parseFloat(value);
+const parseFiniteNumber = (value: string): number | null => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const isBusType = (value: string): value is BusType =>
+  BUS_TYPE_OPTIONS.some((type) => type === value);
 
 export function LoadFlowWorkspace() {
   const [editorState, setEditorState] = useState(
@@ -140,13 +146,18 @@ export function LoadFlowWorkspace() {
                 <select
                   value={selectedBus.type}
                   className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
-                  onChange={(event) =>
+                  onChange={(event) => {
+                    const nextType = event.target.value;
+                    if (!isBusType(nextType)) {
+                      return;
+                    }
+
                     setEditorState((prev) =>
                       updateBus(prev, selectedBus.id, {
-                        type: event.target.value as BusType,
+                        type: nextType,
                       })
-                    )
-                  }
+                    );
+                  }}
                 >
                   {BUS_TYPE_OPTIONS.map((type) => (
                     <option key={type} value={type}>
@@ -166,13 +177,20 @@ export function LoadFlowWorkspace() {
                   type="number"
                   value={selectedBranch.r}
                   className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
-                  onChange={(event) =>
+                  onChange={(event) => {
+                    const parsedResistance = parseFiniteNumber(
+                      event.target.value
+                    );
+                    if (parsedResistance === null) {
+                      return;
+                    }
+
                     setEditorState((prev) =>
                       updateBranch(prev, selectedBranch.id, {
-                        r: numberFromInput(event.target.value),
+                        r: parsedResistance,
                       })
-                    )
-                  }
+                    );
+                  }}
                 />
               </label>
             </div>

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -1,27 +1,196 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { BusType } from "@/features/load-flow/model/types";
+import {
+  addBranch,
+  addBus,
+  createInitialLoadFlowEditorState,
+  selectElement,
+  toLoadFlowCase,
+  updateBranch,
+  updateBus,
+} from "@/features/load-flow/state/loadFlowStore";
+
+const BUS_TYPE_OPTIONS: BusType[] = ["SLACK", "PV", "PQ"];
+
+const numberFromInput = (value: string): number => Number.parseFloat(value);
+
 export function LoadFlowWorkspace() {
+  const [editorState, setEditorState] = useState(
+    createInitialLoadFlowEditorState
+  );
+
+  const selectedBus =
+    editorState.selectedElementType === "BUS" && editorState.selectedElementId
+      ? editorState.busesById[editorState.selectedElementId]
+      : null;
+  const selectedBranch =
+    editorState.selectedElementType === "BRANCH" &&
+    editorState.selectedElementId
+      ? editorState.branchesById[editorState.selectedElementId]
+      : null;
+
+  const serializedCase = useMemo(
+    () => toLoadFlowCase(editorState),
+    [editorState]
+  );
+
   return (
     <section className="rounded-xl border border-gray-700 bg-gray-900/60 p-6 shadow-sm">
-      <h2 className="text-heading-sm text-white">Workspace (MVP)</h2>
+      <h2 className="text-heading-sm text-white">Workspace</h2>
       <p className="text-body mt-2 text-gray-300">
-        The interactive one-line diagram editor and solver controls will land in
-        the next implementation slices.
+        Foundation editor for buses and lines with normalized state
+        serialization.
       </p>
 
-      <div className="mt-6 grid gap-3 text-sm text-gray-300 md:grid-cols-3">
+      <div className="mt-6 grid gap-4 lg:grid-cols-3">
         <div className="rounded-lg border border-gray-700 p-4">
-          <h3 className="font-semibold text-white">Canvas Panel</h3>
-          <p className="mt-1">Node and branch editing placeholder.</p>
+          <h3 className="font-semibold text-white">Palette</h3>
+          <p className="mt-1 text-sm text-gray-300">
+            Add buses, then connect them with line elements.
+          </p>
+          <button
+            type="button"
+            className="mt-3 rounded-md border border-gray-500 px-3 py-2 text-sm text-white hover:bg-gray-800"
+            onClick={() => setEditorState((prev) => addBus(prev))}
+          >
+            Add bus
+          </button>
+
+          <div className="mt-3 space-y-2 text-sm text-gray-200">
+            {editorState.busOrder.length < 2 ? (
+              <p>Add at least two buses to create a line.</p>
+            ) : (
+              <button
+                type="button"
+                className="rounded-md border border-gray-500 px-3 py-2 text-sm text-white hover:bg-gray-800"
+                onClick={() => {
+                  const [fromBusId, toBusId] = editorState.busOrder;
+                  setEditorState((prev) => addBranch(prev, fromBusId, toBusId));
+                }}
+              >
+                Connect first two buses
+              </button>
+            )}
+          </div>
         </div>
 
         <div className="rounded-lg border border-gray-700 p-4">
-          <h3 className="font-semibold text-white">Properties Panel</h3>
-          <p className="mt-1">Element property form placeholder.</p>
+          <h3 className="font-semibold text-white">Canvas Snapshot</h3>
+          <div className="mt-3 space-y-2 text-sm text-gray-200">
+            {editorState.busOrder.map((busId) => {
+              const bus = editorState.busesById[busId];
+              return (
+                <button
+                  key={bus.id}
+                  type="button"
+                  className="block w-full rounded-md border border-gray-600 px-3 py-2 text-left hover:bg-gray-800"
+                  onClick={() =>
+                    setEditorState((prev) => selectElement(prev, "BUS", bus.id))
+                  }
+                >
+                  {bus.name} • {bus.type} • {bus.baseKV} kV
+                </button>
+              );
+            })}
+
+            {editorState.branchOrder.map((branchId) => {
+              const branch = editorState.branchesById[branchId];
+              return (
+                <button
+                  key={branch.id}
+                  type="button"
+                  className="block w-full rounded-md border border-blue-800 px-3 py-2 text-left text-blue-200 hover:bg-gray-800"
+                  onClick={() =>
+                    setEditorState((prev) =>
+                      selectElement(prev, "BRANCH", branch.id)
+                    )
+                  }
+                >
+                  {branch.id}: {branch.fromBusId} → {branch.toBusId}
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         <div className="rounded-lg border border-gray-700 p-4">
-          <h3 className="font-semibold text-white">Solve + Results</h3>
-          <p className="mt-1">Solver controls and results placeholder.</p>
+          <h3 className="font-semibold text-white">Properties</h3>
+          {selectedBus ? (
+            <div className="mt-3 space-y-2 text-sm text-gray-200">
+              <label className="block">
+                <span>Name</span>
+                <input
+                  value={selectedBus.name}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) =>
+                    setEditorState((prev) =>
+                      updateBus(prev, selectedBus.id, {
+                        name: event.target.value,
+                      })
+                    )
+                  }
+                />
+              </label>
+
+              <label className="block">
+                <span>Type</span>
+                <select
+                  value={selectedBus.type}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) =>
+                    setEditorState((prev) =>
+                      updateBus(prev, selectedBus.id, {
+                        type: event.target.value as BusType,
+                      })
+                    )
+                  }
+                >
+                  {BUS_TYPE_OPTIONS.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          ) : null}
+
+          {selectedBranch ? (
+            <div className="mt-3 space-y-2 text-sm text-gray-200">
+              <label className="block">
+                <span>R (pu)</span>
+                <input
+                  type="number"
+                  value={selectedBranch.r}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) =>
+                    setEditorState((prev) =>
+                      updateBranch(prev, selectedBranch.id, {
+                        r: numberFromInput(event.target.value),
+                      })
+                    )
+                  }
+                />
+              </label>
+            </div>
+          ) : null}
+
+          {!selectedBus && !selectedBranch ? (
+            <p className="mt-3 text-sm text-gray-300">
+              Select a bus or line to edit properties.
+            </p>
+          ) : null}
         </div>
+      </div>
+
+      <div className="mt-6 rounded-lg border border-gray-700 p-4">
+        <h3 className="font-semibold text-white">Serialized case preview</h3>
+        <pre className="mt-2 overflow-auto text-xs text-gray-300">
+          {JSON.stringify(serializedCase, null, 2)}
+        </pre>
       </div>
     </section>
   );

--- a/src/app/load-flow/page.tsx
+++ b/src/app/load-flow/page.tsx
@@ -43,9 +43,9 @@ export default function LoadFlowPage() {
         <ResponsiveContainer element="section" className="space-y-6">
           <p className="text-body text-gray-300">
             This page is the foundation for an in-browser AC power flow tool.
-            The current milestone establishes route structure and domain
-            contracts, with graph editing and Newton-Raphson solving coming in
-            subsequent slices.
+            This milestone now includes a first-pass canvas foundation for
+            adding buses and lines, plus normalized editor state serialization.
+            Newton-Raphson solver modules are planned next.
           </p>
           <LoadFlowWorkspace />
         </ResponsiveContainer>

--- a/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
+++ b/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
@@ -44,4 +44,29 @@ describe("loadFlowStore", () => {
       })
     );
   });
+
+  it("serializes detached DTOs without editor-only fields", () => {
+    let state = createInitialLoadFlowEditorState();
+    state = addBus(state, { x: 20, y: 30 });
+    state = addBus(state, { x: 40, y: 50 });
+    state = addBranch(state, "bus-1", "bus-2");
+
+    const snapshot = toLoadFlowCase(state);
+
+    expect(snapshot.buses[0]).toEqual(
+      expect.objectContaining({
+        id: "bus-1",
+        name: "Bus 1",
+        baseKV: 230,
+      })
+    );
+    expect(snapshot.buses[0]).not.toHaveProperty("x");
+    expect(snapshot.buses[0]).not.toHaveProperty("y");
+
+    snapshot.buses[0].name = "Mutated name";
+    snapshot.branches[0].r = 0.23;
+
+    expect(state.busesById["bus-1"].name).toBe("Bus 1");
+    expect(state.branchesById["line-1"].r).toBe(0.01);
+  });
 });

--- a/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
+++ b/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
@@ -1,0 +1,47 @@
+import {
+  addBranch,
+  addBus,
+  createInitialLoadFlowEditorState,
+  toLoadFlowCase,
+  updateBus,
+} from "@/features/load-flow/state/loadFlowStore";
+
+describe("loadFlowStore", () => {
+  it("adds buses with deterministic defaults", () => {
+    const initial = createInitialLoadFlowEditorState();
+    const next = addBus(initial);
+
+    expect(next.busOrder).toEqual(["bus-1"]);
+    expect(next.busesById["bus-1"]).toEqual(
+      expect.objectContaining({
+        id: "bus-1",
+        name: "Bus 1",
+        type: "SLACK",
+        baseKV: 230,
+      })
+    );
+
+    const withSecondBus = addBus(next);
+    expect(withSecondBus.busesById["bus-2"].type).toBe("PQ");
+  });
+
+  it("creates a line between existing buses and serializes graph state", () => {
+    let state = createInitialLoadFlowEditorState();
+    state = addBus(state);
+    state = addBus(state);
+    state = updateBus(state, "bus-2", { type: "PV" });
+
+    state = addBranch(state, "bus-1", "bus-2");
+
+    const snapshot = toLoadFlowCase(state);
+    expect(snapshot.buses).toHaveLength(2);
+    expect(snapshot.branches).toHaveLength(1);
+    expect(snapshot.buses[1].type).toBe("PV");
+    expect(snapshot.branches[0]).toEqual(
+      expect.objectContaining({
+        fromBusId: "bus-1",
+        toBusId: "bus-2",
+      })
+    );
+  });
+});

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -1,0 +1,172 @@
+import {
+  Branch,
+  Bus,
+  BusType,
+  LoadFlowCase,
+} from "@/features/load-flow/model/types";
+
+export interface BusNode {
+  id: string;
+  name: string;
+  baseKV: number;
+  type: BusType;
+  x: number;
+  y: number;
+}
+
+export interface LineEdge {
+  id: string;
+  fromBusId: string;
+  toBusId: string;
+  r: number;
+  x: number;
+  bHalf: number;
+}
+
+export interface LoadFlowEditorState {
+  baseMVA: number;
+  busesById: Record<string, BusNode>;
+  busOrder: string[];
+  branchesById: Record<string, LineEdge>;
+  branchOrder: string[];
+  selectedElementId: string | null;
+  selectedElementType: "BUS" | "BRANCH" | null;
+}
+
+const DEFAULT_BUS_BASE_KV = 230;
+
+export const createInitialLoadFlowEditorState = (): LoadFlowEditorState => ({
+  baseMVA: 100,
+  busesById: {},
+  busOrder: [],
+  branchesById: {},
+  branchOrder: [],
+  selectedElementId: null,
+  selectedElementType: null,
+});
+
+export const addBus = (
+  state: LoadFlowEditorState,
+  options?: { x?: number; y?: number }
+): LoadFlowEditorState => {
+  const id = `bus-${state.busOrder.length + 1}`;
+  const name = `Bus ${state.busOrder.length + 1}`;
+
+  return {
+    ...state,
+    busesById: {
+      ...state.busesById,
+      [id]: {
+        id,
+        name,
+        baseKV: DEFAULT_BUS_BASE_KV,
+        type: state.busOrder.length === 0 ? "SLACK" : "PQ",
+        x: options?.x ?? 120 + state.busOrder.length * 120,
+        y: options?.y ?? 120,
+      },
+    },
+    busOrder: [...state.busOrder, id],
+    selectedElementId: id,
+    selectedElementType: "BUS",
+  };
+};
+
+export const updateBus = (
+  state: LoadFlowEditorState,
+  busId: string,
+  update: Partial<BusNode>
+): LoadFlowEditorState => {
+  const bus = state.busesById[busId];
+  if (!bus) {
+    return state;
+  }
+
+  return {
+    ...state,
+    busesById: {
+      ...state.busesById,
+      [busId]: {
+        ...bus,
+        ...update,
+      },
+    },
+  };
+};
+
+export const addBranch = (
+  state: LoadFlowEditorState,
+  fromBusId: string,
+  toBusId: string
+): LoadFlowEditorState => {
+  if (!state.busesById[fromBusId] || !state.busesById[toBusId]) {
+    return state;
+  }
+
+  const id = `line-${state.branchOrder.length + 1}`;
+
+  return {
+    ...state,
+    branchesById: {
+      ...state.branchesById,
+      [id]: {
+        id,
+        fromBusId,
+        toBusId,
+        r: 0.01,
+        x: 0.1,
+        bHalf: 0,
+      },
+    },
+    branchOrder: [...state.branchOrder, id],
+    selectedElementId: id,
+    selectedElementType: "BRANCH",
+  };
+};
+
+export const updateBranch = (
+  state: LoadFlowEditorState,
+  branchId: string,
+  update: Partial<LineEdge>
+): LoadFlowEditorState => {
+  const branch = state.branchesById[branchId];
+  if (!branch) {
+    return state;
+  }
+
+  return {
+    ...state,
+    branchesById: {
+      ...state.branchesById,
+      [branchId]: {
+        ...branch,
+        ...update,
+      },
+    },
+  };
+};
+
+export const selectElement = (
+  state: LoadFlowEditorState,
+  elementType: "BUS" | "BRANCH" | null,
+  elementId: string | null
+): LoadFlowEditorState => ({
+  ...state,
+  selectedElementType: elementType,
+  selectedElementId: elementId,
+});
+
+export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
+  const buses: Bus[] = state.busOrder.map((busId) => state.busesById[busId]);
+  const branches: Branch[] = state.branchOrder.map(
+    (branchId) => state.branchesById[branchId]
+  );
+
+  return {
+    baseMVA: state.baseMVA,
+    buses,
+    branches,
+    generators: [],
+    loads: [],
+    shunts: [],
+  };
+};

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -26,8 +26,14 @@ export interface LineEdge {
 export interface LoadFlowEditorState {
   baseMVA: number;
   busesById: Record<string, BusNode>;
+  /**
+   * Stable insertion/display order for buses independent of object key order.
+   */
   busOrder: string[];
   branchesById: Record<string, LineEdge>;
+  /**
+   * Stable insertion/display order for branches independent of object key order.
+   */
   branchOrder: string[];
   selectedElementId: string | null;
   selectedElementType: "BUS" | "BRANCH" | null;
@@ -156,10 +162,26 @@ export const selectElement = (
 });
 
 export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
-  const buses: Bus[] = state.busOrder.map((busId) => state.busesById[busId]);
-  const branches: Branch[] = state.branchOrder.map(
-    (branchId) => state.branchesById[branchId]
-  );
+  const buses: Bus[] = state.busOrder.map((busId) => {
+    const bus = state.busesById[busId];
+    return {
+      id: bus.id,
+      name: bus.name,
+      baseKV: bus.baseKV,
+      type: bus.type,
+    };
+  });
+  const branches: Branch[] = state.branchOrder.map((branchId) => {
+    const branch = state.branchesById[branchId];
+    return {
+      id: branch.id,
+      fromBusId: branch.fromBusId,
+      toBusId: branch.toBusId,
+      r: branch.r,
+      x: branch.x,
+      bHalf: branch.bHalf,
+    };
+  });
 
   return {
     baseMVA: state.baseMVA,


### PR DESCRIPTION
### Motivation
- Advance the load-flow feature by delivering the PR 2 canvas/editor foundation so users can create and wire basic one-line elements before solver work begins.
- Provide a normalized, pure editor state API that serializes to the existing `LoadFlowCase` DTO so the forthcoming solver can consume graph state without UI coupling.
- Keep progress documented in the implementation plan so the next slice (solver skeleton) has a clear, testable starting point.

### Description
- Added a normalized editor store at `src/features/load-flow/state/loadFlowStore.ts` with pure helpers `createInitialLoadFlowEditorState`, `addBus`, `addBranch`, `updateBus`, `updateBranch`, `selectElement`, and `toLoadFlowCase` to produce a `LoadFlowCase` from graph state.
- Reworked the workspace UI in `src/app/load-flow/_components/LoadFlowWorkspace.tsx` to expose a palette with `Add bus` and `Connect first two buses` actions, a canvas-snapshot list for selection, property editors for buses/lines, and a live serialized case preview.
- Added unit tests at `src/features/load-flow/state/__tests__/loadFlowStore.test.ts` that assert deterministic bus defaults, branch creation, and graph-to-case serialization.
- Updated route copy and test expectations (`src/app/load-flow/page.tsx` and `src/app/load-flow/__tests__/page.test.tsx`) and marked PR 2 complete in `docs/load-flow-implementation-plan.md` with PR 3 (solver skeleton) set as the next target.

### Testing
- Ran linting and formatting with `yarn lint` after applying Prettier fixes and it passed successfully.
- Type checks with `yarn typecheck` completed with no errors.
- Unit test suite with `yarn test` passed: all test suites succeeded (33 suites, 132 tests).
- Production build with `yarn build` completed successfully and static pages were generated.
- Playwright smoke and visual suites were run via the host-mode wrappers because Docker was not available, and both succeeded: `yarn test:e2e:host` (24 tests passed) and `yarn test:e2e:visual:host` (8 tests passed).
- Note: `docker` was not present in the environment (`docker: command not found`), so CI-style Docker e2e execution was not used and host-mode Playwright wrappers were used per repository guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc7644477083238f7580db33c43512)