### PR TITLE
Refine load-flow architecture boundaries and scaffold solver planning

### DIFF
--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -97,7 +97,7 @@ src/
         validation.ts
         defaults.ts
       graph/
-        graphToCase.ts
+        toLoadFlowCase.ts
       solver/
         core/
           newtonRaphson.ts
@@ -204,31 +204,27 @@ Document and enforce conventions in one place:
 
 ### Algorithm decision policy (v1)
 
-Default decision tree:
+Current implementation phase decision:
 
-1. Use **Newton-Raphson** for small/medium systems and for mixed PV/PQ behavior where robust convergence and Jacobian diagnostics are most important.
-2. Permit **Fast-Decoupled** as an explicit override, and allow heuristic defaulting for very large systems as a performance-oriented baseline.
+1. Use **Newton-Raphson only** until the core kernels (`Ybus`, mismatch, Jacobian, solve/update loop) are complete and benchmarked.
+2. Evaluate **Fast-Decoupled** only after Newton-Raphson parity is validated on the benchmark fixture set (3/5/14 bus + internal stress cases).
 3. Keep Gauss-Seidel out of the primary path (possible educational mode only).
 
 Rationale:
 
-- Newton-Raphson has stronger convergence behavior near solution and handles full AC coupling directly.
-- Fast-Decoupled can be materially faster at scale when assumptions are acceptable.
-- A typed selection layer avoids hard-coding policy inside the numerical kernel.
+- A single production path keeps correctness/debug diagnostics focused while the first engine kernel is maturing.
+- Alternate algorithm work should be gated behind parity benchmarks rather than heuristics in a skeleton phase.
 
 ### Initialization policy (v1)
 
-Support the following initialization modes from the public solve API:
+Current implementation phase decision:
 
-- `FLAT_START` (default): `|V|=1.0 pu`, `θ=0°` for all buses
-- `WARM_START`: caller-supplied prior solved state (for repeated runs)
-- `DC_ANGLE_SEED`: flat magnitudes with DC-seeded angles when available
+- `FLAT_START` only (`|V|=1.0 pu`, `θ=0°` for all buses).
 
-Practical guidance:
+Follow-up expansion criteria:
 
-- Start with flat start for deterministic baseline behavior and easier tests.
-- Add warm-start support before performance sweeps and interactive repeated solves.
-- Use DC angle seeding as a targeted acceleration option for larger meshed cases.
+- Add warm start only when solve results are persisted in a stable state model.
+- Add DC angle seed only when a dedicated DC pre-solve path and regression benchmarks exist.
 
 ### Robustness requirements
 

--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -39,6 +39,30 @@ Next recommended slice:
 
 ---
 
+## Assessment Snapshot (April 1, 2026)
+
+### 1) UI layer vs core engine separation
+
+Current status: **partially good, but not complete**.
+
+- Good: the editor state is already in a pure store module (`state/loadFlowStore.ts`), and domain DTOs are in `model/types.ts`.
+- Gap: graph serialization was previously colocated in the UI/editor state module, which couples editor concerns to solve-case DTO concerns.
+- Remediation in this slice: move serialization to `graph/toLoadFlowCase.ts` and keep `state/` focused on editor interactions only.
+
+### 2) Engine implementation plan quality
+
+Current status: **high-level plan existed; algorithm and initialization decisions were under-specified**.
+
+- Newton-Raphson remains the primary path for correctness and mixed bus-type robustness.
+- Add explicit strategy for optional algorithm fallback and deterministic initialization policy.
+- Add typed solver options and diagnostics interfaces now so solver internals can evolve without breaking UI contracts.
+
+### 3) Planned directory structure
+
+Current status: **planned in prose, not represented in code yet**.
+
+- Remediation in this slice: introduce `graph/` and `solver/` scaffolding directories with typed entrypoints for algorithm selection, initialization, and execution facade.
+
 ## Non-Goals (Initial Scope)
 
 - Real-time transient simulation
@@ -177,6 +201,34 @@ Document and enforce conventions in one place:
 7. Apply damping/step limiting as needed
 8. Enforce `Q` limits on PV buses with PV→PQ switching
 9. Stop on tolerance or max iterations
+
+### Algorithm decision policy (v1)
+
+Default decision tree:
+
+1. Use **Newton-Raphson** for small/medium systems and for mixed PV/PQ behavior where robust convergence and Jacobian diagnostics are most important.
+2. Permit **Fast-Decoupled** as an explicit override, and allow heuristic defaulting for very large systems as a performance-oriented baseline.
+3. Keep Gauss-Seidel out of the primary path (possible educational mode only).
+
+Rationale:
+
+- Newton-Raphson has stronger convergence behavior near solution and handles full AC coupling directly.
+- Fast-Decoupled can be materially faster at scale when assumptions are acceptable.
+- A typed selection layer avoids hard-coding policy inside the numerical kernel.
+
+### Initialization policy (v1)
+
+Support the following initialization modes from the public solve API:
+
+- `FLAT_START` (default): `|V|=1.0 pu`, `θ=0°` for all buses
+- `WARM_START`: caller-supplied prior solved state (for repeated runs)
+- `DC_ANGLE_SEED`: flat magnitudes with DC-seeded angles when available
+
+Practical guidance:
+
+- Start with flat start for deterministic baseline behavior and easier tests.
+- Add warm-start support before performance sweeps and interactive repeated solves.
+- Use DC angle seeding as a targeted acceleration option for larger meshed cases.
 
 ### Robustness requirements
 

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -2,13 +2,13 @@
 
 import { useMemo, useState } from "react";
 
+import { toLoadFlowCase } from "@/features/load-flow/graph/toLoadFlowCase";
 import { BusType } from "@/features/load-flow/model/types";
 import {
   addBranch,
   addBus,
   createInitialLoadFlowEditorState,
   selectElement,
-  toLoadFlowCase,
   updateBranch,
   updateBus,
 } from "@/features/load-flow/state/loadFlowStore";

--- a/src/app/load-flow/page.tsx
+++ b/src/app/load-flow/page.tsx
@@ -45,7 +45,9 @@ export default function LoadFlowPage() {
             This page is the foundation for an in-browser AC power flow tool.
             This milestone now includes a first-pass canvas foundation for
             adding buses and lines, plus normalized editor state serialization.
-            Newton-Raphson solver modules are planned next.
+            Solver scaffolding now separates graph serialization from the
+            upcoming engine layer and documents algorithm/initialization policy
+            before numerical kernels land.
           </p>
           <LoadFlowWorkspace />
         </ResponsiveContainer>

--- a/src/features/load-flow/graph/toLoadFlowCase.ts
+++ b/src/features/load-flow/graph/toLoadFlowCase.ts
@@ -1,0 +1,35 @@
+import { Branch, Bus, LoadFlowCase } from "@/features/load-flow/model/types";
+import { LoadFlowEditorState } from "@/features/load-flow/state/loadFlowStore";
+
+export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
+  const buses: Bus[] = state.busOrder.map((busId) => {
+    const bus = state.busesById[busId];
+    return {
+      id: bus.id,
+      name: bus.name,
+      baseKV: bus.baseKV,
+      type: bus.type,
+    };
+  });
+
+  const branches: Branch[] = state.branchOrder.map((branchId) => {
+    const branch = state.branchesById[branchId];
+    return {
+      id: branch.id,
+      fromBusId: branch.fromBusId,
+      toBusId: branch.toBusId,
+      r: branch.r,
+      x: branch.x,
+      bHalf: branch.bHalf,
+    };
+  });
+
+  return {
+    baseMVA: state.baseMVA,
+    buses,
+    branches,
+    generators: [],
+    loads: [],
+    shunts: [],
+  };
+};

--- a/src/features/load-flow/solver/__tests__/algorithmSelection.test.ts
+++ b/src/features/load-flow/solver/__tests__/algorithmSelection.test.ts
@@ -4,23 +4,11 @@ import { selectSolverAlgorithm } from "../algorithmSelection";
 import { DEFAULT_SOLVE_OPTIONS } from "../types";
 
 describe("selectSolverAlgorithm", () => {
-  it("keeps newton-raphson by default for small systems", () => {
+  it("selects newton-raphson for the current engine phase", () => {
     const loadFlowCase = JSON.parse(JSON.stringify(DEFAULT_LOAD_FLOW_CASE));
 
     const decision = selectSolverAlgorithm(loadFlowCase, DEFAULT_SOLVE_OPTIONS);
     expect(decision.selected).toBe("NEWTON_RAPHSON");
-  });
-
-  it("switches to fast-decoupled heuristic for large systems", () => {
-    const loadFlowCase = JSON.parse(JSON.stringify(DEFAULT_LOAD_FLOW_CASE));
-    loadFlowCase.buses = Array.from({ length: 120 }, (_, index) => ({
-      id: `bus-${index + 1}`,
-      name: `Bus ${index + 1}`,
-      baseKV: 230,
-      type: index === 0 ? "SLACK" : "PQ",
-    }));
-
-    const decision = selectSolverAlgorithm(loadFlowCase, DEFAULT_SOLVE_OPTIONS);
-    expect(decision.selected).toBe("FAST_DECOUPLED");
+    expect(decision.reason).toMatch(/only implemented algorithm/i);
   });
 });

--- a/src/features/load-flow/solver/__tests__/algorithmSelection.test.ts
+++ b/src/features/load-flow/solver/__tests__/algorithmSelection.test.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_LOAD_FLOW_CASE } from "@/features/load-flow/model/defaults";
+
+import { selectSolverAlgorithm } from "../algorithmSelection";
+import { DEFAULT_SOLVE_OPTIONS } from "../types";
+
+describe("selectSolverAlgorithm", () => {
+  it("keeps newton-raphson by default for small systems", () => {
+    const loadFlowCase = JSON.parse(JSON.stringify(DEFAULT_LOAD_FLOW_CASE));
+
+    const decision = selectSolverAlgorithm(loadFlowCase, DEFAULT_SOLVE_OPTIONS);
+    expect(decision.selected).toBe("NEWTON_RAPHSON");
+  });
+
+  it("switches to fast-decoupled heuristic for large systems", () => {
+    const loadFlowCase = JSON.parse(JSON.stringify(DEFAULT_LOAD_FLOW_CASE));
+    loadFlowCase.buses = Array.from({ length: 120 }, (_, index) => ({
+      id: `bus-${index + 1}`,
+      name: `Bus ${index + 1}`,
+      baseKV: 230,
+      type: index === 0 ? "SLACK" : "PQ",
+    }));
+
+    const decision = selectSolverAlgorithm(loadFlowCase, DEFAULT_SOLVE_OPTIONS);
+    expect(decision.selected).toBe("FAST_DECOUPLED");
+  });
+});

--- a/src/features/load-flow/solver/__tests__/initialization.test.ts
+++ b/src/features/load-flow/solver/__tests__/initialization.test.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_LOAD_FLOW_CASE } from "@/features/load-flow/model/defaults";
+
+import { buildInitialization } from "../initialization";
+
+describe("buildInitialization", () => {
+  it("returns deterministic flat start voltage state", () => {
+    const loadFlowCase = JSON.parse(JSON.stringify(DEFAULT_LOAD_FLOW_CASE));
+
+    const initialization = buildInitialization(loadFlowCase, "FLAT_START");
+
+    expect(initialization.source).toBe("FLAT_START");
+    expect(initialization.voltageMagnitudeByBusId["bus-1"]).toBe(1);
+    expect(initialization.voltageAngleDegByBusId["bus-1"]).toBe(0);
+  });
+});

--- a/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
+++ b/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_LOAD_FLOW_CASE } from "@/features/load-flow/model/defaults";
+
+import { runLoadFlow } from "../runLoadFlow";
+
+describe("runLoadFlow", () => {
+  it("returns structured diagnostics from solver skeleton", () => {
+    const loadFlowCase = JSON.parse(JSON.stringify(DEFAULT_LOAD_FLOW_CASE));
+
+    const result = runLoadFlow(loadFlowCase);
+
+    expect(result.diagnostics.converged).toBe(false);
+    expect(result.diagnostics.algorithm).toBe("NEWTON_RAPHSON");
+    expect(result.diagnostics.initialization).toBe("FLAT_START");
+  });
+});

--- a/src/features/load-flow/solver/algorithmSelection.ts
+++ b/src/features/load-flow/solver/algorithmSelection.ts
@@ -1,0 +1,31 @@
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+
+import { AlgorithmSelectionDecision, SolveOptions } from "./types";
+
+const LARGE_CASE_THRESHOLD = 120;
+
+export const selectSolverAlgorithm = (
+  loadFlowCase: LoadFlowCase,
+  options: SolveOptions
+): AlgorithmSelectionDecision => {
+  if (options.algorithm !== "NEWTON_RAPHSON") {
+    return {
+      selected: options.algorithm,
+      reason: "Explicit solver override from options.",
+    };
+  }
+
+  if (loadFlowCase.buses.length >= LARGE_CASE_THRESHOLD) {
+    return {
+      selected: "FAST_DECOUPLED",
+      reason:
+        "Large network heuristic: prefer fast-decoupled as default baseline for iteration speed.",
+    };
+  }
+
+  return {
+    selected: "NEWTON_RAPHSON",
+    reason:
+      "Default for small/medium systems and robust mixed-bus convergence.",
+  };
+};

--- a/src/features/load-flow/solver/algorithmSelection.ts
+++ b/src/features/load-flow/solver/algorithmSelection.ts
@@ -1,31 +1,17 @@
 import { LoadFlowCase } from "@/features/load-flow/model/types";
 
-import { AlgorithmSelectionDecision, SolveOptions } from "./types";
+import { SolveOptions, SolverAlgorithm } from "./types";
 
-const LARGE_CASE_THRESHOLD = 120;
+export interface AlgorithmSelectionDecision {
+  selected: SolverAlgorithm;
+  reason: string;
+}
 
 export const selectSolverAlgorithm = (
-  loadFlowCase: LoadFlowCase,
+  _loadFlowCase: LoadFlowCase,
   options: SolveOptions
-): AlgorithmSelectionDecision => {
-  if (options.algorithm !== "NEWTON_RAPHSON") {
-    return {
-      selected: options.algorithm,
-      reason: "Explicit solver override from options.",
-    };
-  }
-
-  if (loadFlowCase.buses.length >= LARGE_CASE_THRESHOLD) {
-    return {
-      selected: "FAST_DECOUPLED",
-      reason:
-        "Large network heuristic: prefer fast-decoupled as default baseline for iteration speed.",
-    };
-  }
-
-  return {
-    selected: "NEWTON_RAPHSON",
-    reason:
-      "Default for small/medium systems and robust mixed-bus convergence.",
-  };
-};
+): AlgorithmSelectionDecision => ({
+  selected: options.algorithm,
+  reason:
+    "Newton-Raphson is the only implemented algorithm in the current engine phase.",
+});

--- a/src/features/load-flow/solver/initialization.ts
+++ b/src/features/load-flow/solver/initialization.ts
@@ -1,0 +1,25 @@
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+
+import { InitializationMode, SolverInitialization } from "./types";
+
+const getVoltageMagnitudeStart = (): number => 1;
+const getVoltageAngleStart = (): number => 0;
+
+export const buildInitialization = (
+  loadFlowCase: LoadFlowCase,
+  mode: InitializationMode
+): SolverInitialization => {
+  const voltageMagnitudeByBusId: Record<string, number> = {};
+  const voltageAngleDegByBusId: Record<string, number> = {};
+
+  for (const bus of loadFlowCase.buses) {
+    voltageMagnitudeByBusId[bus.id] = getVoltageMagnitudeStart();
+    voltageAngleDegByBusId[bus.id] = getVoltageAngleStart();
+  }
+
+  return {
+    voltageMagnitudeByBusId,
+    voltageAngleDegByBusId,
+    source: mode,
+  };
+};

--- a/src/features/load-flow/solver/runLoadFlow.ts
+++ b/src/features/load-flow/solver/runLoadFlow.ts
@@ -33,7 +33,7 @@ export const runLoadFlow = (
       algorithm: algorithmDecision.selected,
       initialization: initialization.source,
       message:
-        "Solver skeleton is configured. Newton-Raphson and fast-decoupled iteration kernels are not yet implemented.",
+        "Solver skeleton is configured. Newton-Raphson iteration kernels are not yet implemented.",
       iterationsCompleted: 0,
     },
   };

--- a/src/features/load-flow/solver/runLoadFlow.ts
+++ b/src/features/load-flow/solver/runLoadFlow.ts
@@ -1,0 +1,44 @@
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+
+import { selectSolverAlgorithm } from "./algorithmSelection";
+import { buildInitialization } from "./initialization";
+import {
+  DEFAULT_SOLVE_OPTIONS,
+  LoadFlowEngine,
+  LoadFlowResult,
+  SolveOptions,
+} from "./types";
+
+export const runLoadFlow = (
+  loadFlowCase: LoadFlowCase,
+  options?: Partial<SolveOptions>
+): LoadFlowResult => {
+  const resolvedOptions: SolveOptions = {
+    ...DEFAULT_SOLVE_OPTIONS,
+    ...options,
+  };
+
+  const algorithmDecision = selectSolverAlgorithm(
+    loadFlowCase,
+    resolvedOptions
+  );
+  const initialization = buildInitialization(
+    loadFlowCase,
+    resolvedOptions.initialization
+  );
+
+  return {
+    diagnostics: {
+      converged: false,
+      algorithm: algorithmDecision.selected,
+      initialization: initialization.source,
+      message:
+        "Solver skeleton is configured. Newton-Raphson and fast-decoupled iteration kernels are not yet implemented.",
+      iterationsCompleted: 0,
+    },
+  };
+};
+
+export const loadFlowEngine: LoadFlowEngine = {
+  solve: runLoadFlow,
+};

--- a/src/features/load-flow/solver/types.ts
+++ b/src/features/load-flow/solver/types.ts
@@ -1,0 +1,52 @@
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+
+export type SolverAlgorithm = "NEWTON_RAPHSON" | "FAST_DECOUPLED";
+export type InitializationMode = "FLAT_START" | "WARM_START" | "DC_ANGLE_SEED";
+
+export interface SolveOptions {
+  tolerance: number;
+  maxIterations: number;
+  damping: number;
+  enforceReactiveLimits: boolean;
+  algorithm: SolverAlgorithm;
+  initialization: InitializationMode;
+}
+
+export interface SolverInitialization {
+  voltageMagnitudeByBusId: Record<string, number>;
+  voltageAngleDegByBusId: Record<string, number>;
+  source: InitializationMode;
+}
+
+export interface AlgorithmSelectionDecision {
+  selected: SolverAlgorithm;
+  reason: string;
+}
+
+export interface LoadFlowDiagnostics {
+  converged: boolean;
+  algorithm: SolverAlgorithm;
+  initialization: InitializationMode;
+  message: string;
+  iterationsCompleted: number;
+}
+
+export interface LoadFlowResult {
+  diagnostics: LoadFlowDiagnostics;
+}
+
+export interface LoadFlowEngine {
+  solve: (
+    loadFlowCase: LoadFlowCase,
+    options?: Partial<SolveOptions>
+  ) => LoadFlowResult;
+}
+
+export const DEFAULT_SOLVE_OPTIONS: SolveOptions = {
+  tolerance: 1e-6,
+  maxIterations: 20,
+  damping: 1,
+  enforceReactiveLimits: true,
+  algorithm: "NEWTON_RAPHSON",
+  initialization: "FLAT_START",
+};

--- a/src/features/load-flow/solver/types.ts
+++ b/src/features/load-flow/solver/types.ts
@@ -1,7 +1,11 @@
 import { LoadFlowCase } from "@/features/load-flow/model/types";
 
-export type SolverAlgorithm = "NEWTON_RAPHSON" | "FAST_DECOUPLED";
-export type InitializationMode = "FLAT_START" | "WARM_START" | "DC_ANGLE_SEED";
+/**
+ * Keep the public surface area intentionally narrow until the first
+ * numerical kernel is production-ready.
+ */
+export type SolverAlgorithm = "NEWTON_RAPHSON";
+export type InitializationMode = "FLAT_START";
 
 export interface SolveOptions {
   tolerance: number;
@@ -16,11 +20,6 @@ export interface SolverInitialization {
   voltageMagnitudeByBusId: Record<string, number>;
   voltageAngleDegByBusId: Record<string, number>;
   source: InitializationMode;
-}
-
-export interface AlgorithmSelectionDecision {
-  selected: SolverAlgorithm;
-  reason: string;
 }
 
 export interface LoadFlowDiagnostics {

--- a/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
+++ b/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
@@ -1,8 +1,8 @@
+import { toLoadFlowCase } from "@/features/load-flow/graph/toLoadFlowCase";
 import {
   addBranch,
   addBus,
   createInitialLoadFlowEditorState,
-  toLoadFlowCase,
   updateBus,
 } from "@/features/load-flow/state/loadFlowStore";
 

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -1,9 +1,4 @@
-import {
-  Branch,
-  Bus,
-  BusType,
-  LoadFlowCase,
-} from "@/features/load-flow/model/types";
+import { BusType } from "@/features/load-flow/model/types";
 
 export interface BusNode {
   id: string;
@@ -160,35 +155,3 @@ export const selectElement = (
   selectedElementType: elementType,
   selectedElementId: elementId,
 });
-
-export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
-  const buses: Bus[] = state.busOrder.map((busId) => {
-    const bus = state.busesById[busId];
-    return {
-      id: bus.id,
-      name: bus.name,
-      baseKV: bus.baseKV,
-      type: bus.type,
-    };
-  });
-  const branches: Branch[] = state.branchOrder.map((branchId) => {
-    const branch = state.branchesById[branchId];
-    return {
-      id: branch.id,
-      fromBusId: branch.fromBusId,
-      toBusId: branch.toBusId,
-      r: branch.r,
-      x: branch.x,
-      bHalf: branch.bHalf,
-    };
-  });
-
-  return {
-    baseMVA: state.baseMVA,
-    buses,
-    branches,
-    generators: [],
-    loads: [],
-    shunts: [],
-  };
-};


### PR DESCRIPTION
### Motivation

- Improve separation between the interactive editor UI and the numerical load-flow engine so the solver can be extracted or replaced without UI churn. 
- Make the solver implementation plan concrete by specifying algorithm selection policy and deterministic initialization modes to guide numerical kernel work. 
- Represent the planned directory layout in code so the next PR can focus on numerical kernels with minimal refactoring. 

### Description

- Move editor-to-domain serialization out of the editor store and into a dedicated adapter at `src/features/load-flow/graph/toLoadFlowCase.ts` so `state/` stays editor-focused. 
- Add a typed solver scaffold under `src/features/load-flow/solver/` including `types.ts`, `initialization.ts`, `algorithmSelection.ts`, and the `runLoadFlow` facade so the engine API contract is stable. 
- Add unit tests for algorithm selection, initialization, and the `runLoadFlow` facade at `src/features/load-flow/solver/__tests__/` and update editor tests to consume the new `toLoadFlowCase` adapter. 
- Update the implementation plan document `docs/load-flow-implementation-plan.md` with an `Assessment Snapshot`, `Algorithm decision policy` and `Initialization policy`, and update the `/load-flow` page copy to reflect the scaffolding status. 

### Testing

- Ran `yarn lint` and formatting checks which completed successfully. 
- Ran `yarn typecheck` which completed with no errors. 
- Ran the full unit test suite via `yarn test` and all tests passed (`36` test suites, `137` tests). 
- Built the site with `yarn build` and executed the Playwright host-mode smoke and visual suites (`yarn test:e2e:host` and `yarn test:e2e:visual:host`), and the E2E/visual checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc8a4abf048323b66f90771dd3bcf7)