### PR TITLE
Show bus voltages/angles and branch power flows on SLD

### DIFF
--- a/src/app/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/load-flow/_components/LoadFlowWorkspace.tsx
@@ -71,6 +71,26 @@ export function LoadFlowWorkspace() {
     () => runLoadFlow(serializedCase),
     [serializedCase]
   );
+  const busSolutionsById = useMemo(
+    () =>
+      new Map(
+        (solveResult.buses ?? []).map((busSolution) => [
+          busSolution.busId,
+          busSolution,
+        ])
+      ),
+    [solveResult.buses]
+  );
+  const branchFlowsById = useMemo(
+    () =>
+      new Map(
+        (solveResult.branchFlows ?? []).map((branchFlow) => [
+          branchFlow.branchId,
+          branchFlow,
+        ])
+      ),
+    [solveResult.branchFlows]
+  );
 
   const resetActiveReferenceCase = () => {
     if (!selectedReferenceScenario) {
@@ -188,6 +208,8 @@ export function LoadFlowWorkspace() {
           onBranchSelect={(branchId) =>
             setEditorState((prev) => selectElement(prev, "BRANCH", branchId))
           }
+          busSolutionsById={busSolutionsById}
+          branchFlowsById={branchFlowsById}
         />
       </div>
 

--- a/src/app/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/load-flow/_components/SingleLineDiagram.tsx
@@ -1,5 +1,9 @@
 import { PointerEvent, useMemo, useRef, useState, WheelEvent } from "react";
 
+import {
+  BranchFlowSolution,
+  BusSolution,
+} from "@/features/load-flow/solver/types";
 import { BusNode, LineEdge } from "@/features/load-flow/state/loadFlowStore";
 
 interface SingleLineDiagramProps {
@@ -10,10 +14,12 @@ interface SingleLineDiagramProps {
   onBusSelect: (busId: string) => void;
   onBusMove: (busId: string, x: number, y: number) => void;
   onBranchSelect: (branchId: string) => void;
+  busSolutionsById?: Map<string, BusSolution>;
+  branchFlowsById?: Map<string, BranchFlowSolution>;
 }
 
 const BUS_WIDTH = 88;
-const BUS_HEIGHT = 42;
+const BUS_HEIGHT = 66;
 const BUS_HALF_WIDTH = BUS_WIDTH / 2;
 const BUS_HALF_HEIGHT = BUS_HEIGHT / 2;
 const DIAGRAM_PADDING = 48;
@@ -120,6 +126,8 @@ export function SingleLineDiagram({
   onBusSelect,
   onBusMove,
   onBranchSelect,
+  busSolutionsById,
+  branchFlowsById,
 }: SingleLineDiagramProps) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const draggingBusIdRef = useRef<string | null>(null);
@@ -348,6 +356,18 @@ export function SingleLineDiagram({
               const isSelected =
                 selectedElementType === "BRANCH" &&
                 selectedElementId === branch.id;
+              const branchFlow = branchFlowsById?.get(branch.id);
+              const activePowerFromTo = branchFlow?.pFromToMW;
+              const flowDirectionSymbol =
+                activePowerFromTo === undefined
+                  ? null
+                  : activePowerFromTo >= 0
+                    ? "→"
+                    : "←";
+              const flowMagnitudeMW =
+                activePowerFromTo === undefined
+                  ? null
+                  : Math.abs(activePowerFromTo).toFixed(2);
 
               return (
                 <g key={branch.id}>
@@ -367,6 +387,16 @@ export function SingleLineDiagram({
                   >
                     {branch.id}
                   </text>
+                  {flowMagnitudeMW ? (
+                    <text
+                      x={elbowPoint?.x ?? fallbackLabelPoint?.x ?? 0}
+                      y={(elbowPoint?.y ?? fallbackLabelPoint?.y ?? 0) + 4}
+                      textAnchor="middle"
+                      className="fill-emerald-200 text-[10px]"
+                    >
+                      {flowDirectionSymbol} {flowMagnitudeMW} MW
+                    </text>
+                  ) : null}
                 </g>
               );
             })}
@@ -397,6 +427,13 @@ export function SingleLineDiagram({
             {buses.map((bus) => {
               const isSelected =
                 selectedElementType === "BUS" && selectedElementId === bus.id;
+              const busSolution = busSolutionsById?.get(bus.id);
+              const voltageSummary = busSolution
+                ? `${busSolution.voltageMagnitudePu.toFixed(3)} pu`
+                : "— pu";
+              const angleSummary = busSolution
+                ? `${busSolution.voltageAngleDeg.toFixed(2)}°`
+                : "—°";
 
               return (
                 <g
@@ -432,6 +469,22 @@ export function SingleLineDiagram({
                     className="fill-slate-300 text-[10px]"
                   >
                     {bus.type}
+                  </text>
+                  <text
+                    x={BUS_HALF_WIDTH}
+                    y={47}
+                    textAnchor="middle"
+                    className="fill-emerald-100 text-[10px]"
+                  >
+                    V: {voltageSummary}
+                  </text>
+                  <text
+                    x={BUS_HALF_WIDTH}
+                    y={60}
+                    textAnchor="middle"
+                    className="fill-emerald-100 text-[10px]"
+                  >
+                    θ: {angleSummary}
                   </text>
                 </g>
               );


### PR DESCRIPTION
### Motivation
- Make the single-line diagram (SLD) surface solved load-flow results so users can inspect bus voltages/angles and branch power flows directly in the diagram.
- Provide compact, at-a-glance numeric overlays on buses and lines to aid debugging and exploration of solved cases.

### Description
- Wire solver outputs into the SLD by adding `busSolutionsById` and `branchFlowsById` props and mapping `solveResult.buses`/`solveResult.branchFlows` into `Map` instances in `LoadFlowWorkspace`.
- Render per-bus solved voltage magnitude (`V`) and voltage angle (`θ`) text inside each bus glyph and show `—` placeholders when results are absent in `SingleLineDiagram`.
- Render per-branch active-power annotation taken from `pFromToMW` with a direction arrow (`→` for positive, `←` for negative) and MW magnitude on each branch in `SingleLineDiagram`.
- Increase bus glyph height to make room for the new two-line solved-state overlays and import the solver types (`BusSolution`, `BranchFlowSolution`).

### Testing
- Ran `yarn install` successfully to set up dependencies. 
- Ran `yarn lint` and formatting checks which succeeded. 
- Ran `yarn typecheck` and `yarn test` (Jest) with all suites passing. 
- Ran `yarn build` which completed successfully, and ran Playwright smoke and visual suites via host-mode: `yarn test:e2e:host` and `yarn test:e2e:visual:host` both passed; Docker-based `yarn test:e2e` and `yarn test:e2e:visual` could not run in this environment because `docker` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32e850d18832391dcd35c3e3e4b0a)