### PR TITLE
Add transformer tap and phase shift modeling to load flow solver

### DIFF
--- a/src/features/load-flow/model/__tests__/validation.test.ts
+++ b/src/features/load-flow/model/__tests__/validation.test.ts
@@ -111,6 +111,31 @@ describe("validateLoadFlowCase", () => {
     );
   });
 
+  it("flags invalid transformer tap and phase values", () => {
+    const result = validateLoadFlowCase(
+      createCase({
+        branches: [
+          {
+            id: "branch-1",
+            fromBusId: "bus-1",
+            toBusId: "bus-1",
+            r: 0.01,
+            x: 0.03,
+            tapRatio: 0,
+            phaseShiftDeg: Number.NaN,
+          },
+        ],
+      })
+    );
+
+    expect(result.errors).toContain(
+      "Branch branch-1 has invalid tap ratio (must be a finite number greater than zero)."
+    );
+    expect(result.errors).toContain(
+      "Branch branch-1 has invalid phase shift (must be a finite number in degrees)."
+    );
+  });
+
   it("flags duplicate bus identifiers", () => {
     const result = validateLoadFlowCase(
       createCase({

--- a/src/features/load-flow/model/types.ts
+++ b/src/features/load-flow/model/types.ts
@@ -20,6 +20,8 @@ export interface Branch {
   r: number;
   x: number;
   bHalf?: number;
+  tapRatio?: number;
+  phaseShiftDeg?: number;
   thermalLimitMVA?: number;
   status?: "IN_SERVICE" | "OUT_OF_SERVICE";
 }

--- a/src/features/load-flow/model/validation.ts
+++ b/src/features/load-flow/model/validation.ts
@@ -55,6 +55,24 @@ export const validateLoadFlowCase = (
         `Branch ${branch.id} has invalid impedance (r and x cannot both be zero).`
       );
     }
+
+    if (
+      branch.tapRatio !== undefined &&
+      (!isFiniteNumber(branch.tapRatio) || branch.tapRatio <= 0)
+    ) {
+      errors.push(
+        `Branch ${branch.id} has invalid tap ratio (must be a finite number greater than zero).`
+      );
+    }
+
+    if (
+      branch.phaseShiftDeg !== undefined &&
+      !isFiniteNumber(branch.phaseShiftDeg)
+    ) {
+      errors.push(
+        `Branch ${branch.id} has invalid phase shift (must be a finite number in degrees).`
+      );
+    }
   }
 
   for (const generator of loadFlowCase.generators) {

--- a/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
+++ b/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
@@ -126,4 +126,43 @@ describe("runLoadFlow", () => {
       expect(result.diagnostics.iterationsCompleted).toBeGreaterThan(0);
     }
   });
+
+  it("accounts for transformer tap and phase shift in branch modeling", () => {
+    const scenario = LOAD_FLOW_REFERENCE_SCENARIOS.find(
+      (item) => item.id === "two-bus-radial"
+    );
+
+    expect(scenario).toBeDefined();
+
+    const baselineResult = runLoadFlow(scenario!.loadFlowCase);
+    const transformedResult = runLoadFlow({
+      ...scenario!.loadFlowCase,
+      branches: scenario!.loadFlowCase.branches.map((branch) => ({
+        ...branch,
+        tapRatio: 1.08,
+        phaseShiftDeg: 12,
+      })),
+    });
+
+    expect(baselineResult.diagnostics.converged).toBe(true);
+    expect(transformedResult.diagnostics.converged).toBe(true);
+
+    const baselineBus = baselineResult.buses?.find(
+      (bus) => bus.busId === "bus-2"
+    );
+    const transformedBus = transformedResult.buses?.find(
+      (bus) => bus.busId === "bus-2"
+    );
+
+    expect(baselineBus).toBeDefined();
+    expect(transformedBus).toBeDefined();
+    expect(
+      Math.abs(transformedBus!.voltageAngleDeg - baselineBus!.voltageAngleDeg)
+    ).toBeGreaterThan(5);
+    expect(
+      Math.abs(
+        transformedBus!.voltageMagnitudePu - baselineBus!.voltageMagnitudePu
+      )
+    ).toBeGreaterThan(0.01);
+  });
 });

--- a/src/features/load-flow/solver/ieeeReferenceScenarios.ts
+++ b/src/features/load-flow/solver/ieeeReferenceScenarios.ts
@@ -1,7 +1,6 @@
 import type { LoadFlowReferenceScenario } from "./referenceScenarios";
 
 // Source data adapted from MATPOWER benchmark cases (case9, case14, case30, case57, case118).
-// Transformer tap ratio and phase shift fields in MATPOWER are not modeled by the current solver.
 
 export const IEEE_REFERENCE_SCENARIOS: LoadFlowReferenceScenario[] = [
   {
@@ -240,7 +239,7 @@ export const IEEE_REFERENCE_SCENARIOS: LoadFlowReferenceScenario[] = [
     id: "ieee-14-bus",
     name: "IEEE 14-Bus",
     description:
-      "IEEE 14-bus transmission benchmark adapted from MATPOWER case14 (tap/phase data omitted).",
+      "IEEE 14-bus transmission benchmark adapted from MATPOWER case14.",
     loadFlowCase: {
       baseMVA: 100,
       buses: [
@@ -434,6 +433,8 @@ export const IEEE_REFERENCE_SCENARIOS: LoadFlowReferenceScenario[] = [
           r: 0,
           x: 0.20912,
           bHalf: 0,
+          tapRatio: 0.978,
+          phaseShiftDeg: 0,
           status: "IN_SERVICE",
         },
         {
@@ -443,6 +444,8 @@ export const IEEE_REFERENCE_SCENARIOS: LoadFlowReferenceScenario[] = [
           r: 0,
           x: 0.55618,
           bHalf: 0,
+          tapRatio: 0.969,
+          phaseShiftDeg: 0,
           status: "IN_SERVICE",
         },
         {
@@ -452,6 +455,8 @@ export const IEEE_REFERENCE_SCENARIOS: LoadFlowReferenceScenario[] = [
           r: 0,
           x: 0.25202,
           bHalf: 0,
+          tapRatio: 0.932,
+          phaseShiftDeg: 0,
           status: "IN_SERVICE",
         },
         {

--- a/src/features/load-flow/solver/newtonRaphsonSolver.ts
+++ b/src/features/load-flow/solver/newtonRaphsonSolver.ts
@@ -8,7 +8,6 @@ import {
   divideComplex,
   multiplyComplex,
   polarToComplex,
-  subtractComplex,
 } from "./complex";
 import { buildInitialization } from "./initialization";
 import {
@@ -40,6 +39,13 @@ const toDegrees = (radians: number): number => (radians * 180) / Math.PI;
 
 const createMatrix = (size: number): number[][] =>
   Array.from({ length: size }, () => Array(size).fill(0));
+
+interface BranchAdmittanceTerms {
+  yFromFrom: Complex;
+  yFromTo: Complex;
+  yToFrom: Complex;
+  yToTo: Complex;
+}
 
 const solveLinearSystem = (a: number[][], b: number[]): number[] => {
   const size = a.length;
@@ -114,6 +120,36 @@ const getBusPartitions = (buses: Bus[]): BusPartitions => {
   };
 };
 
+const getBranchAdmittanceTerms = (
+  r: number,
+  x: number,
+  bHalf = 0,
+  tapRatio = 1,
+  phaseShiftDeg = 0
+): BranchAdmittanceTerms => {
+  const seriesAdmittance = divideComplex(complex(1, 0), complex(r, x));
+  const shuntAdmittance = complex(0, bHalf);
+  const tap = polarToComplex(tapRatio, toRadians(phaseShiftDeg));
+  const tapConjugate = conjugateComplex(tap);
+  const tapMagnitudeSquared = tapRatio * tapRatio;
+
+  return {
+    yFromFrom: divideComplex(
+      addComplex(seriesAdmittance, shuntAdmittance),
+      complex(tapMagnitudeSquared, 0)
+    ),
+    yFromTo: divideComplex(
+      multiplyComplex(complex(-1, 0), seriesAdmittance),
+      tapConjugate
+    ),
+    yToFrom: divideComplex(
+      multiplyComplex(complex(-1, 0), seriesAdmittance),
+      tap
+    ),
+    yToTo: addComplex(seriesAdmittance, shuntAdmittance),
+  };
+};
+
 const buildYBus = (
   loadFlowCase: LoadFlowCase,
   busIndexById: Record<string, number>
@@ -131,28 +167,30 @@ const buildYBus = (
     const fromIndex = busIndexById[branch.fromBusId];
     const toIndex = busIndexById[branch.toBusId];
 
-    const seriesAdmittance = divideComplex(
-      complex(1, 0),
-      complex(branch.r, branch.x)
+    const branchTerms = getBranchAdmittanceTerms(
+      branch.r,
+      branch.x,
+      branch.bHalf ?? 0,
+      branch.tapRatio ?? 1,
+      branch.phaseShiftDeg ?? 0
     );
-    const shuntAdmittance = complex(0, branch.bHalf ?? 0);
 
     yBus[fromIndex][fromIndex] = addComplex(
       yBus[fromIndex][fromIndex],
-      addComplex(seriesAdmittance, shuntAdmittance)
+      branchTerms.yFromFrom
     );
     yBus[toIndex][toIndex] = addComplex(
       yBus[toIndex][toIndex],
-      addComplex(seriesAdmittance, shuntAdmittance)
+      branchTerms.yToTo
     );
 
-    yBus[fromIndex][toIndex] = subtractComplex(
+    yBus[fromIndex][toIndex] = addComplex(
       yBus[fromIndex][toIndex],
-      seriesAdmittance
+      branchTerms.yFromTo
     );
-    yBus[toIndex][fromIndex] = subtractComplex(
+    yBus[toIndex][fromIndex] = addComplex(
       yBus[toIndex][fromIndex],
-      seriesAdmittance
+      branchTerms.yToFrom
     );
   }
 
@@ -368,25 +406,21 @@ const buildBranchFlows = (
 
       const fromVoltage = voltageByBusIndex[fromIndex];
       const toVoltage = voltageByBusIndex[toIndex];
-      const seriesAdmittance = divideComplex(
-        complex(1, 0),
-        complex(branch.r, branch.x)
+      const branchTerms = getBranchAdmittanceTerms(
+        branch.r,
+        branch.x,
+        branch.bHalf ?? 0,
+        branch.tapRatio ?? 1,
+        branch.phaseShiftDeg ?? 0
       );
-      const shuntAdmittance = complex(0, branch.bHalf ?? 0);
 
       const currentFromTo = addComplex(
-        multiplyComplex(
-          subtractComplex(fromVoltage, toVoltage),
-          seriesAdmittance
-        ),
-        multiplyComplex(fromVoltage, shuntAdmittance)
+        multiplyComplex(branchTerms.yFromFrom, fromVoltage),
+        multiplyComplex(branchTerms.yFromTo, toVoltage)
       );
       const currentToFrom = addComplex(
-        multiplyComplex(
-          subtractComplex(toVoltage, fromVoltage),
-          seriesAdmittance
-        ),
-        multiplyComplex(toVoltage, shuntAdmittance)
+        multiplyComplex(branchTerms.yToFrom, fromVoltage),
+        multiplyComplex(branchTerms.yToTo, toVoltage)
       );
 
       const sFromTo = multiplyComplex(


### PR DESCRIPTION
### Motivation

- Extend the load-flow model to represent off-nominal transformer taps and phase shifts which were previously omitted from the solver and reference data.

### Description

- Add optional `tapRatio` and `phaseShiftDeg` fields to the `Branch` type to represent transformer tap and phase settings.
- Validate `tapRatio` (finite and > 0) and `phaseShiftDeg` (finite degrees) in `validateLoadFlowCase` to catch invalid transformer inputs.
- Amend the Newton–Raphson solver to account for off-nominal transformer taps and phase shifts when assembling the Y-bus and when computing branch currents/flows by computing transformer-adjusted admittance terms.
- Add tests and reference data updates: include IEEE-14 transformer tap entries, a validation unit test for invalid tap/phase values, and a solver regression test that asserts tap/phase fields materially change bus voltages/angles.

### Testing

- Ran `yarn lint` and formatting checks which passed after small fixes to the introduced test code.
- Ran `yarn typecheck` with no type errors reported.
- Ran `yarn test` and all Jest suites passed (`37` test suites, `144` tests total passed).
- Built the site with `yarn build` which completed successfully.
- Ran end-to-end smoke and visual suites using the host-mode wrappers (`yarn test:e2e:host` and `yarn test:e2e:visual:host`) because Docker was unavailable, and those suites passed (`24` smoke tests and `8` visual tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7b2445a8832381fdc8142afff4fc)