### PR TITLE
Sync reference scenario into editor, add SLD drag-and-drop and autolayout

### DIFF
--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -13,7 +13,9 @@ import { runLoadFlow } from "@/features/load-flow/solver/runLoadFlow";
 import {
   addBranch,
   addBus,
+  autoLayoutBuses,
   createInitialLoadFlowEditorState,
+  replaceEditorStateFromLoadFlowCase,
   selectElement,
   updateBranch,
   updateBus,
@@ -54,13 +56,9 @@ export function LoadFlowWorkspace() {
     ? getReferenceScenarioById(selectedReferenceScenarioId)
     : undefined;
 
-  const activeSolveCase = selectedReferenceScenario
-    ? selectedReferenceScenario.loadFlowCase
-    : serializedCase;
-
   const solveResult = useMemo(
-    () => runLoadFlow(activeSolveCase),
-    [activeSolveCase]
+    () => runLoadFlow(serializedCase),
+    [serializedCase]
   );
 
   return (
@@ -81,16 +79,24 @@ export function LoadFlowWorkspace() {
           <button
             type="button"
             className="rounded-md border border-emerald-500 px-3 py-2 text-sm text-emerald-100 hover:bg-emerald-900/50"
-            onClick={() => setSelectedReferenceScenarioId(null)}
+            onClick={() => {
+              setSelectedReferenceScenarioId(null);
+              setEditorState(createInitialLoadFlowEditorState());
+            }}
           >
-            Use editor model
+            Reset editor model
           </button>
           {LOAD_FLOW_REFERENCE_SCENARIOS.map((scenario) => (
             <button
               key={scenario.id}
               type="button"
               className="rounded-md border border-emerald-500 px-3 py-2 text-sm text-emerald-100 hover:bg-emerald-900/50"
-              onClick={() => setSelectedReferenceScenarioId(scenario.id)}
+              onClick={() => {
+                setSelectedReferenceScenarioId(scenario.id);
+                setEditorState(
+                  replaceEditorStateFromLoadFlowCase(scenario.loadFlowCase)
+                );
+              }}
             >
               {scenario.name}
             </button>
@@ -120,6 +126,13 @@ export function LoadFlowWorkspace() {
             onClick={() => setEditorState((prev) => addBus(prev))}
           >
             Add bus
+          </button>
+          <button
+            type="button"
+            className="ml-2 mt-3 rounded-md border border-gray-500 px-3 py-2 text-sm text-white hover:bg-gray-800"
+            onClick={() => setEditorState((prev) => autoLayoutBuses(prev))}
+          >
+            Auto-layout SLD
           </button>
 
           <div className="mt-3 space-y-2 text-sm text-gray-200">
@@ -156,6 +169,9 @@ export function LoadFlowWorkspace() {
             selectedElementType={editorState.selectedElementType}
             onBusSelect={(busId) =>
               setEditorState((prev) => selectElement(prev, "BUS", busId))
+            }
+            onBusMove={(busId, x, y) =>
+              setEditorState((prev) => updateBus(prev, busId, { x, y }))
             }
             onBranchSelect={(branchId) =>
               setEditorState((prev) => selectElement(prev, "BRANCH", branchId))

--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -1,3 +1,5 @@
+import { PointerEvent, useRef } from "react";
+
 import { BusNode, LineEdge } from "@/features/load-flow/state/loadFlowStore";
 
 interface SingleLineDiagramProps {
@@ -6,6 +8,7 @@ interface SingleLineDiagramProps {
   selectedElementId: string | null;
   selectedElementType: "BUS" | "BRANCH" | null;
   onBusSelect: (busId: string) => void;
+  onBusMove: (busId: string, x: number, y: number) => void;
   onBranchSelect: (branchId: string) => void;
 }
 
@@ -38,8 +41,58 @@ export function SingleLineDiagram({
   selectedElementId,
   selectedElementType,
   onBusSelect,
+  onBusMove,
   onBranchSelect,
 }: SingleLineDiagramProps) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const draggingBusIdRef = useRef<string | null>(null);
+
+  const toSvgPoint = (clientX: number, clientY: number) => {
+    const svg = svgRef.current;
+    if (!svg) {
+      return null;
+    }
+
+    const point = svg.createSVGPoint();
+    point.x = clientX;
+    point.y = clientY;
+    const transform = svg.getScreenCTM();
+    if (!transform) {
+      return null;
+    }
+
+    return point.matrixTransform(transform.inverse());
+  };
+
+  const handleBusPointerDown = (
+    event: PointerEvent<SVGRectElement>,
+    busId: string
+  ) => {
+    event.preventDefault();
+    draggingBusIdRef.current = busId;
+    onBusSelect(busId);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handleBusPointerMove = (event: PointerEvent<SVGRectElement>) => {
+    const draggingBusId = draggingBusIdRef.current;
+    if (!draggingBusId) {
+      return;
+    }
+
+    const point = toSvgPoint(event.clientX, event.clientY);
+    if (!point) {
+      return;
+    }
+
+    onBusMove(draggingBusId, point.x, point.y);
+  };
+
+  const handleBusPointerUp = (event: PointerEvent<SVGRectElement>) => {
+    draggingBusIdRef.current = null;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  };
+
   const busesById = new Map(buses.map((bus) => [bus.id, bus]));
   const busCentersX = buses.map((bus) => bus.x);
   const busCentersY = buses.map((bus) => bus.y);
@@ -73,6 +126,7 @@ export function SingleLineDiagram({
         </p>
       ) : (
         <svg
+          ref={svgRef}
           viewBox={`${viewBoxX} ${viewBoxY} ${viewBoxWidth} ${viewBoxHeight}`}
           role="img"
           aria-label="Single line diagram"
@@ -139,6 +193,9 @@ export function SingleLineDiagram({
                   height={BUS_HEIGHT}
                   className={`${busClassName(isSelected)} cursor-pointer stroke-2 transition`}
                   onClick={() => onBusSelect(bus.id)}
+                  onPointerDown={(event) => handleBusPointerDown(event, bus.id)}
+                  onPointerMove={handleBusPointerMove}
+                  onPointerUp={handleBusPointerUp}
                 />
                 <text
                   x={BUS_HALF_WIDTH}

--- a/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
+++ b/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
@@ -19,4 +19,17 @@ describe("LoadFlowWorkspace", () => {
     expect(screen.getByText(/Grid • SLACK • 230 kV/i)).toBeInTheDocument();
     expect(screen.getByText(/\"id\": \"load-1\"/i)).toBeInTheDocument();
   });
+
+  it("keeps reference-bus setpoints when loading a scenario", () => {
+    render(<LoadFlowWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: "3-Bus PV + PQ" }));
+
+    expect(
+      screen.getByText(/"voltageMagnitudeSetpoint": 1.04/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"voltageAngleSetpointDeg": 0/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
+++ b/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
@@ -16,5 +16,7 @@ describe("LoadFlowWorkspace", () => {
     expect(
       screen.getByText(/Active solve case: 2-Bus Radial/i)
     ).toBeInTheDocument();
+    expect(screen.getByText(/Grid • SLACK • 230 kV/i)).toBeInTheDocument();
+    expect(screen.getByText(/\"id\": \"load-1\"/i)).toBeInTheDocument();
   });
 });

--- a/src/features/load-flow/graph/toLoadFlowCase.ts
+++ b/src/features/load-flow/graph/toLoadFlowCase.ts
@@ -9,6 +9,10 @@ export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
       name: bus.name,
       baseKV: bus.baseKV,
       type: bus.type,
+      voltageMagnitudeSetpoint: bus.voltageMagnitudeSetpoint,
+      voltageAngleSetpointDeg: bus.voltageAngleSetpointDeg,
+      voltageMagnitudeMin: bus.voltageMagnitudeMin,
+      voltageMagnitudeMax: bus.voltageMagnitudeMax,
     };
   });
 

--- a/src/features/load-flow/graph/toLoadFlowCase.ts
+++ b/src/features/load-flow/graph/toLoadFlowCase.ts
@@ -28,8 +28,8 @@ export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
     baseMVA: state.baseMVA,
     buses,
     branches,
-    generators: [],
-    loads: [],
-    shunts: [],
+    generators: state.generators.map((generator) => ({ ...generator })),
+    loads: state.loads.map((load) => ({ ...load })),
+    shunts: state.shunts.map((shunt) => ({ ...shunt })),
   };
 };

--- a/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
+++ b/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
@@ -90,7 +90,14 @@ describe("loadFlowStore", () => {
     const replaced = replaceEditorStateFromLoadFlowCase({
       baseMVA: 100,
       buses: [
-        { id: "bus-a", name: "A", baseKV: 115, type: "SLACK" },
+        {
+          id: "bus-a",
+          name: "A",
+          baseKV: 115,
+          type: "SLACK",
+          voltageMagnitudeSetpoint: 1.04,
+          voltageAngleSetpointDeg: 2.5,
+        },
         { id: "bus-b", name: "B", baseKV: 115, type: "PQ" },
       ],
       branches: [
@@ -121,6 +128,12 @@ describe("loadFlowStore", () => {
     const snapshot = toLoadFlowCase(replaced);
     expect(replaced.selectedElementId).toBe("bus-a");
     expect(replaced.selectedElementType).toBe("BUS");
+    expect(snapshot.buses[0]).toEqual(
+      expect.objectContaining({
+        voltageMagnitudeSetpoint: 1.04,
+        voltageAngleSetpointDeg: 2.5,
+      })
+    );
     expect(snapshot.generators).toHaveLength(1);
     expect(snapshot.loads).toHaveLength(1);
   });

--- a/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
+++ b/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
@@ -2,7 +2,9 @@ import { toLoadFlowCase } from "@/features/load-flow/graph/toLoadFlowCase";
 import {
   addBranch,
   addBus,
+  autoLayoutBuses,
   createInitialLoadFlowEditorState,
+  replaceEditorStateFromLoadFlowCase,
   updateBus,
 } from "@/features/load-flow/state/loadFlowStore";
 
@@ -68,5 +70,58 @@ describe("loadFlowStore", () => {
 
     expect(state.busesById["bus-1"].name).toBe("Bus 1");
     expect(state.branchesById["line-1"].r).toBe(0.01);
+  });
+
+  it("applies auto-layout by connectivity levels", () => {
+    let state = createInitialLoadFlowEditorState();
+    state = addBus(state);
+    state = addBus(state);
+    state = addBus(state);
+    state = addBranch(state, "bus-1", "bus-2");
+    state = addBranch(state, "bus-2", "bus-3");
+
+    const laidOut = autoLayoutBuses(state);
+    expect(laidOut.busesById["bus-1"].x).toBe(120);
+    expect(laidOut.busesById["bus-2"].x).toBe(300);
+    expect(laidOut.busesById["bus-3"].x).toBe(480);
+  });
+
+  it("replaces editor state from a reference case including device data", () => {
+    const replaced = replaceEditorStateFromLoadFlowCase({
+      baseMVA: 100,
+      buses: [
+        { id: "bus-a", name: "A", baseKV: 115, type: "SLACK" },
+        { id: "bus-b", name: "B", baseKV: 115, type: "PQ" },
+      ],
+      branches: [
+        {
+          id: "line-a-b",
+          fromBusId: "bus-a",
+          toBusId: "bus-b",
+          r: 0.01,
+          x: 0.05,
+          bHalf: 0.01,
+        },
+      ],
+      generators: [
+        {
+          id: "gen-a",
+          busId: "bus-a",
+          pSet: 100,
+          vSet: 1.02,
+          qMin: -50,
+          qMax: 80,
+          status: "ON",
+        },
+      ],
+      loads: [{ id: "load-b", busId: "bus-b", p: 70, q: 30, status: "ON" }],
+      shunts: [],
+    });
+
+    const snapshot = toLoadFlowCase(replaced);
+    expect(replaced.selectedElementId).toBe("bus-a");
+    expect(replaced.selectedElementType).toBe("BUS");
+    expect(snapshot.generators).toHaveLength(1);
+    expect(snapshot.loads).toHaveLength(1);
   });
 });

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -11,6 +11,10 @@ export interface BusNode {
   name: string;
   baseKV: number;
   type: BusType;
+  voltageMagnitudeSetpoint?: number;
+  voltageAngleSetpointDeg?: number;
+  voltageMagnitudeMin?: number;
+  voltageMagnitudeMax?: number;
   x: number;
   y: number;
 }
@@ -275,6 +279,10 @@ export const replaceEditorStateFromLoadFlowCase = (
         name: bus.name,
         baseKV: bus.baseKV,
         type: bus.type,
+        voltageMagnitudeSetpoint: bus.voltageMagnitudeSetpoint,
+        voltageAngleSetpointDeg: bus.voltageAngleSetpointDeg,
+        voltageMagnitudeMin: bus.voltageMagnitudeMin,
+        voltageMagnitudeMax: bus.voltageMagnitudeMax,
         x: AUTO_LAYOUT_START_X + index * AUTO_LAYOUT_X_SPACING,
         y: AUTO_LAYOUT_START_Y,
       },

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -1,4 +1,10 @@
-import { BusType } from "@/features/load-flow/model/types";
+import {
+  BusType,
+  Generator,
+  Load,
+  LoadFlowCase,
+  ShuntDevice,
+} from "@/features/load-flow/model/types";
 
 export interface BusNode {
   id: string;
@@ -30,6 +36,9 @@ export interface LoadFlowEditorState {
    * Stable insertion/display order for branches independent of object key order.
    */
   branchOrder: string[];
+  generators: Generator[];
+  loads: Load[];
+  shunts: ShuntDevice[];
   selectedElementId: string | null;
   selectedElementType: "BUS" | "BRANCH" | null;
 }
@@ -42,6 +51,9 @@ export const createInitialLoadFlowEditorState = (): LoadFlowEditorState => ({
   busOrder: [],
   branchesById: {},
   branchOrder: [],
+  generators: [],
+  loads: [],
+  shunts: [],
   selectedElementId: null,
   selectedElementType: null,
 });
@@ -155,3 +167,151 @@ export const selectElement = (
   selectedElementType: elementType,
   selectedElementId: elementId,
 });
+
+const AUTO_LAYOUT_X_SPACING = 180;
+const AUTO_LAYOUT_Y_SPACING = 120;
+const AUTO_LAYOUT_START_X = 120;
+const AUTO_LAYOUT_START_Y = 120;
+
+export const autoLayoutBuses = (
+  state: LoadFlowEditorState
+): LoadFlowEditorState => {
+  if (state.busOrder.length === 0) {
+    return state;
+  }
+
+  const adjacency = new Map<string, string[]>();
+  for (const busId of state.busOrder) {
+    adjacency.set(busId, []);
+  }
+
+  for (const branchId of state.branchOrder) {
+    const branch = state.branchesById[branchId];
+    adjacency.get(branch.fromBusId)?.push(branch.toBusId);
+    adjacency.get(branch.toBusId)?.push(branch.fromBusId);
+  }
+
+  const slackBusId = state.busOrder.find(
+    (busId) => state.busesById[busId]?.type === "SLACK"
+  );
+  const roots = [
+    ...(slackBusId ? [slackBusId] : []),
+    ...state.busOrder.filter((busId) => busId !== slackBusId),
+  ];
+
+  const levelByBusId = new Map<string, number>();
+  const visited = new Set<string>();
+
+  for (const root of roots) {
+    if (visited.has(root)) {
+      continue;
+    }
+
+    const queue: Array<{ busId: string; level: number }> = [
+      { busId: root, level: 0 },
+    ];
+    visited.add(root);
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current) {
+        continue;
+      }
+
+      const existing = levelByBusId.get(current.busId);
+      if (existing === undefined || current.level < existing) {
+        levelByBusId.set(current.busId, current.level);
+      }
+
+      for (const nextBusId of adjacency.get(current.busId) ?? []) {
+        if (visited.has(nextBusId)) {
+          continue;
+        }
+        visited.add(nextBusId);
+        queue.push({ busId: nextBusId, level: current.level + 1 });
+      }
+    }
+  }
+
+  const busesByLevel = new Map<number, string[]>();
+  for (const busId of state.busOrder) {
+    const level = levelByBusId.get(busId) ?? 0;
+    const busesInLevel = busesByLevel.get(level) ?? [];
+    busesInLevel.push(busId);
+    busesByLevel.set(level, busesInLevel);
+  }
+
+  const positionedBuses: Record<string, BusNode> = { ...state.busesById };
+  const orderedLevels = [...busesByLevel.keys()].sort((a, b) => a - b);
+  for (const level of orderedLevels) {
+    const buses = busesByLevel.get(level) ?? [];
+    buses.forEach((busId, index) => {
+      const bus = positionedBuses[busId];
+      positionedBuses[busId] = {
+        ...bus,
+        x: AUTO_LAYOUT_START_X + level * AUTO_LAYOUT_X_SPACING,
+        y: AUTO_LAYOUT_START_Y + index * AUTO_LAYOUT_Y_SPACING,
+      };
+    });
+  }
+
+  return {
+    ...state,
+    busesById: positionedBuses,
+  };
+};
+
+export const replaceEditorStateFromLoadFlowCase = (
+  loadFlowCase: LoadFlowCase
+): LoadFlowEditorState => {
+  const busOrder = loadFlowCase.buses.map((bus) => bus.id);
+  const branchOrder = loadFlowCase.branches.map((branch) => branch.id);
+
+  const busesById = Object.fromEntries(
+    loadFlowCase.buses.map((bus, index) => [
+      bus.id,
+      {
+        id: bus.id,
+        name: bus.name,
+        baseKV: bus.baseKV,
+        type: bus.type,
+        x: AUTO_LAYOUT_START_X + index * AUTO_LAYOUT_X_SPACING,
+        y: AUTO_LAYOUT_START_Y,
+      },
+    ])
+  );
+
+  const branchesById = Object.fromEntries(
+    loadFlowCase.branches.map((branch) => [
+      branch.id,
+      {
+        id: branch.id,
+        fromBusId: branch.fromBusId,
+        toBusId: branch.toBusId,
+        r: branch.r,
+        x: branch.x,
+        bHalf: branch.bHalf ?? 0,
+      },
+    ])
+  );
+
+  const selectedElementId = busOrder[0] ?? branchOrder[0] ?? null;
+  const selectedElementType: "BUS" | "BRANCH" | null = busOrder[0]
+    ? "BUS"
+    : branchOrder[0]
+      ? "BRANCH"
+      : null;
+
+  return autoLayoutBuses({
+    baseMVA: loadFlowCase.baseMVA,
+    busesById,
+    busOrder,
+    branchesById,
+    branchOrder,
+    generators: loadFlowCase.generators.map((generator) => ({ ...generator })),
+    loads: loadFlowCase.loads.map((load) => ({ ...load })),
+    shunts: loadFlowCase.shunts.map((shunt) => ({ ...shunt })),
+    selectedElementId,
+    selectedElementType,
+  });
+};


### PR DESCRIPTION
### Motivation
- Selecting a reference case must fully replace the active editor so the Palette, SLD, Serialized case preview, and the Properties panel reflect the chosen scenario.  
- The Single-Line Diagram (SLD) needs direct bus repositioning via drag to enable quick topology edits.  
- Provide an automatic layout mechanism to arrange buses intelligently by connectivity (rooted at the slack bus) to improve readability when importing or creating cases.  

### Description
- Replace editor state from a `LoadFlowCase` with `replaceEditorStateFromLoadFlowCase`, persist device arrays (`generators`, `loads`, `shunts`) in `LoadFlowEditorState`, and wire scenario selection to replace the editor state rather than only swapping solver input.  
- Add `autoLayoutBuses` which computes connectivity levels (BFS rooted at slack) and assigns `x,y` positions per level; add an `Auto-layout SLD` palette action that invokes it.  
- Make buses draggable in the SLD using pointer events and SVG point projection (`createSVGPoint` + `getScreenCTM`) with `onBusMove` updates routed back to `updateBus`.  
- Ensure serialization includes device arrays by updating `toLoadFlowCase` and expand unit tests to cover autolayout and reference-case replacement; update SLD and workspace components to integrate the new flows.  

### Testing
- Ran `yarn lint` and formatting checks which passed.  
- Ran `yarn typecheck` and `yarn test` (Jest) with all suites passing.  
- Built the site with `yarn build` successfully.  
- Ran Playwright smoke and visual suites in host mode (`yarn test:e2e:host` and `yarn test:e2e:visual:host`) because Docker was unavailable, and the E2E and visual checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7d0d48a48323944a718cbb206bb3)