### PR TITLE
Load-flow: SLD layout, selection sync, editable bus/branch properties, orthogonal branch rendering, and serialization updates

### DIFF
--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -45,6 +45,7 @@ Completed across the first two slices (PR 1 + PR 2 scope):
   - bus: name, base kV, type, voltage setpoint, angle setpoint, voltage min/max
   - branch: `R (pu)`, `X (pu)`, `B/2 (pu)`, thermal limit (MVA), and status
 - ✅ Added a dedicated “Reset active reference case” action so edited reference scenarios can be restored from canonical source data.
+- ✅ Reset now preserves the currently selected bus/branch when that element exists in the restored reference case.
 
 Next recommended slice:
 

--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -34,6 +34,18 @@ Completed across the first two slices (PR 1 + PR 2 scope):
 - ✅ Added store unit tests for deterministic bus defaults and bus/line serialization behavior.
 - ✅ Added an interactive SVG single-line diagram panel in `/load-flow` with clickable buses/branches and selected-element highlighting.
 
+## Feedback Follow-ups (April 2, 2026)
+
+- ✅ Updated the workspace layout so the SLD panel spans the full content width before the editor side panels.
+- ✅ Defaulted reference scenario selection to `IEEE 14-Bus` on initial load.
+- ✅ Switched branch rendering from direct segment lines to orthogonal right-angle polylines.
+- ✅ Synchronized topology-list button highlight state with SLD click selection for both buses and lines.
+- ✅ Kept IEEE 14-bus `baseKV` values aligned with MATPOWER case14 source data (0 kV placeholders in the published reference case).
+- ✅ Expanded property editing coverage:
+  - bus: name, base kV, type, voltage setpoint, angle setpoint, voltage min/max
+  - branch: `R (pu)`, `X (pu)`, `B/2 (pu)`, thermal limit (MVA), and status
+- ✅ Added a dedicated “Reset active reference case” action so edited reference scenarios can be restored from canonical source data.
+
 Next recommended slice:
 
 - Build PR 3 solver skeleton: add `graphToCase.ts`, Ybus assembly, and first Newton-Raphson solve loop with deterministic mini-case tests.

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -72,6 +72,37 @@ export function LoadFlowWorkspace() {
     [serializedCase]
   );
 
+  const resetActiveReferenceCase = () => {
+    if (!selectedReferenceScenario) {
+      return;
+    }
+
+    setEditorState((previousState) => {
+      const resetState = replaceEditorStateFromLoadFlowCase(
+        selectedReferenceScenario.loadFlowCase
+      );
+
+      const selectedElementStillExists =
+        previousState.selectedElementType === "BUS"
+          ? previousState.selectedElementId !== null &&
+            Boolean(resetState.busesById[previousState.selectedElementId])
+          : previousState.selectedElementType === "BRANCH"
+            ? previousState.selectedElementId !== null &&
+              Boolean(resetState.branchesById[previousState.selectedElementId])
+            : false;
+
+      if (!selectedElementStillExists) {
+        return resetState;
+      }
+
+      return selectElement(
+        resetState,
+        previousState.selectedElementType,
+        previousState.selectedElementId
+      );
+    });
+  };
+
   return (
     <section className="rounded-xl border border-gray-700 bg-gray-900/60 p-6 shadow-sm">
       <h2 className="text-heading-sm text-white">Workspace</h2>
@@ -116,13 +147,7 @@ export function LoadFlowWorkspace() {
             <button
               type="button"
               className="rounded-md border border-emerald-400 bg-emerald-900/30 px-3 py-2 text-sm text-emerald-50 hover:bg-emerald-900/50"
-              onClick={() => {
-                setEditorState(
-                  replaceEditorStateFromLoadFlowCase(
-                    selectedReferenceScenario.loadFlowCase
-                  )
-                );
-              }}
+              onClick={resetActiveReferenceCase}
             >
               Reset active reference case
             </button>

--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/features/load-flow/state/loadFlowStore";
 
 const BUS_TYPE_OPTIONS: BusType[] = ["SLACK", "PV", "PQ"];
+const BRANCH_STATUS_OPTIONS = ["IN_SERVICE", "OUT_OF_SERVICE"] as const;
 
 const parseFiniteNumber = (value: string): number | null => {
   const parsed = Number.parseFloat(value);
@@ -31,12 +32,22 @@ const parseFiniteNumber = (value: string): number | null => {
 const isBusType = (value: string): value is BusType =>
   BUS_TYPE_OPTIONS.some((type) => type === value);
 
+const isBranchStatus = (
+  value: string
+): value is (typeof BRANCH_STATUS_OPTIONS)[number] =>
+  BRANCH_STATUS_OPTIONS.some((status) => status === value);
+
 export function LoadFlowWorkspace() {
-  const [editorState, setEditorState] = useState(
-    createInitialLoadFlowEditorState
+  const defaultReferenceScenario = getReferenceScenarioById("ieee-14-bus");
+  const [editorState, setEditorState] = useState(() =>
+    defaultReferenceScenario
+      ? replaceEditorStateFromLoadFlowCase(
+          defaultReferenceScenario.loadFlowCase
+        )
+      : createInitialLoadFlowEditorState()
   );
   const [selectedReferenceScenarioId, setSelectedReferenceScenarioId] =
-    useState<string | null>(null);
+    useState<string | null>(defaultReferenceScenario?.id ?? null);
 
   const selectedBus =
     editorState.selectedElementType === "BUS" && editorState.selectedElementId
@@ -101,6 +112,21 @@ export function LoadFlowWorkspace() {
               {scenario.name}
             </button>
           ))}
+          {selectedReferenceScenario ? (
+            <button
+              type="button"
+              className="rounded-md border border-emerald-400 bg-emerald-900/30 px-3 py-2 text-sm text-emerald-50 hover:bg-emerald-900/50"
+              onClick={() => {
+                setEditorState(
+                  replaceEditorStateFromLoadFlowCase(
+                    selectedReferenceScenario.loadFlowCase
+                  )
+                );
+              }}
+            >
+              Reset active reference case
+            </button>
+          ) : null}
         </div>
         {selectedReferenceScenario ? (
           <p className="mt-2 text-xs text-emerald-100/80">
@@ -114,7 +140,33 @@ export function LoadFlowWorkspace() {
         )}
       </div>
 
-      <div className="mt-6 grid gap-4 lg:grid-cols-3">
+      <div className="mt-6 rounded-lg border border-gray-700 p-4">
+        <h3 className="font-semibold text-white">Single-line diagram</h3>
+        <p className="mt-1 text-sm text-gray-300">
+          Interactive topology view of buses and branches.
+        </p>
+        <SingleLineDiagram
+          buses={editorState.busOrder.map(
+            (busId) => editorState.busesById[busId]
+          )}
+          branches={editorState.branchOrder.map(
+            (branchId) => editorState.branchesById[branchId]
+          )}
+          selectedElementId={editorState.selectedElementId}
+          selectedElementType={editorState.selectedElementType}
+          onBusSelect={(busId) =>
+            setEditorState((prev) => selectElement(prev, "BUS", busId))
+          }
+          onBusMove={(busId, x, y) =>
+            setEditorState((prev) => updateBus(prev, busId, { x, y }))
+          }
+          onBranchSelect={(branchId) =>
+            setEditorState((prev) => selectElement(prev, "BRANCH", branchId))
+          }
+        />
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
         <div className="rounded-lg border border-gray-700 p-4">
           <h3 className="font-semibold text-white">Palette</h3>
           <p className="mt-1 text-sm text-gray-300">
@@ -154,37 +206,22 @@ export function LoadFlowWorkspace() {
         </div>
 
         <div className="rounded-lg border border-gray-700 p-4">
-          <h3 className="font-semibold text-white">Single-line diagram</h3>
-          <p className="mt-1 text-sm text-gray-300">
-            Interactive topology view of buses and branches.
-          </p>
-          <SingleLineDiagram
-            buses={editorState.busOrder.map(
-              (busId) => editorState.busesById[busId]
-            )}
-            branches={editorState.branchOrder.map(
-              (branchId) => editorState.branchesById[branchId]
-            )}
-            selectedElementId={editorState.selectedElementId}
-            selectedElementType={editorState.selectedElementType}
-            onBusSelect={(busId) =>
-              setEditorState((prev) => selectElement(prev, "BUS", busId))
-            }
-            onBusMove={(busId, x, y) =>
-              setEditorState((prev) => updateBus(prev, busId, { x, y }))
-            }
-            onBranchSelect={(branchId) =>
-              setEditorState((prev) => selectElement(prev, "BRANCH", branchId))
-            }
-          />
+          <h3 className="font-semibold text-white">Topology selection</h3>
           <div className="mt-3 space-y-2 text-sm text-gray-200">
             {editorState.busOrder.map((busId) => {
               const bus = editorState.busesById[busId];
+              const isSelected =
+                editorState.selectedElementType === "BUS" &&
+                editorState.selectedElementId === bus.id;
               return (
                 <button
                   key={bus.id}
                   type="button"
-                  className="block w-full rounded-md border border-gray-600 px-3 py-2 text-left hover:bg-gray-800"
+                  className={`block w-full rounded-md border px-3 py-2 text-left transition ${
+                    isSelected
+                      ? "border-emerald-300 bg-emerald-900/40 text-emerald-100"
+                      : "border-gray-600 hover:bg-gray-800"
+                  }`}
                   onClick={() =>
                     setEditorState((prev) => selectElement(prev, "BUS", bus.id))
                   }
@@ -196,11 +233,18 @@ export function LoadFlowWorkspace() {
 
             {editorState.branchOrder.map((branchId) => {
               const branch = editorState.branchesById[branchId];
+              const isSelected =
+                editorState.selectedElementType === "BRANCH" &&
+                editorState.selectedElementId === branch.id;
               return (
                 <button
                   key={branch.id}
                   type="button"
-                  className="block w-full rounded-md border border-blue-800 px-3 py-2 text-left text-blue-200 hover:bg-gray-800"
+                  className={`block w-full rounded-md border px-3 py-2 text-left transition ${
+                    isSelected
+                      ? "border-emerald-300 bg-emerald-900/40 text-emerald-100"
+                      : "border-blue-800 text-blue-200 hover:bg-gray-800"
+                  }`}
                   onClick={() =>
                     setEditorState((prev) =>
                       selectElement(prev, "BRANCH", branch.id)
@@ -232,7 +276,151 @@ export function LoadFlowWorkspace() {
                   }
                 />
               </label>
+              <label className="block">
+                <span>Base kV</span>
+                <input
+                  type="number"
+                  value={selectedBus.baseKV}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    const parsedBaseKV = parseFiniteNumber(event.target.value);
+                    if (parsedBaseKV === null) {
+                      return;
+                    }
 
+                    setEditorState((prev) =>
+                      updateBus(prev, selectedBus.id, {
+                        baseKV: parsedBaseKV,
+                      })
+                    );
+                  }}
+                />
+              </label>
+
+              <label className="block">
+                <span>Voltage setpoint |V| (pu)</span>
+                <input
+                  type="number"
+                  value={selectedBus.voltageMagnitudeSetpoint ?? ""}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    if (event.target.value.trim() === "") {
+                      setEditorState((prev) =>
+                        updateBus(prev, selectedBus.id, {
+                          voltageMagnitudeSetpoint: undefined,
+                        })
+                      );
+                      return;
+                    }
+
+                    const parsedSetpoint = parseFiniteNumber(
+                      event.target.value
+                    );
+                    if (parsedSetpoint === null) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBus(prev, selectedBus.id, {
+                        voltageMagnitudeSetpoint: parsedSetpoint,
+                      })
+                    );
+                  }}
+                />
+              </label>
+              <label className="block">
+                <span>Voltage angle setpoint θ (deg)</span>
+                <input
+                  type="number"
+                  value={selectedBus.voltageAngleSetpointDeg ?? ""}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    if (event.target.value.trim() === "") {
+                      setEditorState((prev) =>
+                        updateBus(prev, selectedBus.id, {
+                          voltageAngleSetpointDeg: undefined,
+                        })
+                      );
+                      return;
+                    }
+
+                    const parsedAngleSetpoint = parseFiniteNumber(
+                      event.target.value
+                    );
+                    if (parsedAngleSetpoint === null) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBus(prev, selectedBus.id, {
+                        voltageAngleSetpointDeg: parsedAngleSetpoint,
+                      })
+                    );
+                  }}
+                />
+              </label>
+              <label className="block">
+                <span>Voltage min |V| (pu)</span>
+                <input
+                  type="number"
+                  value={selectedBus.voltageMagnitudeMin ?? ""}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    if (event.target.value.trim() === "") {
+                      setEditorState((prev) =>
+                        updateBus(prev, selectedBus.id, {
+                          voltageMagnitudeMin: undefined,
+                        })
+                      );
+                      return;
+                    }
+
+                    const parsedVoltageMin = parseFiniteNumber(
+                      event.target.value
+                    );
+                    if (parsedVoltageMin === null) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBus(prev, selectedBus.id, {
+                        voltageMagnitudeMin: parsedVoltageMin,
+                      })
+                    );
+                  }}
+                />
+              </label>
+              <label className="block">
+                <span>Voltage max |V| (pu)</span>
+                <input
+                  type="number"
+                  value={selectedBus.voltageMagnitudeMax ?? ""}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    if (event.target.value.trim() === "") {
+                      setEditorState((prev) =>
+                        updateBus(prev, selectedBus.id, {
+                          voltageMagnitudeMax: undefined,
+                        })
+                      );
+                      return;
+                    }
+
+                    const parsedVoltageMax = parseFiniteNumber(
+                      event.target.value
+                    );
+                    if (parsedVoltageMax === null) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBus(prev, selectedBus.id, {
+                        voltageMagnitudeMax: parsedVoltageMax,
+                      })
+                    );
+                  }}
+                />
+              </label>
               <label className="block">
                 <span>Type</span>
                 <select
@@ -284,6 +472,104 @@ export function LoadFlowWorkspace() {
                     );
                   }}
                 />
+              </label>
+              <label className="block">
+                <span>X (pu)</span>
+                <input
+                  type="number"
+                  value={selectedBranch.x}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    const parsedReactance = parseFiniteNumber(
+                      event.target.value
+                    );
+                    if (parsedReactance === null) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBranch(prev, selectedBranch.id, {
+                        x: parsedReactance,
+                      })
+                    );
+                  }}
+                />
+              </label>
+              <label className="block">
+                <span>B/2 (pu)</span>
+                <input
+                  type="number"
+                  value={selectedBranch.bHalf}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    const parsedBHalf = parseFiniteNumber(event.target.value);
+                    if (parsedBHalf === null) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBranch(prev, selectedBranch.id, {
+                        bHalf: parsedBHalf,
+                      })
+                    );
+                  }}
+                />
+              </label>
+              <label className="block">
+                <span>Thermal limit (MVA)</span>
+                <input
+                  type="number"
+                  value={selectedBranch.thermalLimitMVA ?? ""}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    if (event.target.value.trim() === "") {
+                      setEditorState((prev) =>
+                        updateBranch(prev, selectedBranch.id, {
+                          thermalLimitMVA: undefined,
+                        })
+                      );
+                      return;
+                    }
+
+                    const parsedThermalLimit = parseFiniteNumber(
+                      event.target.value
+                    );
+                    if (parsedThermalLimit === null) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBranch(prev, selectedBranch.id, {
+                        thermalLimitMVA: parsedThermalLimit,
+                      })
+                    );
+                  }}
+                />
+              </label>
+              <label className="block">
+                <span>Status</span>
+                <select
+                  value={selectedBranch.status ?? "IN_SERVICE"}
+                  className="mt-1 w-full rounded border border-gray-600 bg-gray-950 px-2 py-1"
+                  onChange={(event) => {
+                    const nextStatus = event.target.value;
+                    if (!isBranchStatus(nextStatus)) {
+                      return;
+                    }
+
+                    setEditorState((prev) =>
+                      updateBranch(prev, selectedBranch.id, {
+                        status: nextStatus,
+                      })
+                    );
+                  }}
+                >
+                  {BRANCH_STATUS_OPTIONS.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
               </label>
             </div>
           ) : null}

--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -130,7 +130,7 @@ export function SingleLineDiagram({
           viewBox={`${viewBoxX} ${viewBoxY} ${viewBoxWidth} ${viewBoxHeight}`}
           role="img"
           aria-label="Single line diagram"
-          className="h-[280px] min-w-[680px] w-full"
+          className="h-[360px] min-w-[980px] w-full"
         >
           <rect
             x={viewBoxX}
@@ -150,23 +150,23 @@ export function SingleLineDiagram({
 
             const from = getBusCenter(fromBus);
             const to = getBusCenter(toBus);
+            const elbowX = to.x;
+            const elbowY = from.y;
             const isSelected =
               selectedElementType === "BRANCH" &&
               selectedElementId === branch.id;
 
             return (
               <g key={branch.id}>
-                <line
-                  x1={from.x}
-                  y1={from.y}
-                  x2={to.x}
-                  y2={to.y}
+                <polyline
+                  points={`${from.x},${from.y} ${elbowX},${elbowY} ${to.x},${to.y}`}
+                  fill="none"
                   className={`${lineClassName(isSelected)} cursor-pointer transition`}
                   onClick={() => onBranchSelect(branch.id)}
                 />
                 <text
-                  x={(from.x + to.x) / 2}
-                  y={(from.y + to.y) / 2 - 10}
+                  x={elbowX}
+                  y={elbowY - 10}
                   textAnchor="middle"
                   className="fill-slate-300 text-[10px]"
                 >

--- a/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
+++ b/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
@@ -68,6 +68,23 @@ describe("LoadFlowWorkspace", () => {
     expect(screen.getByLabelText(/Base kV/i)).toHaveValue(0);
   });
 
+  it("preserves branch selection when resetting the active reference case", () => {
+    render(<LoadFlowWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: /line-1-2-1/i }));
+    const xInput = screen.getByLabelText(/X \(pu\)/i);
+    expect(xInput).toHaveValue(0.05917);
+
+    fireEvent.change(xInput, { target: { value: "0.09" } });
+    expect(screen.getByLabelText(/X \(pu\)/i)).toHaveValue(0.09);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Reset active reference case/i })
+    );
+
+    expect(screen.getByLabelText(/X \(pu\)/i)).toHaveValue(0.05917);
+  });
+
   it("shows additional branch fields for editing", () => {
     render(<LoadFlowWorkspace />);
 

--- a/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
+++ b/src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
@@ -3,12 +3,17 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { LoadFlowWorkspace } from "../LoadFlowWorkspace";
 
 describe("LoadFlowWorkspace", () => {
-  it("solves the selected reference scenario using full scenario data", () => {
+  it("loads IEEE 14-Bus by default", () => {
     render(<LoadFlowWorkspace />);
 
     expect(
-      screen.getByText(/exactly one slack bus is required/i)
+      screen.getByText(/Active solve case: IEEE 14-Bus/i)
     ).toBeInTheDocument();
+    expect(screen.getByText(/converged in/i)).toBeInTheDocument();
+  });
+
+  it("solves the selected reference scenario using full scenario data", () => {
+    render(<LoadFlowWorkspace />);
 
     fireEvent.click(screen.getByRole("button", { name: "2-Bus Radial" }));
 
@@ -31,5 +36,45 @@ describe("LoadFlowWorkspace", () => {
     expect(
       screen.getByText(/"voltageAngleSetpointDeg": 0/i)
     ).toBeInTheDocument();
+  });
+
+  it("shows and edits branch reactance in the properties panel", () => {
+    render(<LoadFlowWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: /line-1-2-1/i }));
+
+    const xInput = screen.getByLabelText(/X \(pu\)/i);
+    expect(xInput).toHaveValue(0.05917);
+
+    fireEvent.change(xInput, { target: { value: "0.07" } });
+
+    expect(xInput).toHaveValue(0.07);
+  });
+
+  it("can reset an edited reference scenario back to source values", () => {
+    render(<LoadFlowWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Bus 1 • SLACK/i }));
+    const baseKVInput = screen.getByLabelText(/Base kV/i);
+    expect(baseKVInput).toHaveValue(0);
+
+    fireEvent.change(baseKVInput, { target: { value: "11" } });
+    expect(baseKVInput).toHaveValue(11);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Reset active reference case/i })
+    );
+
+    expect(screen.getByLabelText(/Base kV/i)).toHaveValue(0);
+  });
+
+  it("shows additional branch fields for editing", () => {
+    render(<LoadFlowWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: /line-1-2-1/i }));
+
+    expect(screen.getByLabelText(/B\/2 \(pu\)/i)).toHaveValue(0.0264);
+    expect(screen.getByLabelText(/Thermal limit \(MVA\)/i)).toHaveValue(null);
+    expect(screen.getByLabelText(/Status/i)).toHaveValue("IN_SERVICE");
   });
 });

--- a/src/features/load-flow/graph/toLoadFlowCase.ts
+++ b/src/features/load-flow/graph/toLoadFlowCase.ts
@@ -25,6 +25,8 @@ export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
       r: branch.r,
       x: branch.x,
       bHalf: branch.bHalf,
+      thermalLimitMVA: branch.thermalLimitMVA,
+      status: branch.status,
     };
   });
 

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -26,6 +26,8 @@ export interface LineEdge {
   r: number;
   x: number;
   bHalf: number;
+  thermalLimitMVA?: number;
+  status?: "IN_SERVICE" | "OUT_OF_SERVICE";
 }
 
 export interface LoadFlowEditorState {
@@ -132,6 +134,7 @@ export const addBranch = (
         r: 0.01,
         x: 0.1,
         bHalf: 0,
+        status: "IN_SERVICE",
       },
     },
     branchOrder: [...state.branchOrder, id],
@@ -299,6 +302,8 @@ export const replaceEditorStateFromLoadFlowCase = (
         r: branch.r,
         x: branch.x,
         bHalf: branch.bHalf ?? 0,
+        thermalLimitMVA: branch.thermalLimitMVA,
+        status: branch.status,
       },
     ])
   );


### PR DESCRIPTION
### Motivation

- Make the single-line diagram (SLD) the primary workspace view and keep topology selection in sync with SLD interactions for a smoother editor UX.
- Expose additional bus and branch electrical properties in the editor so scenarios can be edited and inspected without touching low-level DTOs.
- Ensure the editor-to-case serialization and editor state round-trip include new branch metadata so reference scenarios can be edited and reset reliably.

### Description

- Default the workspace to load the `IEEE 14-Bus` reference scenario on initial load and initialize the editor from that case via `replaceEditorStateFromLoadFlowCase`.
- Promote the SLD panel to span the main content area and add click handlers to synchronize selection between the SLD and the topology list. 
- Swap branch rendering from straight segments to orthogonal right-angle polylines in `SingleLineDiagram` and increase the SVG view size for better layout. 
- Add expanded bus property editing fields (base kV, voltage magnitude/angle setpoints, min/max) and branch property editing fields (`X (pu)`, `B/2 (pu)`, thermal limit in MVA, and `status`) in `LoadFlowWorkspace`, including parsing/validation helpers. 
- Introduce `BRANCH_STATUS_OPTIONS` and `isBranchStatus` guard; default new branches to `IN_SERVICE` in `addBranch`. 
- Include `thermalLimitMVA` and `status` in the editor store `LineEdge` type and flow-case serialization in `toLoadFlowCase`, and hydrate these fields when replacing editor state from a `LoadFlowCase`. 
- Add a `Reset active reference case` action to restore the canonical source scenario into the editor without changing selection. 
- Update component tests in `__tests__/LoadFlowWorkspace.test.tsx` to cover default scenario selection, branch/property editing, and reset behavior.

### Testing

- Ran the load-flow component unit tests in `src/app/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx` with the test runner and all tests passed.
- Ran the updated component interaction checks (selection sync, property edits, reset action) as part of the test suite and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceadc953988323bdcd06c72cbc23fc)