### PR TITLE
Implement Newton–Raphson load-flow engine and wire reference scenarios into /load-flow workspace

### DIFF
--- a/src/app/load-flow/__tests__/page.test.tsx
+++ b/src/app/load-flow/__tests__/page.test.tsx
@@ -11,7 +11,7 @@ describe("LoadFlowPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Workspace")).toBeInTheDocument();
     expect(
-      screen.getByText(/foundation for an in-browser AC power flow tool/i)
+      screen.getByText(/newton-raphson ac load flow engine/i)
     ).toBeInTheDocument();
   });
 });

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -5,6 +5,11 @@ import { useMemo, useState } from "react";
 import { toLoadFlowCase } from "@/features/load-flow/graph/toLoadFlowCase";
 import { BusType } from "@/features/load-flow/model/types";
 import {
+  getReferenceScenarioById,
+  LOAD_FLOW_REFERENCE_SCENARIOS,
+} from "@/features/load-flow/solver/referenceScenarios";
+import { runLoadFlow } from "@/features/load-flow/solver/runLoadFlow";
+import {
   addBranch,
   addBus,
   createInitialLoadFlowEditorState,
@@ -42,14 +47,75 @@ export function LoadFlowWorkspace() {
     () => toLoadFlowCase(editorState),
     [editorState]
   );
+  const solveResult = useMemo(
+    () => runLoadFlow(serializedCase),
+    [serializedCase]
+  );
 
   return (
     <section className="rounded-xl border border-gray-700 bg-gray-900/60 p-6 shadow-sm">
       <h2 className="text-heading-sm text-white">Workspace</h2>
       <p className="text-body mt-2 text-gray-300">
-        Foundation editor for buses and lines with normalized state
-        serialization.
+        Build a one-line model, run an AC load flow solve, and inspect voltage
+        and branch flow outputs.
       </p>
+
+      <div className="mt-4 rounded-lg border border-emerald-700/70 bg-emerald-950/30 p-4">
+        <h3 className="font-semibold text-emerald-200">Reference scenarios</h3>
+        <p className="mt-1 text-sm text-emerald-100/90">
+          Load a standard scenario to validate the solver before building a
+          custom case.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {LOAD_FLOW_REFERENCE_SCENARIOS.map((scenario) => (
+            <button
+              key={scenario.id}
+              type="button"
+              className="rounded-md border border-emerald-500 px-3 py-2 text-sm text-emerald-100 hover:bg-emerald-900/50"
+              onClick={() => {
+                const selectedScenario = getReferenceScenarioById(scenario.id);
+                if (!selectedScenario) {
+                  return;
+                }
+
+                setEditorState((prev) => ({
+                  ...prev,
+                  baseMVA: selectedScenario.loadFlowCase.baseMVA,
+                  busesById: Object.fromEntries(
+                    selectedScenario.loadFlowCase.buses.map((bus, index) => [
+                      bus.id,
+                      {
+                        ...bus,
+                        x: 120 + index * 120,
+                        y: 140,
+                      },
+                    ])
+                  ),
+                  busOrder: selectedScenario.loadFlowCase.buses.map(
+                    (bus) => bus.id
+                  ),
+                  branchesById: Object.fromEntries(
+                    selectedScenario.loadFlowCase.branches.map((branch) => [
+                      branch.id,
+                      {
+                        ...branch,
+                        bHalf: branch.bHalf ?? 0,
+                      },
+                    ])
+                  ),
+                  branchOrder: selectedScenario.loadFlowCase.branches.map(
+                    (branch) => branch.id
+                  ),
+                  selectedElementType: null,
+                  selectedElementId: null,
+                }));
+              }}
+            >
+              {scenario.name}
+            </button>
+          ))}
+        </div>
+      </div>
 
       <div className="mt-6 grid gap-4 lg:grid-cols-3">
         <div className="rounded-lg border border-gray-700 p-4">
@@ -202,6 +268,41 @@ export function LoadFlowWorkspace() {
             </p>
           ) : null}
         </div>
+      </div>
+
+      <div className="mt-6 rounded-lg border border-gray-700 p-4">
+        <h3 className="font-semibold text-white">Solve results</h3>
+        <p className="mt-2 text-sm text-gray-300">
+          {solveResult.diagnostics.message}
+        </p>
+        {solveResult.buses ? (
+          <div className="mt-3 overflow-auto">
+            <table className="min-w-full text-left text-xs text-gray-200">
+              <thead>
+                <tr>
+                  <th className="pr-3">Bus</th>
+                  <th className="pr-3">|V| (pu)</th>
+                  <th className="pr-3">θ (deg)</th>
+                  <th className="pr-3">P inj (pu)</th>
+                  <th>Q inj (pu)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {solveResult.buses.map((bus) => (
+                  <tr key={bus.busId}>
+                    <td className="pr-3">{bus.busId}</td>
+                    <td className="pr-3">
+                      {bus.voltageMagnitudePu.toFixed(4)}
+                    </td>
+                    <td className="pr-3">{bus.voltageAngleDeg.toFixed(3)}</td>
+                    <td className="pr-3">{bus.pInjectionPu.toFixed(4)}</td>
+                    <td>{bus.qInjectionPu.toFixed(4)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
       </div>
 
       <div className="mt-6 rounded-lg border border-gray-700 p-4">

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -32,6 +32,8 @@ export function LoadFlowWorkspace() {
   const [editorState, setEditorState] = useState(
     createInitialLoadFlowEditorState
   );
+  const [selectedReferenceScenarioId, setSelectedReferenceScenarioId] =
+    useState<string | null>(null);
 
   const selectedBus =
     editorState.selectedElementType === "BUS" && editorState.selectedElementId
@@ -47,9 +49,17 @@ export function LoadFlowWorkspace() {
     () => toLoadFlowCase(editorState),
     [editorState]
   );
+  const selectedReferenceScenario = selectedReferenceScenarioId
+    ? getReferenceScenarioById(selectedReferenceScenarioId)
+    : undefined;
+
+  const activeSolveCase = selectedReferenceScenario
+    ? selectedReferenceScenario.loadFlowCase
+    : serializedCase;
+
   const solveResult = useMemo(
-    () => runLoadFlow(serializedCase),
-    [serializedCase]
+    () => runLoadFlow(activeSolveCase),
+    [activeSolveCase]
   );
 
   return (
@@ -63,58 +73,38 @@ export function LoadFlowWorkspace() {
       <div className="mt-4 rounded-lg border border-emerald-700/70 bg-emerald-950/30 p-4">
         <h3 className="font-semibold text-emerald-200">Reference scenarios</h3>
         <p className="mt-1 text-sm text-emerald-100/90">
-          Load a standard scenario to validate the solver before building a
-          custom case.
+          Solve against standard benchmark cases, or switch back to the current
+          editor graph model.
         </p>
         <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="rounded-md border border-emerald-500 px-3 py-2 text-sm text-emerald-100 hover:bg-emerald-900/50"
+            onClick={() => setSelectedReferenceScenarioId(null)}
+          >
+            Use editor model
+          </button>
           {LOAD_FLOW_REFERENCE_SCENARIOS.map((scenario) => (
             <button
               key={scenario.id}
               type="button"
               className="rounded-md border border-emerald-500 px-3 py-2 text-sm text-emerald-100 hover:bg-emerald-900/50"
-              onClick={() => {
-                const selectedScenario = getReferenceScenarioById(scenario.id);
-                if (!selectedScenario) {
-                  return;
-                }
-
-                setEditorState((prev) => ({
-                  ...prev,
-                  baseMVA: selectedScenario.loadFlowCase.baseMVA,
-                  busesById: Object.fromEntries(
-                    selectedScenario.loadFlowCase.buses.map((bus, index) => [
-                      bus.id,
-                      {
-                        ...bus,
-                        x: 120 + index * 120,
-                        y: 140,
-                      },
-                    ])
-                  ),
-                  busOrder: selectedScenario.loadFlowCase.buses.map(
-                    (bus) => bus.id
-                  ),
-                  branchesById: Object.fromEntries(
-                    selectedScenario.loadFlowCase.branches.map((branch) => [
-                      branch.id,
-                      {
-                        ...branch,
-                        bHalf: branch.bHalf ?? 0,
-                      },
-                    ])
-                  ),
-                  branchOrder: selectedScenario.loadFlowCase.branches.map(
-                    (branch) => branch.id
-                  ),
-                  selectedElementType: null,
-                  selectedElementId: null,
-                }));
-              }}
+              onClick={() => setSelectedReferenceScenarioId(scenario.id)}
             >
               {scenario.name}
             </button>
           ))}
         </div>
+        {selectedReferenceScenario ? (
+          <p className="mt-2 text-xs text-emerald-100/80">
+            Active solve case: {selectedReferenceScenario.name} —{" "}
+            {selectedReferenceScenario.description}
+          </p>
+        ) : (
+          <p className="mt-2 text-xs text-emerald-100/80">
+            Active solve case: editor graph serialization.
+          </p>
+        )}
       </div>
 
       <div className="mt-6 grid gap-4 lg:grid-cols-3">

--- a/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
+++ b/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { LoadFlowWorkspace } from "../LoadFlowWorkspace";
+
+describe("LoadFlowWorkspace", () => {
+  it("solves the selected reference scenario using full scenario data", () => {
+    render(<LoadFlowWorkspace />);
+
+    expect(
+      screen.getByText(/exactly one slack bus is required/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "2-Bus Radial" }));
+
+    expect(screen.getByText(/converged in/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Active solve case: 2-Bus Radial/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/load-flow/page.tsx
+++ b/src/app/load-flow/page.tsx
@@ -42,12 +42,10 @@ export default function LoadFlowPage() {
       <PageShell title="Load Flow" titleId="load-flow">
         <ResponsiveContainer element="section" className="space-y-6">
           <p className="text-body text-gray-300">
-            This page is the foundation for an in-browser AC power flow tool.
-            This milestone now includes a first-pass canvas foundation for
-            adding buses and lines, plus normalized editor state serialization.
-            Solver scaffolding now separates graph serialization from the
-            upcoming engine layer and documents algorithm/initialization policy
-            before numerical kernels land.
+            This workspace now includes a Newton-Raphson AC load flow engine
+            with reference scenarios, bus-voltage results, and branch-flow
+            outputs. You can start from a standard benchmark case or build and
+            tune a custom one-line model directly in the browser.
           </p>
           <LoadFlowWorkspace />
         </ResponsiveContainer>

--- a/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
+++ b/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
@@ -60,6 +60,27 @@ describe("runLoadFlow", () => {
     expect(result.diagnostics.iterationMaxMismatchPu.length).toBeGreaterThan(0);
   });
 
+  it("returns consistent bus injections when max iterations are hit", () => {
+    const scenario = LOAD_FLOW_REFERENCE_SCENARIOS.find(
+      (item) => item.id === "two-bus-radial"
+    );
+
+    expect(scenario).toBeDefined();
+
+    const result = runLoadFlow(scenario!.loadFlowCase, {
+      maxIterations: 1,
+      tolerance: 1e-12,
+    });
+
+    expect(result.diagnostics.converged).toBe(false);
+    expect(result.buses).toBeDefined();
+
+    for (const bus of result.buses ?? []) {
+      expect(Number.isFinite(bus.pInjectionPu)).toBe(true);
+      expect(Number.isFinite(bus.qInjectionPu)).toBe(true);
+    }
+  });
+
   it("reports island diagnostics for disconnected networks", () => {
     const islandedCase = {
       ...DEFAULT_LOAD_FLOW_CASE,

--- a/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
+++ b/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
@@ -1,15 +1,82 @@
 import { DEFAULT_LOAD_FLOW_CASE } from "@/features/load-flow/model/defaults";
 
+import { LOAD_FLOW_REFERENCE_SCENARIOS } from "../referenceScenarios";
 import { runLoadFlow } from "../runLoadFlow";
 
 describe("runLoadFlow", () => {
-  it("returns structured diagnostics from solver skeleton", () => {
-    const loadFlowCase = JSON.parse(JSON.stringify(DEFAULT_LOAD_FLOW_CASE));
+  it("returns validation diagnostics for invalid cases", () => {
+    const invalidCase = {
+      ...DEFAULT_LOAD_FLOW_CASE,
+      baseMVA: 0,
+    };
 
-    const result = runLoadFlow(loadFlowCase);
+    const result = runLoadFlow(invalidCase);
 
     expect(result.diagnostics.converged).toBe(false);
-    expect(result.diagnostics.algorithm).toBe("NEWTON_RAPHSON");
-    expect(result.diagnostics.initialization).toBe("FLAT_START");
+    expect(result.diagnostics.message).toMatch(/base mva/i);
+    expect(result.buses).toBeUndefined();
+  });
+
+  it("solves the two-bus radial reference scenario", () => {
+    const scenario = LOAD_FLOW_REFERENCE_SCENARIOS.find(
+      (item) => item.id === "two-bus-radial"
+    );
+
+    expect(scenario).toBeDefined();
+
+    const result = runLoadFlow(scenario!.loadFlowCase);
+
+    expect(result.diagnostics.converged).toBe(true);
+    expect(result.buses).toHaveLength(2);
+
+    const plantBus = result.buses?.find((bus) => bus.busId === "bus-2");
+    expect(plantBus).toBeDefined();
+    expect(plantBus?.voltageMagnitudePu).toBeGreaterThan(0.94);
+    expect(plantBus?.voltageMagnitudePu).toBeLessThan(0.98);
+    expect(plantBus?.voltageAngleDeg).toBeLessThan(0);
+    expect(result.branchFlows).toHaveLength(1);
+  });
+
+  it("solves the three-bus PV + PQ reference scenario", () => {
+    const scenario = LOAD_FLOW_REFERENCE_SCENARIOS.find(
+      (item) => item.id === "three-bus-with-pv"
+    );
+
+    expect(scenario).toBeDefined();
+
+    const result = runLoadFlow(scenario!.loadFlowCase);
+
+    expect(result.diagnostics.converged).toBe(true);
+    expect(result.buses).toHaveLength(3);
+
+    const pvBus = result.buses?.find((bus) => bus.busId === "bus-2");
+    const pqBus = result.buses?.find((bus) => bus.busId === "bus-3");
+
+    expect(pvBus?.voltageMagnitudePu).toBeCloseTo(1.025, 6);
+    expect(pqBus?.voltageMagnitudePu).toBeGreaterThan(0.94);
+    expect(pqBus?.voltageMagnitudePu).toBeLessThan(0.99);
+    expect(pqBus?.voltageAngleDeg).toBeLessThan(0);
+    expect(result.diagnostics.maxMismatchPu).not.toBeNull();
+    expect(result.diagnostics.iterationMaxMismatchPu.length).toBeGreaterThan(0);
+  });
+
+  it("reports island diagnostics for disconnected networks", () => {
+    const islandedCase = {
+      ...DEFAULT_LOAD_FLOW_CASE,
+      buses: [
+        ...DEFAULT_LOAD_FLOW_CASE.buses,
+        {
+          id: "bus-2",
+          name: "Islanded bus",
+          baseKV: 13.8,
+          type: "PQ" as const,
+        },
+      ],
+    };
+
+    const result = runLoadFlow(islandedCase);
+
+    expect(result.diagnostics.converged).toBe(false);
+    expect(result.diagnostics.message).toMatch(/island/i);
   });
 });

--- a/src/features/load-flow/solver/complex.ts
+++ b/src/features/load-flow/solver/complex.ts
@@ -1,0 +1,45 @@
+export interface Complex {
+  re: number;
+  im: number;
+}
+
+export const complex = (re: number, im: number): Complex => ({ re, im });
+
+export const addComplex = (a: Complex, b: Complex): Complex => ({
+  re: a.re + b.re,
+  im: a.im + b.im,
+});
+
+export const subtractComplex = (a: Complex, b: Complex): Complex => ({
+  re: a.re - b.re,
+  im: a.im - b.im,
+});
+
+export const multiplyComplex = (a: Complex, b: Complex): Complex => ({
+  re: a.re * b.re - a.im * b.im,
+  im: a.re * b.im + a.im * b.re,
+});
+
+export const divideComplex = (a: Complex, b: Complex): Complex => {
+  const denominator = b.re * b.re + b.im * b.im;
+  return {
+    re: (a.re * b.re + a.im * b.im) / denominator,
+    im: (a.im * b.re - a.re * b.im) / denominator,
+  };
+};
+
+export const conjugateComplex = (value: Complex): Complex => ({
+  re: value.re,
+  im: -value.im,
+});
+
+export const absComplex = (value: Complex): number =>
+  Math.hypot(value.re, value.im);
+
+export const polarToComplex = (
+  magnitude: number,
+  angleRad: number
+): Complex => ({
+  re: magnitude * Math.cos(angleRad),
+  im: magnitude * Math.sin(angleRad),
+});

--- a/src/features/load-flow/solver/complex.ts
+++ b/src/features/load-flow/solver/complex.ts
@@ -33,9 +33,6 @@ export const conjugateComplex = (value: Complex): Complex => ({
   im: -value.im,
 });
 
-export const absComplex = (value: Complex): number =>
-  Math.hypot(value.re, value.im);
-
 export const polarToComplex = (
   magnitude: number,
   angleRad: number

--- a/src/features/load-flow/solver/newtonRaphsonSolver.ts
+++ b/src/features/load-flow/solver/newtonRaphsonSolver.ts
@@ -1,0 +1,602 @@
+import { Bus, BusType, LoadFlowCase } from "@/features/load-flow/model/types";
+
+import {
+  addComplex,
+  Complex,
+  complex,
+  conjugateComplex,
+  divideComplex,
+  multiplyComplex,
+  polarToComplex,
+  subtractComplex,
+} from "./complex";
+import { buildInitialization } from "./initialization";
+import {
+  BranchFlowSolution,
+  BusSolution,
+  LoadFlowResult,
+  SolveOptions,
+} from "./types";
+
+interface SolveState {
+  voltageMagnitudes: number[];
+  voltageAnglesRad: number[];
+}
+
+interface SpecifiedInjections {
+  pByBusIndex: number[];
+  qByBusIndex: number[];
+}
+
+interface BusPartitions {
+  slack: number[];
+  pv: number[];
+  pq: number[];
+  nonSlack: number[];
+}
+
+const toRadians = (degrees: number): number => (degrees * Math.PI) / 180;
+const toDegrees = (radians: number): number => (radians * 180) / Math.PI;
+
+const createMatrix = (size: number): number[][] =>
+  Array.from({ length: size }, () => Array(size).fill(0));
+
+const solveLinearSystem = (a: number[][], b: number[]): number[] => {
+  const size = a.length;
+  const augmented = a.map((row, rowIndex) => [...row, b[rowIndex]]);
+
+  for (let pivot = 0; pivot < size; pivot += 1) {
+    let maxRow = pivot;
+    let maxValue = Math.abs(augmented[pivot][pivot]);
+
+    for (let row = pivot + 1; row < size; row += 1) {
+      const candidate = Math.abs(augmented[row][pivot]);
+      if (candidate > maxValue) {
+        maxValue = candidate;
+        maxRow = row;
+      }
+    }
+
+    if (maxValue < 1e-12) {
+      throw new Error("Jacobian is singular or ill-conditioned.");
+    }
+
+    if (maxRow !== pivot) {
+      const temp = augmented[pivot];
+      augmented[pivot] = augmented[maxRow];
+      augmented[maxRow] = temp;
+    }
+
+    for (let row = pivot + 1; row < size; row += 1) {
+      const factor = augmented[row][pivot] / augmented[pivot][pivot];
+      for (let col = pivot; col <= size; col += 1) {
+        augmented[row][col] -= factor * augmented[pivot][col];
+      }
+    }
+  }
+
+  const solution = Array(size).fill(0);
+  for (let row = size - 1; row >= 0; row -= 1) {
+    let total = augmented[row][size];
+    for (let col = row + 1; col < size; col += 1) {
+      total -= augmented[row][col] * solution[col];
+    }
+    solution[row] = total / augmented[row][row];
+  }
+
+  return solution;
+};
+
+const getBusPartitions = (buses: Bus[]): BusPartitions => {
+  const slack: number[] = [];
+  const pv: number[] = [];
+  const pq: number[] = [];
+
+  buses.forEach((bus, index) => {
+    if (bus.type === "SLACK") {
+      slack.push(index);
+      return;
+    }
+
+    if (bus.type === "PV") {
+      pv.push(index);
+      return;
+    }
+
+    pq.push(index);
+  });
+
+  return {
+    slack,
+    pv,
+    pq,
+    nonSlack: [...pv, ...pq],
+  };
+};
+
+const buildYBus = (
+  loadFlowCase: LoadFlowCase,
+  busIndexById: Record<string, number>
+): Complex[][] => {
+  const size = loadFlowCase.buses.length;
+  const yBus = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => complex(0, 0))
+  );
+
+  for (const branch of loadFlowCase.branches) {
+    if (branch.status === "OUT_OF_SERVICE") {
+      continue;
+    }
+
+    const fromIndex = busIndexById[branch.fromBusId];
+    const toIndex = busIndexById[branch.toBusId];
+
+    const seriesAdmittance = divideComplex(
+      complex(1, 0),
+      complex(branch.r, branch.x)
+    );
+    const shuntAdmittance = complex(0, branch.bHalf ?? 0);
+
+    yBus[fromIndex][fromIndex] = addComplex(
+      yBus[fromIndex][fromIndex],
+      addComplex(seriesAdmittance, shuntAdmittance)
+    );
+    yBus[toIndex][toIndex] = addComplex(
+      yBus[toIndex][toIndex],
+      addComplex(seriesAdmittance, shuntAdmittance)
+    );
+
+    yBus[fromIndex][toIndex] = subtractComplex(
+      yBus[fromIndex][toIndex],
+      seriesAdmittance
+    );
+    yBus[toIndex][fromIndex] = subtractComplex(
+      yBus[toIndex][fromIndex],
+      seriesAdmittance
+    );
+  }
+
+  for (const shunt of loadFlowCase.shunts) {
+    if (shunt.status !== "ON") {
+      continue;
+    }
+
+    const busIndex = busIndexById[shunt.busId];
+    const signedSusceptance =
+      shunt.kind === "CAPACITOR" ? shunt.bPu : -Math.abs(shunt.bPu);
+    yBus[busIndex][busIndex] = addComplex(
+      yBus[busIndex][busIndex],
+      complex(0, signedSusceptance)
+    );
+  }
+
+  return yBus;
+};
+
+const computeSpecifiedInjections = (
+  loadFlowCase: LoadFlowCase,
+  busIndexById: Record<string, number>
+): SpecifiedInjections => {
+  const size = loadFlowCase.buses.length;
+  const pByBusIndex = Array(size).fill(0);
+  const qByBusIndex = Array(size).fill(0);
+
+  for (const generator of loadFlowCase.generators) {
+    if (generator.status !== "ON") {
+      continue;
+    }
+
+    const index = busIndexById[generator.busId];
+    pByBusIndex[index] += generator.pSet / loadFlowCase.baseMVA;
+  }
+
+  for (const load of loadFlowCase.loads) {
+    if (load.status !== "ON") {
+      continue;
+    }
+
+    const index = busIndexById[load.busId];
+    pByBusIndex[index] -= load.p / loadFlowCase.baseMVA;
+    qByBusIndex[index] -= load.q / loadFlowCase.baseMVA;
+  }
+
+  return { pByBusIndex, qByBusIndex };
+};
+
+const calculatePowerInjections = (
+  yBus: Complex[][],
+  state: SolveState
+): { pCalculated: number[]; qCalculated: number[] } => {
+  const size = yBus.length;
+  const pCalculated = Array(size).fill(0);
+  const qCalculated = Array(size).fill(0);
+
+  for (let i = 0; i < size; i += 1) {
+    for (let j = 0; j < size; j += 1) {
+      const delta = state.voltageAnglesRad[i] - state.voltageAnglesRad[j];
+      const g = yBus[i][j].re;
+      const b = yBus[i][j].im;
+      const vmProduct = state.voltageMagnitudes[i] * state.voltageMagnitudes[j];
+
+      pCalculated[i] += vmProduct * (g * Math.cos(delta) + b * Math.sin(delta));
+      qCalculated[i] += vmProduct * (g * Math.sin(delta) - b * Math.cos(delta));
+    }
+  }
+
+  return { pCalculated, qCalculated };
+};
+
+const buildJacobian = (
+  yBus: Complex[][],
+  state: SolveState,
+  partitions: BusPartitions,
+  pCalculated: number[],
+  qCalculated: number[]
+): number[][] => {
+  const pSize = partitions.nonSlack.length;
+  const qSize = partitions.pq.length;
+  const totalSize = pSize + qSize;
+  const jacobian = createMatrix(totalSize);
+
+  partitions.nonSlack.forEach((i, row) => {
+    partitions.nonSlack.forEach((j, col) => {
+      if (i === j) {
+        jacobian[row][col] =
+          -qCalculated[i] - yBus[i][i].im * state.voltageMagnitudes[i] ** 2;
+        return;
+      }
+
+      const delta = state.voltageAnglesRad[i] - state.voltageAnglesRad[j];
+      const g = yBus[i][j].re;
+      const b = yBus[i][j].im;
+      jacobian[row][col] =
+        state.voltageMagnitudes[i] *
+        state.voltageMagnitudes[j] *
+        (g * Math.sin(delta) - b * Math.cos(delta));
+    });
+  });
+
+  partitions.nonSlack.forEach((i, row) => {
+    partitions.pq.forEach((j, col) => {
+      const column = pSize + col;
+      if (i === j) {
+        jacobian[row][column] =
+          pCalculated[i] / state.voltageMagnitudes[i] +
+          yBus[i][i].re * state.voltageMagnitudes[i];
+        return;
+      }
+
+      const delta = state.voltageAnglesRad[i] - state.voltageAnglesRad[j];
+      const g = yBus[i][j].re;
+      const b = yBus[i][j].im;
+      jacobian[row][column] =
+        state.voltageMagnitudes[i] *
+        (g * Math.cos(delta) + b * Math.sin(delta));
+    });
+  });
+
+  partitions.pq.forEach((i, row) => {
+    const matrixRow = pSize + row;
+
+    partitions.nonSlack.forEach((j, col) => {
+      if (i === j) {
+        jacobian[matrixRow][col] =
+          pCalculated[i] - yBus[i][i].re * state.voltageMagnitudes[i] ** 2;
+        return;
+      }
+
+      const delta = state.voltageAnglesRad[i] - state.voltageAnglesRad[j];
+      const g = yBus[i][j].re;
+      const b = yBus[i][j].im;
+      jacobian[matrixRow][col] =
+        -state.voltageMagnitudes[i] *
+        state.voltageMagnitudes[j] *
+        (g * Math.cos(delta) + b * Math.sin(delta));
+    });
+
+    partitions.pq.forEach((j, col) => {
+      const matrixCol = pSize + col;
+      if (i === j) {
+        jacobian[matrixRow][matrixCol] =
+          qCalculated[i] / state.voltageMagnitudes[i] -
+          yBus[i][i].im * state.voltageMagnitudes[i];
+        return;
+      }
+
+      const delta = state.voltageAnglesRad[i] - state.voltageAnglesRad[j];
+      const g = yBus[i][j].re;
+      const b = yBus[i][j].im;
+      jacobian[matrixRow][matrixCol] =
+        state.voltageMagnitudes[i] *
+        (g * Math.sin(delta) - b * Math.cos(delta));
+    });
+  });
+
+  return jacobian;
+};
+
+const buildMismatchVector = (
+  partitions: BusPartitions,
+  specified: SpecifiedInjections,
+  pCalculated: number[],
+  qCalculated: number[]
+): number[] => {
+  const mismatch: number[] = [];
+
+  for (const busIndex of partitions.nonSlack) {
+    mismatch.push(specified.pByBusIndex[busIndex] - pCalculated[busIndex]);
+  }
+
+  for (const busIndex of partitions.pq) {
+    mismatch.push(specified.qByBusIndex[busIndex] - qCalculated[busIndex]);
+  }
+
+  return mismatch;
+};
+
+const getMaximumAbsolute = (values: number[]): number =>
+  values.reduce((maxValue, value) => Math.max(maxValue, Math.abs(value)), 0);
+
+const buildSolvedBusStates = (
+  loadFlowCase: LoadFlowCase,
+  state: SolveState,
+  pCalculated: number[],
+  qCalculated: number[]
+): BusSolution[] =>
+  loadFlowCase.buses.map((bus, index) => ({
+    busId: bus.id,
+    voltageMagnitudePu: state.voltageMagnitudes[index],
+    voltageAngleDeg: toDegrees(state.voltageAnglesRad[index]),
+    pInjectionPu: pCalculated[index],
+    qInjectionPu: qCalculated[index],
+  }));
+
+const buildBranchFlows = (
+  loadFlowCase: LoadFlowCase,
+  busIndexById: Record<string, number>,
+  state: SolveState
+): BranchFlowSolution[] => {
+  const voltageByBusIndex = state.voltageMagnitudes.map((magnitude, index) =>
+    polarToComplex(magnitude, state.voltageAnglesRad[index])
+  );
+
+  return loadFlowCase.branches
+    .filter((branch) => branch.status !== "OUT_OF_SERVICE")
+    .map((branch) => {
+      const fromIndex = busIndexById[branch.fromBusId];
+      const toIndex = busIndexById[branch.toBusId];
+
+      const fromVoltage = voltageByBusIndex[fromIndex];
+      const toVoltage = voltageByBusIndex[toIndex];
+      const seriesAdmittance = divideComplex(
+        complex(1, 0),
+        complex(branch.r, branch.x)
+      );
+      const shuntAdmittance = complex(0, branch.bHalf ?? 0);
+
+      const currentFromTo = addComplex(
+        multiplyComplex(
+          subtractComplex(fromVoltage, toVoltage),
+          seriesAdmittance
+        ),
+        multiplyComplex(fromVoltage, shuntAdmittance)
+      );
+      const currentToFrom = addComplex(
+        multiplyComplex(
+          subtractComplex(toVoltage, fromVoltage),
+          seriesAdmittance
+        ),
+        multiplyComplex(toVoltage, shuntAdmittance)
+      );
+
+      const sFromTo = multiplyComplex(
+        fromVoltage,
+        conjugateComplex(currentFromTo)
+      );
+      const sToFrom = multiplyComplex(
+        toVoltage,
+        conjugateComplex(currentToFrom)
+      );
+
+      return {
+        branchId: branch.id,
+        fromBusId: branch.fromBusId,
+        toBusId: branch.toBusId,
+        pFromToMW: sFromTo.re * loadFlowCase.baseMVA,
+        qFromToMVar: sFromTo.im * loadFlowCase.baseMVA,
+        pToFromMW: sToFrom.re * loadFlowCase.baseMVA,
+        qToFromMVar: sToFrom.im * loadFlowCase.baseMVA,
+        pLossMW: (sFromTo.re + sToFrom.re) * loadFlowCase.baseMVA,
+        qLossMVar: (sFromTo.im + sToFrom.im) * loadFlowCase.baseMVA,
+      };
+    });
+};
+
+const getInitialState = (
+  loadFlowCase: LoadFlowCase,
+  options: SolveOptions
+): SolveState => {
+  const initialization = buildInitialization(
+    loadFlowCase,
+    options.initialization
+  );
+
+  const voltageMagnitudes = loadFlowCase.buses.map((bus) => {
+    if (bus.type === "SLACK" || bus.type === "PV") {
+      return (
+        bus.voltageMagnitudeSetpoint ??
+        initialization.voltageMagnitudeByBusId[bus.id]
+      );
+    }
+
+    return initialization.voltageMagnitudeByBusId[bus.id];
+  });
+
+  const voltageAnglesRad = loadFlowCase.buses.map((bus) => {
+    if (bus.type === "SLACK") {
+      return toRadians(bus.voltageAngleSetpointDeg ?? 0);
+    }
+
+    return toRadians(initialization.voltageAngleDegByBusId[bus.id]);
+  });
+
+  return { voltageMagnitudes, voltageAnglesRad };
+};
+
+const findIslands = (yBus: Complex[][], busTypes: BusType[]): boolean => {
+  const slackIndex = busTypes.findIndex((busType) => busType === "SLACK");
+  if (slackIndex === -1) {
+    return true;
+  }
+
+  const visited = new Set<number>([slackIndex]);
+  const queue = [slackIndex];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) {
+      break;
+    }
+
+    for (let neighbor = 0; neighbor < yBus.length; neighbor += 1) {
+      if (neighbor === current) {
+        continue;
+      }
+
+      const connected =
+        Math.abs(yBus[current][neighbor].re) > Number.EPSILON ||
+        Math.abs(yBus[current][neighbor].im) > Number.EPSILON;
+
+      if (connected && !visited.has(neighbor)) {
+        visited.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return visited.size !== yBus.length;
+};
+
+export const solveWithNewtonRaphson = (
+  loadFlowCase: LoadFlowCase,
+  options: SolveOptions
+): LoadFlowResult => {
+  const busIndexById = Object.fromEntries(
+    loadFlowCase.buses.map((bus, index) => [bus.id, index])
+  );
+
+  const yBus = buildYBus(loadFlowCase, busIndexById);
+
+  if (
+    findIslands(
+      yBus,
+      loadFlowCase.buses.map((bus) => bus.type)
+    )
+  ) {
+    return {
+      diagnostics: {
+        converged: false,
+        algorithm: options.algorithm,
+        initialization: options.initialization,
+        message:
+          "Network contains an electrical island that is disconnected from the slack bus.",
+        iterationsCompleted: 0,
+        maxMismatchPu: null,
+        iterationMaxMismatchPu: [],
+      },
+    };
+  }
+
+  const state = getInitialState(loadFlowCase, options);
+  const specified = computeSpecifiedInjections(loadFlowCase, busIndexById);
+  const partitions = getBusPartitions(loadFlowCase.buses);
+
+  let maxMismatchPu = Number.POSITIVE_INFINITY;
+  const iterationMaxMismatchPu: number[] = [];
+  let pCalculated: number[] = [];
+  let qCalculated: number[] = [];
+
+  for (let iteration = 0; iteration < options.maxIterations; iteration += 1) {
+    const calculated = calculatePowerInjections(yBus, state);
+    pCalculated = calculated.pCalculated;
+    qCalculated = calculated.qCalculated;
+
+    const mismatch = buildMismatchVector(
+      partitions,
+      specified,
+      pCalculated,
+      qCalculated
+    );
+    maxMismatchPu = getMaximumAbsolute(mismatch);
+    iterationMaxMismatchPu.push(maxMismatchPu);
+
+    if (maxMismatchPu <= options.tolerance) {
+      return {
+        buses: buildSolvedBusStates(
+          loadFlowCase,
+          state,
+          pCalculated,
+          qCalculated
+        ),
+        branchFlows: buildBranchFlows(loadFlowCase, busIndexById, state),
+        diagnostics: {
+          converged: true,
+          algorithm: options.algorithm,
+          initialization: options.initialization,
+          message: `Converged in ${iteration} iterations.`,
+          iterationsCompleted: iteration,
+          maxMismatchPu,
+          iterationMaxMismatchPu,
+        },
+      };
+    }
+
+    const jacobian = buildJacobian(
+      yBus,
+      state,
+      partitions,
+      pCalculated,
+      qCalculated
+    );
+
+    let deltaState: number[];
+    try {
+      deltaState = solveLinearSystem(jacobian, mismatch);
+    } catch {
+      return {
+        diagnostics: {
+          converged: false,
+          algorithm: options.algorithm,
+          initialization: options.initialization,
+          message:
+            "Power flow failed because the Jacobian matrix became singular.",
+          iterationsCompleted: iteration,
+          maxMismatchPu,
+          iterationMaxMismatchPu,
+        },
+      };
+    }
+
+    partitions.nonSlack.forEach((busIndex, index) => {
+      state.voltageAnglesRad[busIndex] += deltaState[index] * options.damping;
+    });
+    partitions.pq.forEach((busIndex, index) => {
+      const deltaV = deltaState[partitions.nonSlack.length + index];
+      state.voltageMagnitudes[busIndex] += deltaV * options.damping;
+    });
+  }
+
+  return {
+    buses: buildSolvedBusStates(loadFlowCase, state, pCalculated, qCalculated),
+    branchFlows: buildBranchFlows(loadFlowCase, busIndexById, state),
+    diagnostics: {
+      converged: false,
+      algorithm: options.algorithm,
+      initialization: options.initialization,
+      message: `Did not converge after ${options.maxIterations} iterations.`,
+      iterationsCompleted: options.maxIterations,
+      maxMismatchPu,
+      iterationMaxMismatchPu,
+    },
+  };
+};

--- a/src/features/load-flow/solver/newtonRaphsonSolver.ts
+++ b/src/features/load-flow/solver/newtonRaphsonSolver.ts
@@ -586,8 +586,15 @@ export const solveWithNewtonRaphson = (
     });
   }
 
+  const finalCalculated = calculatePowerInjections(yBus, state);
+
   return {
-    buses: buildSolvedBusStates(loadFlowCase, state, pCalculated, qCalculated),
+    buses: buildSolvedBusStates(
+      loadFlowCase,
+      state,
+      finalCalculated.pCalculated,
+      finalCalculated.qCalculated
+    ),
     branchFlows: buildBranchFlows(loadFlowCase, busIndexById, state),
     diagnostics: {
       converged: false,

--- a/src/features/load-flow/solver/referenceScenarios.ts
+++ b/src/features/load-flow/solver/referenceScenarios.ts
@@ -1,0 +1,148 @@
+import { LoadFlowCase } from "@/features/load-flow/model/types";
+
+export interface LoadFlowReferenceScenario {
+  id: string;
+  name: string;
+  description: string;
+  loadFlowCase: LoadFlowCase;
+}
+
+export const LOAD_FLOW_REFERENCE_SCENARIOS: LoadFlowReferenceScenario[] = [
+  {
+    id: "two-bus-radial",
+    name: "2-Bus Radial",
+    description:
+      "Slack source feeding a single PQ load through an inductive line.",
+    loadFlowCase: {
+      baseMVA: 100,
+      buses: [
+        {
+          id: "bus-1",
+          name: "Grid",
+          baseKV: 230,
+          type: "SLACK",
+          voltageMagnitudeSetpoint: 1,
+          voltageAngleSetpointDeg: 0,
+        },
+        {
+          id: "bus-2",
+          name: "Plant Bus",
+          baseKV: 230,
+          type: "PQ",
+        },
+      ],
+      branches: [
+        {
+          id: "line-1",
+          fromBusId: "bus-1",
+          toBusId: "bus-2",
+          r: 0.02,
+          x: 0.06,
+          bHalf: 0.015,
+        },
+      ],
+      generators: [],
+      loads: [
+        {
+          id: "load-1",
+          busId: "bus-2",
+          p: 90,
+          q: 30,
+          status: "ON",
+        },
+      ],
+      shunts: [],
+    },
+  },
+  {
+    id: "three-bus-with-pv",
+    name: "3-Bus PV + PQ",
+    description:
+      "Classical small-system scenario with one slack, one PV generation bus, and one PQ load bus.",
+    loadFlowCase: {
+      baseMVA: 100,
+      buses: [
+        {
+          id: "bus-1",
+          name: "Slack",
+          baseKV: 230,
+          type: "SLACK",
+          voltageMagnitudeSetpoint: 1.04,
+          voltageAngleSetpointDeg: 0,
+        },
+        {
+          id: "bus-2",
+          name: "Gen Bus",
+          baseKV: 230,
+          type: "PV",
+          voltageMagnitudeSetpoint: 1.025,
+        },
+        {
+          id: "bus-3",
+          name: "Load Bus",
+          baseKV: 230,
+          type: "PQ",
+        },
+      ],
+      branches: [
+        {
+          id: "line-1-2",
+          fromBusId: "bus-1",
+          toBusId: "bus-2",
+          r: 0.02,
+          x: 0.06,
+          bHalf: 0.015,
+        },
+        {
+          id: "line-1-3",
+          fromBusId: "bus-1",
+          toBusId: "bus-3",
+          r: 0.08,
+          x: 0.24,
+          bHalf: 0.0125,
+        },
+        {
+          id: "line-2-3",
+          fromBusId: "bus-2",
+          toBusId: "bus-3",
+          r: 0.06,
+          x: 0.18,
+          bHalf: 0.01,
+        },
+      ],
+      generators: [
+        {
+          id: "gen-2",
+          busId: "bus-2",
+          pSet: 50,
+          vSet: 1.025,
+          qMin: -40,
+          qMax: 80,
+          status: "ON",
+        },
+      ],
+      loads: [
+        {
+          id: "load-2",
+          busId: "bus-2",
+          p: 20,
+          q: 10,
+          status: "ON",
+        },
+        {
+          id: "load-3",
+          busId: "bus-3",
+          p: 90,
+          q: 30,
+          status: "ON",
+        },
+      ],
+      shunts: [],
+    },
+  },
+];
+
+export const getReferenceScenarioById = (
+  scenarioId: string
+): LoadFlowReferenceScenario | undefined =>
+  LOAD_FLOW_REFERENCE_SCENARIOS.find((scenario) => scenario.id === scenarioId);

--- a/src/features/load-flow/solver/runLoadFlow.ts
+++ b/src/features/load-flow/solver/runLoadFlow.ts
@@ -1,7 +1,8 @@
 import { LoadFlowCase } from "@/features/load-flow/model/types";
+import { validateLoadFlowCase } from "@/features/load-flow/model/validation";
 
 import { selectSolverAlgorithm } from "./algorithmSelection";
-import { buildInitialization } from "./initialization";
+import { solveWithNewtonRaphson } from "./newtonRaphsonSolver";
 import {
   DEFAULT_SOLVE_OPTIONS,
   LoadFlowEngine,
@@ -18,23 +19,39 @@ export const runLoadFlow = (
     ...options,
   };
 
+  const validation = validateLoadFlowCase(loadFlowCase);
+  if (validation.errors.length > 0) {
+    return {
+      diagnostics: {
+        converged: false,
+        algorithm: resolvedOptions.algorithm,
+        initialization: resolvedOptions.initialization,
+        message: validation.errors.join(" "),
+        iterationsCompleted: 0,
+        maxMismatchPu: null,
+        iterationMaxMismatchPu: [],
+      },
+    };
+  }
+
   const algorithmDecision = selectSolverAlgorithm(
     loadFlowCase,
     resolvedOptions
   );
-  const initialization = buildInitialization(
-    loadFlowCase,
-    resolvedOptions.initialization
-  );
+
+  if (algorithmDecision.selected === "NEWTON_RAPHSON") {
+    return solveWithNewtonRaphson(loadFlowCase, resolvedOptions);
+  }
 
   return {
     diagnostics: {
       converged: false,
       algorithm: algorithmDecision.selected,
-      initialization: initialization.source,
-      message:
-        "Solver skeleton is configured. Newton-Raphson iteration kernels are not yet implemented.",
+      initialization: resolvedOptions.initialization,
+      message: "No matching solver implementation found.",
       iterationsCompleted: 0,
+      maxMismatchPu: null,
+      iterationMaxMismatchPu: [],
     },
   };
 };

--- a/src/features/load-flow/solver/types.ts
+++ b/src/features/load-flow/solver/types.ts
@@ -22,16 +22,40 @@ export interface SolverInitialization {
   source: InitializationMode;
 }
 
+export interface BusSolution {
+  busId: string;
+  voltageMagnitudePu: number;
+  voltageAngleDeg: number;
+  pInjectionPu: number;
+  qInjectionPu: number;
+}
+
+export interface BranchFlowSolution {
+  branchId: string;
+  fromBusId: string;
+  toBusId: string;
+  pFromToMW: number;
+  qFromToMVar: number;
+  pToFromMW: number;
+  qToFromMVar: number;
+  pLossMW: number;
+  qLossMVar: number;
+}
+
 export interface LoadFlowDiagnostics {
   converged: boolean;
   algorithm: SolverAlgorithm;
   initialization: InitializationMode;
   message: string;
   iterationsCompleted: number;
+  maxMismatchPu: number | null;
+  iterationMaxMismatchPu: number[];
 }
 
 export interface LoadFlowResult {
   diagnostics: LoadFlowDiagnostics;
+  buses?: BusSolution[];
+  branchFlows?: BranchFlowSolution[];
 }
 
 export interface LoadFlowEngine {
@@ -43,7 +67,7 @@ export interface LoadFlowEngine {
 
 export const DEFAULT_SOLVE_OPTIONS: SolveOptions = {
   tolerance: 1e-6,
-  maxIterations: 20,
+  maxIterations: 30,
   damping: 1,
   enforceReactiveLimits: true,
   algorithm: "NEWTON_RAPHSON",


### PR DESCRIPTION
### Motivation
- Provide a first production-quality AC load-flow engine so the workspace can produce solved bus voltages, angles, and branch flows from an editor-serializable case. 
- Make the solver UI-friendly and testable by adding deterministic reference scenarios that exercise Slack/PV/PQ partitions and island detection. 
- Keep the solver engine UI-agnostic and extensible so future algorithm variants or extraction to a library are straightforward. 

### Description
- Implemented a Newton–Raphson solver pipeline including `Ybus` assembly, deterministic flat-start initialization, mismatch/Jacobian construction, dense linear solver with singular-Jacobian handling, PV/PQ partitioning, island detection, and branch-flow post-processing in `src/features/load-flow/solver/newtonRaphsonSolver.ts`. 
- Added small complex-number utilities in `src/features/load-flow/solver/complex.ts` and introduced reusable reference cases in `src/features/load-flow/solver/referenceScenarios.ts`. 
- Expanded solver surface types in `src/features/load-flow/solver/types.ts` and replaced the skeleton path in `src/features/load-flow/solver/runLoadFlow.ts` to validate input (`validateLoadFlowCase`) and dispatch to `solveWithNewtonRaphson`. 
- Wired the workspace to run the solver and load reference scenarios from the UI, and added a solve-results table and scenario buttons in `src/app/load-flow/_components/LoadFlowWorkspace.tsx`, plus updated page copy and tests in `src/app/load-flow/page.tsx` and its route test. 
- Added and extended unit tests to cover invalid-case diagnostics, successful solves for the 2-bus and 3-bus reference scenarios, and island detection in `src/features/load-flow/solver/__tests__/runLoadFlow.test.ts`.

### Testing
- Ran formatting and linting with `yarn lint` and Prettier, which succeeded. 
- Performed static checks with `yarn typecheck`, which passed after UI typing adjustments. 
- Ran the full Jest suite with `yarn test`, and all unit tests (including the new solver tests) passed. 
- Verified production build with `yarn build`, which completed successfully. 
- Executed Playwright smoke and visual checks in host-mode with `yarn test:e2e:host` and `yarn test:e2e:visual:host` because Docker was unavailable, and both host-mode suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc9423350c8323a4b32abf5aa835bd)