### PR TITLE
Add single-line diagram visualization to load-flow workspace

### DIFF
--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -32,6 +32,7 @@ Completed across the first two slices (PR 1 + PR 2 scope):
 - ✅ Added normalized editor store helpers under `src/features/load-flow/state/loadFlowStore.ts`.
 - ✅ Added serialization path from editor graph state to `LoadFlowCase` shape (`toLoadFlowCase`).
 - ✅ Added store unit tests for deterministic bus defaults and bus/line serialization behavior.
+- ✅ Added an interactive SVG single-line diagram panel in `/load-flow` with clickable buses/branches and selected-element highlighting.
 
 Next recommended slice:
 
@@ -257,6 +258,23 @@ Follow-up expansion criteria:
 - Global base MVA
 - Solver settings (tolerance, max iterations, damping)
 - Solve / Reset / Export actions
+
+### Single-line diagram expectations (implemented baseline)
+
+The workspace should include a dedicated **single-line diagram** visualization
+rather than a plain topology list. The baseline implementation now renders:
+
+- Bus nodes (name + type label) using their editor coordinates
+- Branch segments between bus centers
+- Selection highlighting for the currently selected bus/branch
+- Click interactions on both buses and branches that sync with the properties panel
+
+Planned follow-up upgrades:
+
+- Drag-to-reposition buses directly in the diagram (persisting `x`,`y`)
+- Device glyph overlays for generators/loads/shunts at each bus
+- Zoom/pan controls for larger multi-bus systems
+- Optional result overlays (voltage magnitude heatmap and branch flow labels)
 
 ### Validation UX
 

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { SingleLineDiagram } from "@/app/load-flow/_components/SingleLineDiagram";
 import { toLoadFlowCase } from "@/features/load-flow/graph/toLoadFlowCase";
 import { BusType } from "@/features/load-flow/model/types";
 import {
@@ -140,7 +141,26 @@ export function LoadFlowWorkspace() {
         </div>
 
         <div className="rounded-lg border border-gray-700 p-4">
-          <h3 className="font-semibold text-white">Canvas Snapshot</h3>
+          <h3 className="font-semibold text-white">Single-line diagram</h3>
+          <p className="mt-1 text-sm text-gray-300">
+            Interactive topology view of buses and branches.
+          </p>
+          <SingleLineDiagram
+            buses={editorState.busOrder.map(
+              (busId) => editorState.busesById[busId]
+            )}
+            branches={editorState.branchOrder.map(
+              (branchId) => editorState.branchesById[branchId]
+            )}
+            selectedElementId={editorState.selectedElementId}
+            selectedElementType={editorState.selectedElementType}
+            onBusSelect={(busId) =>
+              setEditorState((prev) => selectElement(prev, "BUS", busId))
+            }
+            onBranchSelect={(branchId) =>
+              setEditorState((prev) => selectElement(prev, "BRANCH", branchId))
+            }
+          />
           <div className="mt-3 space-y-2 text-sm text-gray-200">
             {editorState.busOrder.map((busId) => {
               const bus = editorState.busesById[busId];

--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -9,12 +9,13 @@ interface SingleLineDiagramProps {
   onBranchSelect: (branchId: string) => void;
 }
 
-const VIEWBOX_WIDTH = 780;
-const VIEWBOX_HEIGHT = 280;
 const BUS_WIDTH = 88;
 const BUS_HEIGHT = 42;
 const BUS_HALF_WIDTH = BUS_WIDTH / 2;
 const BUS_HALF_HEIGHT = BUS_HEIGHT / 2;
+const DIAGRAM_PADDING = 48;
+const MIN_VIEWBOX_WIDTH = 680;
+const MIN_VIEWBOX_HEIGHT = 280;
 
 const getBusCenter = (bus: BusNode) => ({
   x: bus.x,
@@ -40,6 +41,29 @@ export function SingleLineDiagram({
   onBranchSelect,
 }: SingleLineDiagramProps) {
   const busesById = new Map(buses.map((bus) => [bus.id, bus]));
+  const busCentersX = buses.map((bus) => bus.x);
+  const busCentersY = buses.map((bus) => bus.y);
+
+  const minBusCenterX = Math.min(...busCentersX);
+  const maxBusCenterX = Math.max(...busCentersX);
+  const minBusCenterY = Math.min(...busCentersY);
+  const maxBusCenterY = Math.max(...busCentersY);
+
+  const contentMinX = minBusCenterX - BUS_HALF_WIDTH;
+  const contentMaxX = maxBusCenterX + BUS_HALF_WIDTH;
+  const contentMinY = minBusCenterY - BUS_HALF_HEIGHT;
+  const contentMaxY = maxBusCenterY + BUS_HALF_HEIGHT;
+
+  const viewBoxX = contentMinX - DIAGRAM_PADDING;
+  const viewBoxY = contentMinY - DIAGRAM_PADDING;
+  const viewBoxWidth = Math.max(
+    contentMaxX - contentMinX + DIAGRAM_PADDING * 2,
+    MIN_VIEWBOX_WIDTH
+  );
+  const viewBoxHeight = Math.max(
+    contentMaxY - contentMinY + DIAGRAM_PADDING * 2,
+    MIN_VIEWBOX_HEIGHT
+  );
 
   return (
     <div className="mt-3 overflow-x-auto rounded-md border border-slate-700 bg-slate-950/60 p-3">
@@ -49,16 +73,16 @@ export function SingleLineDiagram({
         </p>
       ) : (
         <svg
-          viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+          viewBox={`${viewBoxX} ${viewBoxY} ${viewBoxWidth} ${viewBoxHeight}`}
           role="img"
           aria-label="Single line diagram"
           className="h-[280px] min-w-[680px] w-full"
         >
           <rect
-            x={0}
-            y={0}
-            width={VIEWBOX_WIDTH}
-            height={VIEWBOX_HEIGHT}
+            x={viewBoxX}
+            y={viewBoxY}
+            width={viewBoxWidth}
+            height={viewBoxHeight}
             className="fill-slate-950"
           />
 

--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -1,0 +1,142 @@
+import { BusNode, LineEdge } from "@/features/load-flow/state/loadFlowStore";
+
+interface SingleLineDiagramProps {
+  buses: BusNode[];
+  branches: LineEdge[];
+  selectedElementId: string | null;
+  selectedElementType: "BUS" | "BRANCH" | null;
+  onBusSelect: (busId: string) => void;
+  onBranchSelect: (branchId: string) => void;
+}
+
+const VIEWBOX_WIDTH = 780;
+const VIEWBOX_HEIGHT = 280;
+const BUS_WIDTH = 88;
+const BUS_HEIGHT = 42;
+const BUS_HALF_WIDTH = BUS_WIDTH / 2;
+const BUS_HALF_HEIGHT = BUS_HEIGHT / 2;
+
+const getBusCenter = (bus: BusNode) => ({
+  x: bus.x,
+  y: bus.y,
+});
+
+const lineClassName = (isSelected: boolean) =>
+  isSelected
+    ? "stroke-emerald-300 stroke-[4]"
+    : "stroke-slate-300/85 stroke-[3] hover:stroke-emerald-200";
+
+const busClassName = (isSelected: boolean) =>
+  isSelected
+    ? "fill-emerald-500/30 stroke-emerald-300"
+    : "fill-slate-900 stroke-slate-200";
+
+export function SingleLineDiagram({
+  buses,
+  branches,
+  selectedElementId,
+  selectedElementType,
+  onBusSelect,
+  onBranchSelect,
+}: SingleLineDiagramProps) {
+  const busesById = new Map(buses.map((bus) => [bus.id, bus]));
+
+  return (
+    <div className="mt-3 overflow-x-auto rounded-md border border-slate-700 bg-slate-950/60 p-3">
+      {buses.length === 0 ? (
+        <p className="text-sm text-gray-300">
+          Add buses from the palette to render the one-line diagram.
+        </p>
+      ) : (
+        <svg
+          viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+          role="img"
+          aria-label="Single line diagram"
+          className="h-[280px] min-w-[680px] w-full"
+        >
+          <rect
+            x={0}
+            y={0}
+            width={VIEWBOX_WIDTH}
+            height={VIEWBOX_HEIGHT}
+            className="fill-slate-950"
+          />
+
+          {branches.map((branch) => {
+            const fromBus = busesById.get(branch.fromBusId);
+            const toBus = busesById.get(branch.toBusId);
+
+            if (!fromBus || !toBus) {
+              return null;
+            }
+
+            const from = getBusCenter(fromBus);
+            const to = getBusCenter(toBus);
+            const isSelected =
+              selectedElementType === "BRANCH" &&
+              selectedElementId === branch.id;
+
+            return (
+              <g key={branch.id}>
+                <line
+                  x1={from.x}
+                  y1={from.y}
+                  x2={to.x}
+                  y2={to.y}
+                  className={`${lineClassName(isSelected)} cursor-pointer transition`}
+                  onClick={() => onBranchSelect(branch.id)}
+                />
+                <text
+                  x={(from.x + to.x) / 2}
+                  y={(from.y + to.y) / 2 - 10}
+                  textAnchor="middle"
+                  className="fill-slate-300 text-[10px]"
+                >
+                  {branch.id}
+                </text>
+              </g>
+            );
+          })}
+
+          {buses.map((bus) => {
+            const isSelected =
+              selectedElementType === "BUS" && selectedElementId === bus.id;
+
+            return (
+              <g
+                key={bus.id}
+                transform={`translate(${bus.x - BUS_HALF_WIDTH}, ${bus.y - BUS_HALF_HEIGHT})`}
+              >
+                <rect
+                  x={0}
+                  y={0}
+                  rx={6}
+                  width={BUS_WIDTH}
+                  height={BUS_HEIGHT}
+                  className={`${busClassName(isSelected)} cursor-pointer stroke-2 transition`}
+                  onClick={() => onBusSelect(bus.id)}
+                />
+                <text
+                  x={BUS_HALF_WIDTH}
+                  y={17}
+                  textAnchor="middle"
+                  className="fill-white text-[11px] font-medium"
+                >
+                  {bus.name}
+                </text>
+                <text
+                  x={BUS_HALF_WIDTH}
+                  y={32}
+                  textAnchor="middle"
+                  className="fill-slate-300 text-[10px]"
+                >
+                  {bus.type}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- The load-flow workspace previously exposed only a topology list / canvas snapshot and lacked a one-line diagram visualization, which makes inspecting topology and selecting elements cumbersome.
- Provide a baseline interactive single-line diagram in the workspace so users can see a conventional power-system view and select buses/branches directly from the diagram.

### Description

- Add a new `SingleLineDiagram` SVG component (`src/app/load-flow/_components/SingleLineDiagram.tsx`) that renders buses at editor coordinates, draws branch segments, labels elements, and highlights selected buses/branches.
- Replace the former “Canvas Snapshot” area in the workspace with the single-line diagram panel and wire diagram click handlers to the existing selection flow so the Properties panel stays in sync (`src/app/load-flow/_components/LoadFlowWorkspace.tsx`).
- Update the load-flow implementation plan document (`docs/load-flow-implementation-plan.md`) to record the single-line diagram baseline and list planned follow-ups (drag-to-reposition, device glyphs, zoom/pan, result overlays).

### Testing

- Ran `yarn lint` and formatting checks, which passed after applying style-consistent edits.
- Ran `yarn typecheck` and `yarn test`, with the test suite passing (`37` test suites, `141` tests total passed).
- Built the site with `yarn build` and ran Playwright flows using host-mode wrappers: `yarn test:e2e:host` (smoke flows passed) and `yarn test:e2e:visual:host` (initial attempt hit an APT lock during browser install but a rerun completed and the visual tests passed); note Docker was not available so host-mode Playwright was used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdebd208c083238bcce0104ab22f8a)