### PR TITLE
Fix mobile overlay gap when browser chrome collapses

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,7 +29,8 @@
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: 100vh;
+    height: 100dvh;
     background: rgba(255, 255, 255, 0.85);
     z-index: -1;
     pointer-events: none;


### PR DESCRIPTION
### Motivation
- On some mobile browsers the bottom UI chrome collapses while scrolling, exposing a gap because the overlay used `height: 100%`; switching to viewport-relative sizing keeps the shade covering the visible viewport.

### Description
- Update `.bg-overlay::before` to use a viewport-based fallback chain, replacing `height: 100%` with `height: 100vh; height: 100dvh;` in `src/app/globals.css` so the overlay covers the dynamic viewport height.

### Testing
- Ran `corepack install && yarn --version`, `yarn lint`, `yarn typecheck`, `yarn test`, and `yarn build`, all of which passed. 
- Ran `yarn test:e2e` which could not run due to `docker` being unavailable in this environment, and ran `yarn test:e2e:host` and `yarn test:e2e:visual:host`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1357016ac832384d2e479f694b721)