### PR TITLE
SLD: prevent bus overlap, add crossing hops and zoom controls

### DIFF
--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -1,4 +1,4 @@
-import { PointerEvent, useRef } from "react";
+import { PointerEvent, useMemo, useRef, useState, WheelEvent } from "react";
 
 import { BusNode, LineEdge } from "@/features/load-flow/state/loadFlowStore";
 
@@ -19,6 +19,19 @@ const BUS_HALF_HEIGHT = BUS_HEIGHT / 2;
 const DIAGRAM_PADDING = 48;
 const MIN_VIEWBOX_WIDTH = 680;
 const MIN_VIEWBOX_HEIGHT = 280;
+const MIN_ZOOM = 0.6;
+const MAX_ZOOM = 2.5;
+const ZOOM_STEP = 0.2;
+const LINE_HOP_RADIUS = 10;
+
+interface BranchSegment {
+  branchId: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  orientation: "HORIZONTAL" | "VERTICAL";
+}
 
 const getBusCenter = (bus: BusNode) => ({
   x: bus.x,
@@ -46,6 +59,7 @@ export function SingleLineDiagram({
 }: SingleLineDiagramProps) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const draggingBusIdRef = useRef<string | null>(null);
+  const [zoom, setZoom] = useState(1);
 
   const toSvgPoint = (clientX: number, clientY: number) => {
     const svg = svgRef.current;
@@ -117,6 +131,125 @@ export function SingleLineDiagram({
     contentMaxY - contentMinY + DIAGRAM_PADDING * 2,
     MIN_VIEWBOX_HEIGHT
   );
+  const viewBoxCenterX = viewBoxX + viewBoxWidth / 2;
+  const viewBoxCenterY = viewBoxY + viewBoxHeight / 2;
+  const zoomedViewBoxWidth = viewBoxWidth / zoom;
+  const zoomedViewBoxHeight = viewBoxHeight / zoom;
+  const zoomedViewBoxX = viewBoxCenterX - zoomedViewBoxWidth / 2;
+  const zoomedViewBoxY = viewBoxCenterY - zoomedViewBoxHeight / 2;
+
+  const clampZoom = (nextZoom: number) =>
+    Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, nextZoom));
+
+  const handleZoomIn = () => {
+    setZoom((previousZoom) => clampZoom(previousZoom + ZOOM_STEP));
+  };
+
+  const handleZoomOut = () => {
+    setZoom((previousZoom) => clampZoom(previousZoom - ZOOM_STEP));
+  };
+
+  const handleWheel = (event: WheelEvent<SVGSVGElement>) => {
+    if (!event.ctrlKey) {
+      return;
+    }
+
+    event.preventDefault();
+    setZoom((previousZoom) =>
+      clampZoom(previousZoom + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP))
+    );
+  };
+
+  const branchSegmentsById = useMemo(() => {
+    const segmentsById = new Map<string, BranchSegment[]>();
+
+    branches.forEach((branch) => {
+      const fromBus = busesById.get(branch.fromBusId);
+      const toBus = busesById.get(branch.toBusId);
+
+      if (!fromBus || !toBus) {
+        return;
+      }
+
+      const from = getBusCenter(fromBus);
+      const to = getBusCenter(toBus);
+      const elbowX = to.x;
+      const elbowY = from.y;
+
+      segmentsById.set(branch.id, [
+        {
+          branchId: branch.id,
+          x1: from.x,
+          y1: from.y,
+          x2: elbowX,
+          y2: elbowY,
+          orientation: "HORIZONTAL",
+        },
+        {
+          branchId: branch.id,
+          x1: elbowX,
+          y1: elbowY,
+          x2: to.x,
+          y2: to.y,
+          orientation: "VERTICAL",
+        },
+      ]);
+    });
+
+    return segmentsById;
+  }, [branches, busesById]);
+
+  const lineHopPointsByBranchId = useMemo(() => {
+    const hopsByBranchId = new Map<string, Array<{ x: number; y: number }>>();
+
+    branches.forEach((branch, branchIndex) => {
+      const branchSegments = branchSegmentsById.get(branch.id) ?? [];
+      branches.slice(0, branchIndex).forEach((previousBranch) => {
+        const previousSegments =
+          branchSegmentsById.get(previousBranch.id) ?? [];
+
+        for (const currentSegment of branchSegments) {
+          for (const previousSegment of previousSegments) {
+            if (
+              currentSegment.orientation === previousSegment.orientation ||
+              currentSegment.orientation !== "VERTICAL" ||
+              previousSegment.orientation !== "HORIZONTAL"
+            ) {
+              continue;
+            }
+
+            const minHorizontalX = Math.min(
+              previousSegment.x1,
+              previousSegment.x2
+            );
+            const maxHorizontalX = Math.max(
+              previousSegment.x1,
+              previousSegment.x2
+            );
+            const minVerticalY = Math.min(currentSegment.y1, currentSegment.y2);
+            const maxVerticalY = Math.max(currentSegment.y1, currentSegment.y2);
+            const crossingX = currentSegment.x1;
+            const crossingY = previousSegment.y1;
+            const crosses =
+              crossingX > minHorizontalX &&
+              crossingX < maxHorizontalX &&
+              crossingY > minVerticalY &&
+              crossingY < maxVerticalY;
+
+            if (!crosses) {
+              continue;
+            }
+
+            const branchHops = hopsByBranchId.get(branch.id) ?? [];
+            branchHops.push({ x: crossingX, y: crossingY });
+            hopsByBranchId.set(branch.id, branchHops);
+          }
+        }
+      });
+    });
+
+    return hopsByBranchId;
+  }, [branchSegmentsById, branches]);
 
   return (
     <div className="mt-3 overflow-x-auto rounded-md border border-slate-700 bg-slate-950/60 p-3">
@@ -125,98 +258,141 @@ export function SingleLineDiagram({
           Add buses from the palette to render the one-line diagram.
         </p>
       ) : (
-        <svg
-          ref={svgRef}
-          viewBox={`${viewBoxX} ${viewBoxY} ${viewBoxWidth} ${viewBoxHeight}`}
-          role="img"
-          aria-label="Single line diagram"
-          className="h-[360px] min-w-[980px] w-full"
-        >
-          <rect
-            x={viewBoxX}
-            y={viewBoxY}
-            width={viewBoxWidth}
-            height={viewBoxHeight}
-            className="fill-slate-950"
-          />
+        <>
+          <div className="mb-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleZoomOut}
+              className="rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-emerald-300 hover:text-white"
+              aria-label="Zoom out"
+            >
+              −
+            </button>
+            <button
+              type="button"
+              onClick={handleZoomIn}
+              className="rounded border border-slate-600 px-2 py-1 text-xs text-slate-200 hover:border-emerald-300 hover:text-white"
+              aria-label="Zoom in"
+            >
+              +
+            </button>
+            <span className="text-xs text-slate-400">
+              {Math.round(zoom * 100)}% (Ctrl + wheel)
+            </span>
+          </div>
+          <svg
+            ref={svgRef}
+            viewBox={`${zoomedViewBoxX} ${zoomedViewBoxY} ${zoomedViewBoxWidth} ${zoomedViewBoxHeight}`}
+            role="img"
+            aria-label="Single line diagram"
+            className="h-[360px] min-w-[980px] w-full"
+            onWheel={handleWheel}
+          >
+            <rect
+              x={viewBoxX}
+              y={viewBoxY}
+              width={viewBoxWidth}
+              height={viewBoxHeight}
+              className="fill-slate-950"
+            />
 
-          {branches.map((branch) => {
-            const fromBus = busesById.get(branch.fromBusId);
-            const toBus = busesById.get(branch.toBusId);
+            {branches.map((branch) => {
+              const fromBus = busesById.get(branch.fromBusId);
+              const toBus = busesById.get(branch.toBusId);
 
-            if (!fromBus || !toBus) {
-              return null;
-            }
+              if (!fromBus || !toBus) {
+                return null;
+              }
 
-            const from = getBusCenter(fromBus);
-            const to = getBusCenter(toBus);
-            const elbowX = to.x;
-            const elbowY = from.y;
-            const isSelected =
-              selectedElementType === "BRANCH" &&
-              selectedElementId === branch.id;
+              const from = getBusCenter(fromBus);
+              const to = getBusCenter(toBus);
+              const elbowX = to.x;
+              const elbowY = from.y;
+              const isSelected =
+                selectedElementType === "BRANCH" &&
+                selectedElementId === branch.id;
+              const lineHops = lineHopPointsByBranchId.get(branch.id) ?? [];
 
-            return (
-              <g key={branch.id}>
-                <polyline
-                  points={`${from.x},${from.y} ${elbowX},${elbowY} ${to.x},${to.y}`}
-                  fill="none"
-                  className={`${lineClassName(isSelected)} cursor-pointer transition`}
-                  onClick={() => onBranchSelect(branch.id)}
-                />
-                <text
-                  x={elbowX}
-                  y={elbowY - 10}
-                  textAnchor="middle"
-                  className="fill-slate-300 text-[10px]"
+              return (
+                <g key={branch.id}>
+                  <polyline
+                    points={`${from.x},${from.y} ${elbowX},${elbowY} ${to.x},${to.y}`}
+                    fill="none"
+                    className={`${lineClassName(isSelected)} cursor-pointer transition`}
+                    onClick={() => onBranchSelect(branch.id)}
+                  />
+                  <text
+                    x={elbowX}
+                    y={elbowY - 10}
+                    textAnchor="middle"
+                    className="fill-slate-300 text-[10px]"
+                  >
+                    {branch.id}
+                  </text>
+                  {lineHops.map((lineHop, index) => (
+                    <g key={`${branch.id}-hop-${index}`}>
+                      <rect
+                        x={lineHop.x - LINE_HOP_RADIUS}
+                        y={lineHop.y - LINE_HOP_RADIUS}
+                        width={LINE_HOP_RADIUS * 2}
+                        height={LINE_HOP_RADIUS * 2}
+                        className="fill-slate-950"
+                      />
+                      <path
+                        d={`M ${lineHop.x} ${lineHop.y - LINE_HOP_RADIUS} A ${LINE_HOP_RADIUS} ${LINE_HOP_RADIUS} 0 0 1 ${lineHop.x} ${lineHop.y + LINE_HOP_RADIUS}`}
+                        fill="none"
+                        className={`${lineClassName(isSelected)} stroke-[3]`}
+                      />
+                    </g>
+                  ))}
+                </g>
+              );
+            })}
+
+            {buses.map((bus) => {
+              const isSelected =
+                selectedElementType === "BUS" && selectedElementId === bus.id;
+
+              return (
+                <g
+                  key={bus.id}
+                  transform={`translate(${bus.x - BUS_HALF_WIDTH}, ${bus.y - BUS_HALF_HEIGHT})`}
                 >
-                  {branch.id}
-                </text>
-              </g>
-            );
-          })}
-
-          {buses.map((bus) => {
-            const isSelected =
-              selectedElementType === "BUS" && selectedElementId === bus.id;
-
-            return (
-              <g
-                key={bus.id}
-                transform={`translate(${bus.x - BUS_HALF_WIDTH}, ${bus.y - BUS_HALF_HEIGHT})`}
-              >
-                <rect
-                  x={0}
-                  y={0}
-                  rx={6}
-                  width={BUS_WIDTH}
-                  height={BUS_HEIGHT}
-                  className={`${busClassName(isSelected)} cursor-pointer stroke-2 transition`}
-                  onClick={() => onBusSelect(bus.id)}
-                  onPointerDown={(event) => handleBusPointerDown(event, bus.id)}
-                  onPointerMove={handleBusPointerMove}
-                  onPointerUp={handleBusPointerUp}
-                />
-                <text
-                  x={BUS_HALF_WIDTH}
-                  y={17}
-                  textAnchor="middle"
-                  className="fill-white text-[11px] font-medium"
-                >
-                  {bus.name}
-                </text>
-                <text
-                  x={BUS_HALF_WIDTH}
-                  y={32}
-                  textAnchor="middle"
-                  className="fill-slate-300 text-[10px]"
-                >
-                  {bus.type}
-                </text>
-              </g>
-            );
-          })}
-        </svg>
+                  <rect
+                    x={0}
+                    y={0}
+                    rx={6}
+                    width={BUS_WIDTH}
+                    height={BUS_HEIGHT}
+                    className={`${busClassName(isSelected)} cursor-pointer stroke-2 transition`}
+                    onClick={() => onBusSelect(bus.id)}
+                    onPointerDown={(event) =>
+                      handleBusPointerDown(event, bus.id)
+                    }
+                    onPointerMove={handleBusPointerMove}
+                    onPointerUp={handleBusPointerUp}
+                  />
+                  <text
+                    x={BUS_HALF_WIDTH}
+                    y={17}
+                    textAnchor="middle"
+                    className="fill-white text-[11px] font-medium"
+                  >
+                    {bus.name}
+                  </text>
+                  <text
+                    x={BUS_HALF_WIDTH}
+                    y={32}
+                    textAnchor="middle"
+                    className="fill-slate-300 text-[10px]"
+                  >
+                    {bus.type}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </>
       )}
     </div>
   );

--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -33,6 +33,38 @@ interface BranchSegment {
   orientation: "HORIZONTAL" | "VERTICAL";
 }
 
+const getOrthogonalCrossingPoint = (
+  firstSegment: BranchSegment,
+  secondSegment: BranchSegment
+) => {
+  if (firstSegment.orientation === secondSegment.orientation) {
+    return null;
+  }
+
+  const horizontalSegment =
+    firstSegment.orientation === "HORIZONTAL" ? firstSegment : secondSegment;
+  const verticalSegment =
+    firstSegment.orientation === "VERTICAL" ? firstSegment : secondSegment;
+
+  const minHorizontalX = Math.min(horizontalSegment.x1, horizontalSegment.x2);
+  const maxHorizontalX = Math.max(horizontalSegment.x1, horizontalSegment.x2);
+  const minVerticalY = Math.min(verticalSegment.y1, verticalSegment.y2);
+  const maxVerticalY = Math.max(verticalSegment.y1, verticalSegment.y2);
+  const crossingX = verticalSegment.x1;
+  const crossingY = horizontalSegment.y1;
+  const isCrossing =
+    crossingX > minHorizontalX &&
+    crossingX < maxHorizontalX &&
+    crossingY > minVerticalY &&
+    crossingY < maxVerticalY;
+
+  if (!isCrossing) {
+    return null;
+  }
+
+  return { x: crossingX, y: crossingY };
+};
+
 const getBusCenter = (bus: BusNode) => ({
   x: bus.x,
   y: bus.y,
@@ -210,38 +242,16 @@ export function SingleLineDiagram({
 
         for (const currentSegment of branchSegments) {
           for (const previousSegment of previousSegments) {
-            if (
-              currentSegment.orientation === previousSegment.orientation ||
-              currentSegment.orientation !== "VERTICAL" ||
-              previousSegment.orientation !== "HORIZONTAL"
-            ) {
-              continue;
-            }
-
-            const minHorizontalX = Math.min(
-              previousSegment.x1,
-              previousSegment.x2
+            const crossingPoint = getOrthogonalCrossingPoint(
+              currentSegment,
+              previousSegment
             );
-            const maxHorizontalX = Math.max(
-              previousSegment.x1,
-              previousSegment.x2
-            );
-            const minVerticalY = Math.min(currentSegment.y1, currentSegment.y2);
-            const maxVerticalY = Math.max(currentSegment.y1, currentSegment.y2);
-            const crossingX = currentSegment.x1;
-            const crossingY = previousSegment.y1;
-            const crosses =
-              crossingX > minHorizontalX &&
-              crossingX < maxHorizontalX &&
-              crossingY > minVerticalY &&
-              crossingY < maxVerticalY;
-
-            if (!crosses) {
+            if (!crossingPoint) {
               continue;
             }
 
             const branchHops = hopsByBranchId.get(branch.id) ?? [];
-            branchHops.push({ x: crossingX, y: crossingY });
+            branchHops.push(crossingPoint);
             hopsByBranchId.set(branch.id, branchHops);
           }
         }

--- a/src/app/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
+++ b/src/app/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
@@ -31,6 +31,8 @@ const branches: LineEdge[] = [
   },
 ];
 
+const reversedBranchOrder = [branches[1], branches[0]];
+
 describe("SingleLineDiagram", () => {
   const onBusSelect = jest.fn();
   const onBusMove = jest.fn();
@@ -76,6 +78,23 @@ describe("SingleLineDiagram", () => {
       <SingleLineDiagram
         buses={buses}
         branches={branches}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    const hopPaths = container.querySelectorAll('path[d*="A 10 10"]');
+    expect(hopPaths.length).toBeGreaterThan(0);
+  });
+
+  it("renders hop markers regardless of branch insertion order", () => {
+    const { container } = render(
+      <SingleLineDiagram
+        buses={buses}
+        branches={reversedBranchOrder}
         selectedElementId={null}
         selectedElementType={null}
         onBusSelect={onBusSelect}

--- a/src/app/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
+++ b/src/app/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { SingleLineDiagram } from "@/app/load-flow/_components/SingleLineDiagram";
+import { BusNode, LineEdge } from "@/features/load-flow/state/loadFlowStore";
+
+const buses: BusNode[] = [
+  { id: "bus-1", name: "Bus 1", type: "SLACK", baseKV: 230, x: 100, y: 100 },
+  { id: "bus-2", name: "Bus 2", type: "PQ", baseKV: 230, x: 300, y: 300 },
+  { id: "bus-3", name: "Bus 3", type: "PQ", baseKV: 230, x: 50, y: 20 },
+  { id: "bus-4", name: "Bus 4", type: "PQ", baseKV: 230, x: 250, y: 220 },
+];
+
+const branches: LineEdge[] = [
+  {
+    id: "line-1",
+    fromBusId: "bus-1",
+    toBusId: "bus-2",
+    r: 0.01,
+    x: 0.1,
+    bHalf: 0,
+    status: "IN_SERVICE",
+  },
+  {
+    id: "line-2",
+    fromBusId: "bus-3",
+    toBusId: "bus-4",
+    r: 0.01,
+    x: 0.1,
+    bHalf: 0,
+    status: "IN_SERVICE",
+  },
+];
+
+describe("SingleLineDiagram", () => {
+  const onBusSelect = jest.fn();
+  const onBusMove = jest.fn();
+  const onBranchSelect = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("supports zoom controls and ctrl-wheel zooming", () => {
+    const { container } = render(
+      <SingleLineDiagram
+        buses={buses}
+        branches={branches}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    expect(screen.getByText("100% (Ctrl + wheel)")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    expect(screen.getByText("120% (Ctrl + wheel)")).toBeInTheDocument();
+
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    if (!svg) {
+      return;
+    }
+
+    fireEvent.wheel(svg, { deltaY: -100 });
+    expect(screen.getByText("120% (Ctrl + wheel)")).toBeInTheDocument();
+
+    fireEvent.wheel(svg, { ctrlKey: true, deltaY: -100 });
+    expect(screen.getByText("140% (Ctrl + wheel)")).toBeInTheDocument();
+  });
+
+  it("renders hop markers when two line segments cross", () => {
+    const { container } = render(
+      <SingleLineDiagram
+        buses={buses}
+        branches={branches}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    const hopPaths = container.querySelectorAll('path[d*="A 10 10"]');
+    expect(hopPaths.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
+++ b/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
@@ -86,6 +86,25 @@ describe("loadFlowStore", () => {
     expect(laidOut.busesById["bus-3"].x).toBe(480);
   });
 
+  it("keeps auto-layout bus positions non-overlapping", () => {
+    let state = createInitialLoadFlowEditorState();
+    state = addBus(state);
+    state = addBus(state);
+    state = addBus(state);
+    state = addBus(state);
+    state = addBranch(state, "bus-1", "bus-2");
+    state = addBranch(state, "bus-3", "bus-4");
+
+    const laidOut = autoLayoutBuses(state);
+    const positions = laidOut.busOrder.map((busId) => laidOut.busesById[busId]);
+
+    const uniquePositionCount = new Set(
+      positions.map((bus) => `${bus.x}-${bus.y}`)
+    ).size;
+
+    expect(uniquePositionCount).toBe(positions.length);
+  });
+
   it("replaces editor state from a reference case including device data", () => {
     const replaced = replaceEditorStateFromLoadFlowCase({
       baseMVA: 100,

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -179,6 +179,36 @@ const AUTO_LAYOUT_X_SPACING = 180;
 const AUTO_LAYOUT_Y_SPACING = 120;
 const AUTO_LAYOUT_START_X = 120;
 const AUTO_LAYOUT_START_Y = 120;
+const AUTO_LAYOUT_MIN_BUS_HORIZONTAL_CLEARANCE = 104;
+const AUTO_LAYOUT_MIN_BUS_VERTICAL_CLEARANCE = 58;
+
+const isOverlappingBusPosition = (
+  x: number,
+  y: number,
+  placed: Array<{ x: number; y: number }>
+) =>
+  placed.some(
+    (position) =>
+      Math.abs(position.x - x) < AUTO_LAYOUT_MIN_BUS_HORIZONTAL_CLEARANCE &&
+      Math.abs(position.y - y) < AUTO_LAYOUT_MIN_BUS_VERTICAL_CLEARANCE
+  );
+
+const resolveNonOverlappingPosition = (
+  x: number,
+  y: number,
+  placed: Array<{ x: number; y: number }>
+) => {
+  if (!isOverlappingBusPosition(x, y, placed)) {
+    return { x, y };
+  }
+
+  let nextY = y;
+  while (isOverlappingBusPosition(x, nextY, placed)) {
+    nextY += AUTO_LAYOUT_Y_SPACING;
+  }
+
+  return { x, y: nextY };
+};
 
 export const autoLayoutBuses = (
   state: LoadFlowEditorState
@@ -250,15 +280,26 @@ export const autoLayoutBuses = (
 
   const positionedBuses: Record<string, BusNode> = { ...state.busesById };
   const orderedLevels = [...busesByLevel.keys()].sort((a, b) => a - b);
+  const placedPositions: Array<{ x: number; y: number }> = [];
+
   for (const level of orderedLevels) {
     const buses = busesByLevel.get(level) ?? [];
     buses.forEach((busId, index) => {
       const bus = positionedBuses[busId];
+      const proposedX = AUTO_LAYOUT_START_X + level * AUTO_LAYOUT_X_SPACING;
+      const proposedY = AUTO_LAYOUT_START_Y + index * AUTO_LAYOUT_Y_SPACING;
+      const { x, y } = resolveNonOverlappingPosition(
+        proposedX,
+        proposedY,
+        placedPositions
+      );
+
       positionedBuses[busId] = {
         ...bus,
-        x: AUTO_LAYOUT_START_X + level * AUTO_LAYOUT_X_SPACING,
-        y: AUTO_LAYOUT_START_Y + index * AUTO_LAYOUT_Y_SPACING,
+        x,
+        y,
       };
+      placedPositions.push({ x, y });
     });
   }
 


### PR DESCRIPTION
### Motivation
- Prevent automatic bus placements from colliding so the single-line diagram (SLD) remains readable after `Auto-layout`.
- Make branch crossings visually obvious using a small overpass/hop affordance to avoid ambiguous overlaps.
- Provide keyboard + UI zoom affordances so users can inspect dense diagrams via `+`/`−` buttons and `Ctrl +` mouse wheel.

### Description
- Implemented non-overlap logic in `autoLayoutBuses` (`src/features/load-flow/state/loadFlowStore.ts`) by adding overlap thresholds and `resolveNonOverlappingPosition` to shift colliding proposals vertically.
- Added zoom state and controls in `SingleLineDiagram` (`src/app/load-flow/_components/SingleLineDiagram.tsx`) including clamped zoom bounds, `+`/`−` buttons, a percent readout, and `Ctrl + wheel` handling that adjusts the SVG `viewBox`.
- Detect horizontal/vertical branch segment intersections and compute crossing hop points, then render a small overpass marker (rect + arc path) at crossings in the SLD rendering (`SingleLineDiagram.tsx`).
- Added unit tests: component tests for zoom interactions and hop rendering (`src/app/load-flow/_components/__tests__/SingleLineDiagram.test.tsx`) and a store test verifying auto-layout produces unique bus coordinates (`src/features/load-flow/state/__tests__/loadFlowStore.test.ts`).

### Testing
- Ran `yarn lint` and formatting (Prettier) and the workspace reported success.
- Ran `yarn typecheck` and `yarn test` where all Jest suites passed (`38` suites, `155` tests passed).
- Ran `yarn build` successfully producing the static output without errors.
- Ran E2E smoke and visual host-mode suites: `yarn test:e2e` failed due to missing `docker` in this environment, while `yarn test:e2e:host` (24 smoke tests) and `yarn test:e2e:visual:host` (8 visual tests) both passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cec8515c7c8323b89ed8ee4d46e33c)