### PR TITLE
Improve SLD auto-layout readability and line-hop visibility

### DIFF
--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -33,6 +33,12 @@ interface BranchSegment {
   orientation: "HORIZONTAL" | "VERTICAL";
 }
 
+interface RoutedBranch {
+  branchId: string;
+  points: Array<{ x: number; y: number }>;
+  segments: BranchSegment[];
+}
+
 const getOrthogonalCrossingPoint = (
   firstSegment: BranchSegment,
   secondSegment: BranchSegment
@@ -69,6 +75,32 @@ const getBusCenter = (bus: BusNode) => ({
   x: bus.x,
   y: bus.y,
 });
+
+const toBranchSegments = (
+  branchId: string,
+  points: Array<{ x: number; y: number }>
+): BranchSegment[] =>
+  points.slice(0, -1).flatMap((fromPoint, index) => {
+    const toPoint = points[index + 1];
+    if (!toPoint) {
+      return [];
+    }
+    if (fromPoint.x === toPoint.x && fromPoint.y === toPoint.y) {
+      return [];
+    }
+
+    const orientation = fromPoint.y === toPoint.y ? "HORIZONTAL" : "VERTICAL";
+    return [
+      {
+        branchId,
+        x1: fromPoint.x,
+        y1: fromPoint.y,
+        x2: toPoint.x,
+        y2: toPoint.y,
+        orientation,
+      },
+    ];
+  });
 
 const lineClassName = (isSelected: boolean) =>
   isSelected
@@ -192,8 +224,8 @@ export function SingleLineDiagram({
     );
   };
 
-  const branchSegmentsById = useMemo(() => {
-    const segmentsById = new Map<string, BranchSegment[]>();
+  const routedBranchesById = useMemo(() => {
+    const routedById = new Map<string, RoutedBranch>();
 
     branches.forEach((branch) => {
       const fromBus = busesById.get(branch.fromBusId);
@@ -208,37 +240,29 @@ export function SingleLineDiagram({
       const elbowX = to.x;
       const elbowY = from.y;
 
-      segmentsById.set(branch.id, [
-        {
-          branchId: branch.id,
-          x1: from.x,
-          y1: from.y,
-          x2: elbowX,
-          y2: elbowY,
-          orientation: "HORIZONTAL",
-        },
-        {
-          branchId: branch.id,
-          x1: elbowX,
-          y1: elbowY,
-          x2: to.x,
-          y2: to.y,
-          orientation: "VERTICAL",
-        },
-      ]);
+      const points = [
+        { x: from.x, y: from.y },
+        { x: elbowX, y: elbowY },
+        { x: to.x, y: to.y },
+      ];
+      routedById.set(branch.id, {
+        branchId: branch.id,
+        points,
+        segments: toBranchSegments(branch.id, points),
+      });
     });
 
-    return segmentsById;
+    return routedById;
   }, [branches, busesById]);
 
   const lineHopPointsByBranchId = useMemo(() => {
     const hopsByBranchId = new Map<string, Array<{ x: number; y: number }>>();
 
     branches.forEach((branch, branchIndex) => {
-      const branchSegments = branchSegmentsById.get(branch.id) ?? [];
+      const branchSegments = routedBranchesById.get(branch.id)?.segments ?? [];
       branches.slice(0, branchIndex).forEach((previousBranch) => {
         const previousSegments =
-          branchSegmentsById.get(previousBranch.id) ?? [];
+          routedBranchesById.get(previousBranch.id)?.segments ?? [];
 
         for (const currentSegment of branchSegments) {
           for (const previousSegment of previousSegments) {
@@ -259,7 +283,7 @@ export function SingleLineDiagram({
     });
 
     return hopsByBranchId;
-  }, [branchSegmentsById, branches]);
+  }, [routedBranchesById, branches]);
 
   return (
     <div className="mt-3 overflow-x-auto rounded-md border border-slate-700 bg-slate-950/60 p-3">
@@ -314,49 +338,60 @@ export function SingleLineDiagram({
                 return null;
               }
 
-              const from = getBusCenter(fromBus);
-              const to = getBusCenter(toBus);
-              const elbowX = to.x;
-              const elbowY = from.y;
+              const routedBranch = routedBranchesById.get(branch.id);
+              if (!routedBranch) {
+                return null;
+              }
+              const elbowPoint = routedBranch.points[1];
+              const fallbackLabelPoint =
+                routedBranch.points[routedBranch.points.length - 1];
               const isSelected =
                 selectedElementType === "BRANCH" &&
                 selectedElementId === branch.id;
-              const lineHops = lineHopPointsByBranchId.get(branch.id) ?? [];
 
               return (
                 <g key={branch.id}>
                   <polyline
-                    points={`${from.x},${from.y} ${elbowX},${elbowY} ${to.x},${to.y}`}
+                    points={routedBranch.points
+                      .map((point) => `${point.x},${point.y}`)
+                      .join(" ")}
                     fill="none"
                     className={`${lineClassName(isSelected)} cursor-pointer transition`}
                     onClick={() => onBranchSelect(branch.id)}
                   />
                   <text
-                    x={elbowX}
-                    y={elbowY - 10}
+                    x={elbowPoint?.x ?? fallbackLabelPoint?.x ?? 0}
+                    y={(elbowPoint?.y ?? fallbackLabelPoint?.y ?? 0) - 10}
                     textAnchor="middle"
                     className="fill-slate-300 text-[10px]"
                   >
                     {branch.id}
                   </text>
-                  {lineHops.map((lineHop, index) => (
-                    <g key={`${branch.id}-hop-${index}`}>
-                      <rect
-                        x={lineHop.x - LINE_HOP_RADIUS}
-                        y={lineHop.y - LINE_HOP_RADIUS}
-                        width={LINE_HOP_RADIUS * 2}
-                        height={LINE_HOP_RADIUS * 2}
-                        className="fill-slate-950"
-                      />
-                      <path
-                        d={`M ${lineHop.x} ${lineHop.y - LINE_HOP_RADIUS} A ${LINE_HOP_RADIUS} ${LINE_HOP_RADIUS} 0 0 1 ${lineHop.x} ${lineHop.y + LINE_HOP_RADIUS}`}
-                        fill="none"
-                        className={`${lineClassName(isSelected)} stroke-[3]`}
-                      />
-                    </g>
-                  ))}
                 </g>
               );
+            })}
+
+            {branches.map((branch) => {
+              const isSelected =
+                selectedElementType === "BRANCH" &&
+                selectedElementId === branch.id;
+              const lineHops = lineHopPointsByBranchId.get(branch.id) ?? [];
+              return lineHops.map((lineHop, index) => (
+                <g key={`${branch.id}-hop-${index}`}>
+                  <rect
+                    x={lineHop.x - LINE_HOP_RADIUS}
+                    y={lineHop.y - LINE_HOP_RADIUS}
+                    width={LINE_HOP_RADIUS * 2}
+                    height={LINE_HOP_RADIUS * 2}
+                    className="fill-slate-950"
+                  />
+                  <path
+                    d={`M ${lineHop.x} ${lineHop.y - LINE_HOP_RADIUS} A ${LINE_HOP_RADIUS} ${LINE_HOP_RADIUS} 0 0 1 ${lineHop.x} ${lineHop.y + LINE_HOP_RADIUS}`}
+                    fill="none"
+                    className={`${lineClassName(isSelected)} stroke-[3]`}
+                  />
+                </g>
+              ));
             })}
 
             {buses.map((bus) => {

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -176,7 +176,7 @@ export const selectElement = (
 });
 
 const AUTO_LAYOUT_X_SPACING = 180;
-const AUTO_LAYOUT_Y_SPACING = 120;
+const AUTO_LAYOUT_Y_SPACING = 140;
 const AUTO_LAYOUT_START_X = 120;
 const AUTO_LAYOUT_START_Y = 120;
 const AUTO_LAYOUT_MIN_BUS_HORIZONTAL_CLEARANCE = 104;
@@ -281,13 +281,45 @@ export const autoLayoutBuses = (
   const positionedBuses: Record<string, BusNode> = { ...state.busesById };
   const orderedLevels = [...busesByLevel.keys()].sort((a, b) => a - b);
   const placedPositions: Array<{ x: number; y: number }> = [];
+  const busRankById = new Map(
+    state.busOrder.map((busId, index) => [busId, index])
+  );
+
+  orderedLevels.forEach((level) => {
+    const buses = busesByLevel.get(level) ?? [];
+    buses.sort((a, b) => {
+      const neighborsA = (adjacency.get(a) ?? []).filter(
+        (neighborId) => (levelByBusId.get(neighborId) ?? 0) < level
+      );
+      const neighborsB = (adjacency.get(b) ?? []).filter(
+        (neighborId) => (levelByBusId.get(neighborId) ?? 0) < level
+      );
+      const avgA =
+        neighborsA.reduce(
+          (sum, neighborId) => sum + (busRankById.get(neighborId) ?? 0),
+          0
+        ) / (neighborsA.length || 1);
+      const avgB =
+        neighborsB.reduce(
+          (sum, neighborId) => sum + (busRankById.get(neighborId) ?? 0),
+          0
+        ) / (neighborsB.length || 1);
+      if (avgA === avgB) {
+        return (busRankById.get(a) ?? 0) - (busRankById.get(b) ?? 0);
+      }
+      return avgA - avgB;
+    });
+    busesByLevel.set(level, buses);
+  });
 
   for (const level of orderedLevels) {
     const buses = busesByLevel.get(level) ?? [];
+    const levelYOffset =
+      AUTO_LAYOUT_START_Y - ((buses.length - 1) * AUTO_LAYOUT_Y_SPACING) / 2;
     buses.forEach((busId, index) => {
       const bus = positionedBuses[busId];
       const proposedX = AUTO_LAYOUT_START_X + level * AUTO_LAYOUT_X_SPACING;
-      const proposedY = AUTO_LAYOUT_START_Y + index * AUTO_LAYOUT_Y_SPACING;
+      const proposedY = levelYOffset + index * AUTO_LAYOUT_Y_SPACING;
       const { x, y } = resolveNonOverlappingPosition(
         proposedX,
         proposedY,
@@ -300,6 +332,7 @@ export const autoLayoutBuses = (
         y,
       };
       placedPositions.push({ x, y });
+      busRankById.set(busId, index);
     });
   }
 


### PR DESCRIPTION
### Motivation
- Fix overlapping buses and missing line-hop affordance in the Single-Line Diagram (SLD) by improving routing and layout so dense topologies remain readable and the line-hop visual cue is visible.

### Description
- Refactored branch routing to produce a reusable `RoutedBranch` shape (ordered `points` + derived `segments`) and switched SLD rendering to use that single geometry source; changed `SingleLineDiagram.tsx` accordingly.
- Rendered line-hop markers in a dedicated overlay pass after drawing branch polylines so hop arcs are not painted over by later strokes; retained the same hop-detection logic but moved rendering out-of-band in `SingleLineDiagram.tsx`.
- Improved the auto-layout algorithm in `loadFlowStore.ts` by increasing vertical spacing, barycentrically sorting buses within each level by parent/neighbor ranks to reduce crossings, and vertically centering each level before collision resolution.
- Misc: small formatting/type fixes to satisfy lint/typecheck and keep generated `points`/`segments` consistent with existing tests; changes touch `src/app/load-flow/_components/SingleLineDiagram.tsx` and `src/features/load-flow/state/loadFlowStore.ts`.

### Testing
- Ran `yarn lint` and formatting checks which passed after fixes.
- Ran `yarn typecheck` which passed with no TypeScript errors after the changes.
- Ran unit tests with `yarn test` where all Jest suites passed (`38` suites, `156` tests passed).
- Built the site with `yarn build` which initially exposed a TS issue that was fixed and the final build succeeded.
- Ran E2E smoke tests using the host fallback because Docker was unavailable; `yarn test:e2e:host` passed (24 tests passed) after the Docker run reported `command not found: docker`.
- Ran visual E2E via `yarn test:e2e:visual:host` which encountered a transient apt mirror error on the first attempt but succeeded on retry (visual suites passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d134c64cc08323afb60f5030dc0795)