### PR TITLE
[codex] Add interactive PID controller simulator

### DIFF
--- a/docs/pid-controller-simulator.md
+++ b/docs/pid-controller-simulator.md
@@ -1,0 +1,58 @@
+# PID Controller Simulator Architecture
+
+This simulator is implemented as a client-only feature for static export compatibility.
+
+## Module layout
+
+- `src/features/pid-simulator/types.ts` defines plant, controller, runtime, and preset contracts.
+- `src/features/pid-simulator/pidController.ts` implements PID math and state (`integralState`, `previousError`).
+- `src/features/pid-simulator/firstOrderPlant.ts` provides a first-order plant model.
+- `src/features/pid-simulator/simulationEngine.ts` manages deterministic fixed-step simulation and behavior metrics.
+- `src/features/pid-simulator/presets.ts` provides educational tuning presets matched to the current plant and actuator limits.
+- `src/app/pid-controller/_components/*` contains UI composition, chart rendering, and controls.
+
+## Mathematical model
+
+### Plant
+
+The simulator uses a first-order process:
+
+`dy/dt = (-y + K·u) / τ`
+
+- `y`: process variable
+- `u`: controller output
+- `K`: plant gain
+- `τ`: time constant
+
+Integration is explicit Euler with fixed timestep `dt = 1/60 s`.
+
+### PID controller
+
+The controller output is:
+
+`u(t) = Kp·e(t) + Ki·∫e(t)dt + Kd·de(t)/dt`
+
+where `e(t) = setpoint - processVariable`.
+
+Implementation details:
+
+- Integral state is accumulated and clamped to reduce windup.
+- Output is clamped to configured actuator limits.
+- Derivative term uses discrete error slope `(e[k] - e[k-1]) / dt`.
+
+## Numerical update approach
+
+Rendering uses `requestAnimationFrame`, but simulation stepping is deterministic:
+
+1. Accumulate elapsed wall-clock time scaled by user speed.
+2. Step the engine with constant `dt` while `accumulator >= dt`.
+3. Append samples until a configurable max simulation time is reached, then pause.
+4. Reset the sampled response when gains or setpoint change so the new step response fills the chart again.
+
+This keeps simulation behavior stable across frame rate differences.
+
+## Extension points
+
+- Additional plants can implement the `PlantModel` contract.
+- Alternate controllers can reuse `simulationEngine.ts` with the same stepping interface.
+- Preset definitions are data-only and can be expanded without UI rewrites.

--- a/src/app/__tests__/sitemap.test.ts
+++ b/src/app/__tests__/sitemap.test.ts
@@ -30,7 +30,11 @@ describe("sitemap", () => {
     const blogPostEntry = entries.find(
       (entry) => entry.url === "https://alexleung.ca/blog/my-post/"
     );
+    const pidControllerEntry = entries.find(
+      (entry) => entry.url === "https://alexleung.ca/pid-controller/"
+    );
 
     expect(blogPostEntry).toBeDefined();
+    expect(pidControllerEntry).toBeUndefined();
   });
 });

--- a/src/app/pid-controller/__tests__/page.test.tsx
+++ b/src/app/pid-controller/__tests__/page.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+
+import PidControllerPage from "../page";
+
+describe("PidControllerPage", () => {
+  it("renders the PID simulator page shell", () => {
+    render(<PidControllerPage />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "PID Controller" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "PID Controller Simulator",
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/u\(t\) = kp·e\(t\)/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/changing gains or setpoint restarts the run/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/pid-controller/_components/PidChart.tsx
+++ b/src/app/pid-controller/_components/PidChart.tsx
@@ -1,0 +1,195 @@
+import { SimulationSample } from "@/features/pid-simulator/types";
+
+type PidChartProps = {
+  samples: SimulationSample[];
+};
+
+type LegendItem = {
+  label: string;
+  stroke: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+  value: number;
+};
+
+const WIDTH = 880;
+const HEIGHT = 320;
+const MARGIN = { top: 20, right: 20, bottom: 30, left: 48 };
+const LEGEND_SWATCH_WIDTH = 28;
+const LEGEND_SWATCH_HEIGHT = 10;
+
+const toPath = (
+  samples: SimulationSample[],
+  readValue: (sample: SimulationSample) => number,
+  scaleX: (value: number) => number,
+  scaleY: (value: number) => number
+): string =>
+  samples
+    .map((sample, index) => {
+      const prefix = index === 0 ? "M" : "L";
+      return `${prefix}${scaleX(sample.timeSeconds)} ${scaleY(readValue(sample))}`;
+    })
+    .join(" ");
+
+export function PidChart({ samples }: PidChartProps) {
+  if (samples.length < 2) {
+    return (
+      <figure className="rounded-lg border border-gray-700 bg-black/40 p-3">
+        <figcaption
+          className="text-body-sm mb-3 text-gray-200"
+          role="img"
+          aria-label="PID simulator response chart"
+        >
+          Response over time (collecting samples...)
+        </figcaption>
+      </figure>
+    );
+  }
+
+  const minX = samples[0].timeSeconds;
+  const maxX = samples.at(-1)?.timeSeconds ?? minX + 1;
+
+  const values = samples.flatMap((sample) => [
+    sample.setpoint,
+    sample.processVariable,
+    sample.controllerOutput,
+    sample.error,
+  ]);
+  const minY = Math.min(...values);
+  const maxY = Math.max(...values);
+  const yPadding = Math.max((maxY - minY) * 0.1, 0.2);
+
+  const xSpan = Math.max(maxX - minX, 1);
+  const ySpan = Math.max(maxY - minY, 0.1) + yPadding * 2;
+
+  const chartWidth = WIDTH - MARGIN.left - MARGIN.right;
+  const chartHeight = HEIGHT - MARGIN.top - MARGIN.bottom;
+
+  const scaleX = (value: number): number =>
+    MARGIN.left + ((value - minX) / xSpan) * chartWidth;
+  const scaleY = (value: number): number =>
+    MARGIN.top + ((maxY + yPadding - value) / ySpan) * chartHeight;
+
+  const setpointPath = toPath(
+    samples,
+    (sample) => sample.setpoint,
+    scaleX,
+    scaleY
+  );
+  const pvPath = toPath(
+    samples,
+    (sample) => sample.processVariable,
+    scaleX,
+    scaleY
+  );
+  const outputPath = toPath(
+    samples,
+    (sample) => sample.controllerOutput,
+    scaleX,
+    scaleY
+  );
+  const errorPath = toPath(samples, (sample) => sample.error, scaleX, scaleY);
+  const latestSample = samples.at(-1) ?? samples[0];
+  const legendItems: readonly LegendItem[] = [
+    {
+      label: "Setpoint",
+      stroke: "#f59e0b",
+      strokeWidth: 2,
+      value: latestSample.setpoint,
+    },
+    {
+      label: "Process variable",
+      stroke: "#22d3ee",
+      strokeWidth: 2,
+      value: latestSample.processVariable,
+    },
+    {
+      label: "Controller output",
+      stroke: "#a78bfa",
+      strokeWidth: 2,
+      value: latestSample.controllerOutput,
+    },
+    {
+      label: "Error",
+      stroke: "#fb7185",
+      strokeWidth: 1.5,
+      strokeDasharray: "5 3",
+      value: latestSample.error,
+    },
+  ] as const;
+
+  return (
+    <figure className="rounded-lg border border-gray-700 bg-black/40 p-3">
+      <figcaption className="text-body-sm mb-3 text-gray-200">
+        Response over time (fixed-step simulation)
+      </figcaption>
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        className="h-auto w-full"
+        role="img"
+        aria-label="PID simulator response chart"
+      >
+        <line
+          x1={MARGIN.left}
+          y1={MARGIN.top + chartHeight}
+          x2={MARGIN.left + chartWidth}
+          y2={MARGIN.top + chartHeight}
+          stroke="#4b5563"
+          strokeWidth={1}
+        />
+        <line
+          x1={MARGIN.left}
+          y1={MARGIN.top}
+          x2={MARGIN.left}
+          y2={MARGIN.top + chartHeight}
+          stroke="#4b5563"
+          strokeWidth={1}
+        />
+
+        <path d={setpointPath} stroke="#f59e0b" strokeWidth={2} fill="none" />
+        <path d={pvPath} stroke="#22d3ee" strokeWidth={2} fill="none" />
+        <path d={outputPath} stroke="#a78bfa" strokeWidth={2} fill="none" />
+        <path
+          d={errorPath}
+          stroke="#fb7185"
+          strokeWidth={1.5}
+          strokeDasharray="5 3"
+          fill="none"
+        />
+      </svg>
+      <div className="mt-3 grid gap-2 text-gray-300 sm:grid-cols-2 xl:grid-cols-4">
+        {legendItems.map((item) => (
+          <div
+            key={item.label}
+            className="flex items-center justify-between gap-3 rounded-md border border-gray-800 bg-gray-950/60 px-3 py-2"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <svg
+                width={LEGEND_SWATCH_WIDTH}
+                height={LEGEND_SWATCH_HEIGHT}
+                viewBox={`0 0 ${LEGEND_SWATCH_WIDTH} ${LEGEND_SWATCH_HEIGHT}`}
+                aria-hidden="true"
+                className="shrink-0"
+              >
+                <line
+                  x1={1}
+                  y1={LEGEND_SWATCH_HEIGHT / 2}
+                  x2={LEGEND_SWATCH_WIDTH - 1}
+                  y2={LEGEND_SWATCH_HEIGHT / 2}
+                  stroke={item.stroke}
+                  strokeWidth={item.strokeWidth}
+                  strokeDasharray={item.strokeDasharray}
+                  strokeLinecap="round"
+                />
+              </svg>
+              <span className="text-body-sm truncate">{item.label}</span>
+            </div>
+            <span className="text-body-sm shrink-0 font-mono text-gray-100">
+              {item.value.toFixed(2)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </figure>
+  );
+}

--- a/src/app/pid-controller/_components/PidControls.tsx
+++ b/src/app/pid-controller/_components/PidControls.tsx
@@ -1,0 +1,196 @@
+import { ChangeEvent } from "react";
+
+import { SimulatorPreset } from "@/features/pid-simulator/types";
+
+type PidControlsProps = {
+  kp: number;
+  ki: number;
+  kd: number;
+  setpoint: number;
+  simulationSpeed: number;
+  maxTimeSeconds: number;
+  activePresetId: string;
+  presets: readonly SimulatorPreset[];
+  isRunning: boolean;
+  hasReachedMaxTime: boolean;
+  onPresetChange: (presetId: string) => void;
+  onKpChange: (value: number) => void;
+  onKiChange: (value: number) => void;
+  onKdChange: (value: number) => void;
+  onSetpointChange: (value: number) => void;
+  onSimulationSpeedChange: (value: number) => void;
+  onMaxTimeChange: (value: number) => void;
+  onToggleRunning: () => void;
+  onReset: () => void;
+};
+
+const handleNumericChange = (
+  event: ChangeEvent<HTMLInputElement>,
+  onChange: (value: number) => void
+) => {
+  const value = Number.parseFloat(event.target.value);
+  if (Number.isFinite(value)) {
+    onChange(value);
+  }
+};
+
+const SliderRow = ({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}) => (
+  <div className="space-y-1">
+    <label
+      htmlFor={id}
+      className="text-body-sm flex justify-between text-gray-200"
+    >
+      <span>{label}</span>
+      <span>{value.toFixed(2)}</span>
+    </label>
+    <input
+      id={id}
+      type="range"
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      className="w-full"
+      aria-label={label}
+      onChange={(event) => handleNumericChange(event, onChange)}
+    />
+  </div>
+);
+
+export function PidControls({
+  kp,
+  ki,
+  kd,
+  setpoint,
+  simulationSpeed,
+  maxTimeSeconds,
+  activePresetId,
+  presets,
+  isRunning,
+  hasReachedMaxTime,
+  onPresetChange,
+  onKpChange,
+  onKiChange,
+  onKdChange,
+  onSetpointChange,
+  onSimulationSpeedChange,
+  onMaxTimeChange,
+  onToggleRunning,
+  onReset,
+}: PidControlsProps) {
+  return (
+    <section className="space-y-4 rounded-lg border border-gray-700 bg-black/40 p-4">
+      <div>
+        <label htmlFor="pid-preset" className="text-body-sm text-gray-200">
+          Preset response
+        </label>
+        <select
+          id="pid-preset"
+          className="text-body mt-1 w-full rounded-md border border-gray-600 bg-gray-900 p-2 text-gray-100"
+          value={activePresetId}
+          onChange={(event) => onPresetChange(event.target.value)}
+        >
+          {presets.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.name}
+            </option>
+          ))}
+        </select>
+        <p className="text-body-sm mt-2 text-gray-400">
+          {presets.find((preset) => preset.id === activePresetId)?.description}
+        </p>
+      </div>
+
+      <SliderRow
+        id="pid-kp"
+        label="Kp"
+        value={kp}
+        min={0}
+        max={6}
+        step={0.05}
+        onChange={onKpChange}
+      />
+      <SliderRow
+        id="pid-ki"
+        label="Ki"
+        value={ki}
+        min={0}
+        max={3}
+        step={0.05}
+        onChange={onKiChange}
+      />
+      <SliderRow
+        id="pid-kd"
+        label="Kd"
+        value={kd}
+        min={0}
+        max={3}
+        step={0.05}
+        onChange={onKdChange}
+      />
+      <SliderRow
+        id="pid-setpoint"
+        label="Setpoint"
+        value={setpoint}
+        min={0.2}
+        max={2}
+        step={0.05}
+        onChange={onSetpointChange}
+      />
+      <SliderRow
+        id="pid-speed"
+        label="Simulation speed"
+        value={simulationSpeed}
+        min={0.25}
+        max={4}
+        step={0.25}
+        onChange={onSimulationSpeedChange}
+      />
+      <SliderRow
+        id="pid-max-time"
+        label="Max time (s)"
+        value={maxTimeSeconds}
+        min={5}
+        max={60}
+        step={1}
+        onChange={onMaxTimeChange}
+      />
+      <p className="text-body-sm text-gray-400">
+        The run stops automatically at the selected max time.
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded-md border border-emerald-500 px-3 py-2 text-sm text-emerald-100 hover:bg-emerald-900/50"
+          onClick={onToggleRunning}
+        >
+          {isRunning ? "Pause" : hasReachedMaxTime ? "Replay" : "Play"}
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-gray-500 px-3 py-2 text-sm text-gray-100 hover:bg-gray-800"
+          onClick={onReset}
+        >
+          Reset simulation
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/pid-controller/_components/PidSimulatorWorkspace.tsx
+++ b/src/app/pid-controller/_components/PidSimulatorWorkspace.tsx
@@ -272,19 +272,16 @@ export function PidSimulatorWorkspace() {
           }}
           onKpChange={(value) =>
             applySimulationParameters({
-              nextPresetId: "well-tuned",
               nextKp: value,
             })
           }
           onKiChange={(value) =>
             applySimulationParameters({
-              nextPresetId: "well-tuned",
               nextKi: value,
             })
           }
           onKdChange={(value) =>
             applySimulationParameters({
-              nextPresetId: "well-tuned",
               nextKd: value,
             })
           }

--- a/src/app/pid-controller/_components/PidSimulatorWorkspace.tsx
+++ b/src/app/pid-controller/_components/PidSimulatorWorkspace.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { PidChart } from "@/app/pid-controller/_components/PidChart";
+import { PidControls } from "@/app/pid-controller/_components/PidControls";
+import { createFirstOrderPlant } from "@/features/pid-simulator/firstOrderPlant";
+import { PidController } from "@/features/pid-simulator/pidController";
+import {
+  getPresetById,
+  PID_SIMULATOR_PRESETS,
+} from "@/features/pid-simulator/presets";
+import {
+  computeControlBehaviorMetrics,
+  createInitialSimulationState,
+  stepSimulation,
+} from "@/features/pid-simulator/simulationEngine";
+import {
+  PidControllerConfig,
+  SimulationSample,
+  SimulatorPresetId,
+} from "@/features/pid-simulator/types";
+import { roundTo } from "@/features/pid-simulator/utils";
+
+const FIXED_DT_SECONDS = 1 / 60;
+const MAX_ELAPSED_SECONDS = 0.25;
+const MAX_CATCH_UP_STEPS_PER_FRAME = 12;
+const DEFAULT_MAX_TIME_SECONDS = 20;
+const TIME_EPSILON = FIXED_DT_SECONDS / 2;
+
+const firstPreset = PID_SIMULATOR_PRESETS[0];
+
+const buildControllerConfig = (
+  kp: number,
+  ki: number,
+  kd: number
+): PidControllerConfig => ({
+  gains: { kp, ki, kd },
+  outputMin: -2,
+  outputMax: 2,
+  integralMin: -4,
+  integralMax: 4,
+});
+
+export function PidSimulatorWorkspace() {
+  const plant = useMemo(
+    () =>
+      createFirstOrderPlant({
+        gain: 1,
+        timeConstantSeconds: 1.1,
+        initialOutput: 0,
+      }),
+    []
+  );
+
+  const [presetId, setPresetId] = useState<SimulatorPresetId>(firstPreset.id);
+  const [kp, setKp] = useState(firstPreset.gains.kp);
+  const [ki, setKi] = useState(firstPreset.gains.ki);
+  const [kd, setKd] = useState(firstPreset.gains.kd);
+  const [setpoint, setSetpoint] = useState(firstPreset.setpoint);
+  const [simulationSpeed, setSimulationSpeed] = useState(1);
+  const [maxTimeSeconds, setMaxTimeSeconds] = useState(
+    DEFAULT_MAX_TIME_SECONDS
+  );
+  const [isRunning, setIsRunning] = useState(true);
+
+  const controllerRef = useRef(
+    new PidController(buildControllerConfig(kp, ki, kd))
+  );
+  const [simulationState, setSimulationState] = useState(() =>
+    createInitialSimulationState(plant, {
+      setpoint,
+      timeStepSeconds: FIXED_DT_SECONDS,
+      maxTimeSeconds,
+    })
+  );
+  const simulationStateRef = useRef(simulationState);
+  const metricSamplesRef = useRef<SimulationSample[]>(simulationState.samples);
+
+  useEffect(() => {
+    controllerRef.current.setConfig(buildControllerConfig(kp, ki, kd));
+  }, [kp, ki, kd]);
+
+  const initializeSimulation = (
+    nextSetpoint: number,
+    nextMaxTimeSeconds: number,
+    nextIsRunning = isRunning
+  ) => {
+    controllerRef.current.reset();
+    const resetState = createInitialSimulationState(plant, {
+      setpoint: nextSetpoint,
+      timeStepSeconds: FIXED_DT_SECONDS,
+      maxTimeSeconds: nextMaxTimeSeconds,
+    });
+
+    simulationStateRef.current = resetState;
+    metricSamplesRef.current = resetState.samples;
+    setSimulationState(resetState);
+    setIsRunning(nextIsRunning);
+  };
+
+  const applySimulationParameters = ({
+    nextPresetId = presetId,
+    nextKp = kp,
+    nextKi = ki,
+    nextKd = kd,
+    nextSetpoint = setpoint,
+    nextMaxTimeSeconds = maxTimeSeconds,
+    nextIsRunning = true,
+  }: {
+    nextPresetId?: SimulatorPresetId;
+    nextKp?: number;
+    nextKi?: number;
+    nextKd?: number;
+    nextSetpoint?: number;
+    nextMaxTimeSeconds?: number;
+    nextIsRunning?: boolean;
+  }) => {
+    setPresetId(nextPresetId);
+    setKp(nextKp);
+    setKi(nextKi);
+    setKd(nextKd);
+    setSetpoint(nextSetpoint);
+    setMaxTimeSeconds(nextMaxTimeSeconds);
+    controllerRef.current.setConfig(
+      buildControllerConfig(nextKp, nextKi, nextKd)
+    );
+    initializeSimulation(nextSetpoint, nextMaxTimeSeconds, nextIsRunning);
+  };
+
+  const resetSimulation = (nextIsRunning = isRunning) => {
+    controllerRef.current.setConfig(buildControllerConfig(kp, ki, kd));
+    initializeSimulation(setpoint, maxTimeSeconds, nextIsRunning);
+  };
+
+  const hasReachedMaxTime =
+    simulationState.timeSeconds >= maxTimeSeconds - TIME_EPSILON;
+
+  useEffect(() => {
+    let rafId: number;
+    let lastFrame = performance.now();
+    let accumulator = 0;
+
+    const tick = (now: number) => {
+      const elapsedSeconds = Math.min(
+        Math.max((now - lastFrame) / 1000, 0),
+        MAX_ELAPSED_SECONDS
+      );
+      lastFrame = now;
+
+      if (isRunning) {
+        accumulator += elapsedSeconds * simulationSpeed;
+
+        let stepsToRun = 0;
+        while (
+          accumulator >= FIXED_DT_SECONDS &&
+          stepsToRun < MAX_CATCH_UP_STEPS_PER_FRAME
+        ) {
+          accumulator -= FIXED_DT_SECONDS;
+          stepsToRun += 1;
+        }
+
+        accumulator = Math.min(
+          accumulator,
+          FIXED_DT_SECONDS * MAX_CATCH_UP_STEPS_PER_FRAME
+        );
+
+        if (stepsToRun > 0) {
+          let next = simulationStateRef.current;
+          const nextMetricSamples = [...metricSamplesRef.current];
+          let shouldPause = false;
+
+          for (let index = 0; index < stepsToRun; index += 1) {
+            if (next.timeSeconds >= maxTimeSeconds - TIME_EPSILON) {
+              shouldPause = true;
+              break;
+            }
+
+            next = stepSimulation(next, plant, controllerRef.current, {
+              setpoint,
+              timeStepSeconds: FIXED_DT_SECONDS,
+              maxTimeSeconds,
+            });
+
+            const latestSample = next.samples.at(-1);
+            if (latestSample) {
+              nextMetricSamples.push(latestSample);
+            }
+
+            if (next.timeSeconds >= maxTimeSeconds - TIME_EPSILON) {
+              shouldPause = true;
+              break;
+            }
+          }
+
+          simulationStateRef.current = next;
+          metricSamplesRef.current = nextMetricSamples;
+          setSimulationState(next);
+
+          if (shouldPause) {
+            setIsRunning(false);
+            accumulator = 0;
+          }
+        }
+      }
+
+      rafId = window.requestAnimationFrame(tick);
+    };
+
+    rafId = window.requestAnimationFrame(tick);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+    };
+  }, [isRunning, maxTimeSeconds, plant, setpoint, simulationSpeed]);
+
+  useEffect(() => {
+    simulationStateRef.current = simulationState;
+  }, [simulationState]);
+
+  const metrics = useMemo(
+    () => computeControlBehaviorMetrics(metricSamplesRef.current, setpoint),
+    [setpoint, simulationState.timeSeconds]
+  );
+
+  return (
+    <section className="space-y-6 rounded-xl border border-gray-700 bg-gray-900/60 p-6 shadow-sm">
+      <div>
+        <h2 className="text-heading-sm text-white">PID Controller Simulator</h2>
+        <p className="text-body mt-2 text-gray-300">
+          This model uses a first-order plant and a deterministic fixed timestep
+          of {FIXED_DT_SECONDS.toFixed(4)}s. The PID control law is u(t) =
+          Kp·e(t) + Ki·∫e(t)dt + Kd·de(t)/dt.
+        </p>
+        <p className="text-body-sm mt-2 text-gray-400">
+          Timeline: {roundTo(simulationState.timeSeconds, 2)}s /{" "}
+          {maxTimeSeconds.toFixed(0)}s
+        </p>
+        <p className="text-body-sm mt-2 text-gray-400">
+          Changing gains or setpoint restarts the run so the full step response
+          stays in view.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+        <PidChart samples={simulationState.samples} />
+
+        <PidControls
+          kp={kp}
+          ki={ki}
+          kd={kd}
+          setpoint={setpoint}
+          simulationSpeed={simulationSpeed}
+          maxTimeSeconds={maxTimeSeconds}
+          activePresetId={presetId}
+          presets={PID_SIMULATOR_PRESETS}
+          isRunning={isRunning}
+          hasReachedMaxTime={hasReachedMaxTime}
+          onPresetChange={(nextPresetId) => {
+            const preset = getPresetById(nextPresetId);
+            if (!preset) {
+              return;
+            }
+
+            applySimulationParameters({
+              nextPresetId: preset.id,
+              nextKp: preset.gains.kp,
+              nextKi: preset.gains.ki,
+              nextKd: preset.gains.kd,
+              nextSetpoint: preset.setpoint,
+            });
+          }}
+          onKpChange={(value) =>
+            applySimulationParameters({
+              nextPresetId: "well-tuned",
+              nextKp: value,
+            })
+          }
+          onKiChange={(value) =>
+            applySimulationParameters({
+              nextPresetId: "well-tuned",
+              nextKi: value,
+            })
+          }
+          onKdChange={(value) =>
+            applySimulationParameters({
+              nextPresetId: "well-tuned",
+              nextKd: value,
+            })
+          }
+          onSetpointChange={(value) =>
+            applySimulationParameters({
+              nextSetpoint: value,
+            })
+          }
+          onSimulationSpeedChange={setSimulationSpeed}
+          onMaxTimeChange={(value) =>
+            applySimulationParameters({
+              nextMaxTimeSeconds: value,
+            })
+          }
+          onToggleRunning={() => {
+            if (hasReachedMaxTime) {
+              resetSimulation(true);
+              return;
+            }
+
+            setIsRunning((current) => !current);
+          }}
+          onReset={resetSimulation}
+        />
+      </div>
+
+      <section className="grid gap-3 rounded-lg border border-gray-700 bg-black/40 p-4 text-sm md:grid-cols-2 xl:grid-cols-4">
+        <div>
+          <p className="text-gray-400">Rise time (10%→90%)</p>
+          <p className="text-lg text-white">
+            {metrics.riseTimeSeconds === null
+              ? "—"
+              : `${roundTo(metrics.riseTimeSeconds, 2)} s`}
+          </p>
+        </div>
+        <div>
+          <p className="text-gray-400">Settling time (±2%)</p>
+          <p className="text-lg text-white">
+            {metrics.settlingTimeSeconds === null
+              ? "—"
+              : `${roundTo(metrics.settlingTimeSeconds, 2)} s`}
+          </p>
+        </div>
+        <div>
+          <p className="text-gray-400">Overshoot</p>
+          <p className="text-lg text-white">
+            {metrics.overshootPercent === null
+              ? "—"
+              : `${roundTo(Math.max(metrics.overshootPercent, 0), 1)} %`}
+          </p>
+        </div>
+        <div>
+          <p className="text-gray-400">Steady-state error</p>
+          <p className="text-lg text-white">
+            {roundTo(metrics.steadyStateError, 3)}
+          </p>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/src/app/pid-controller/_components/__tests__/PidChart.test.tsx
+++ b/src/app/pid-controller/_components/__tests__/PidChart.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+
+import { PidChart } from "../PidChart";
+
+describe("PidChart", () => {
+  it("renders a styled legend with latest series values", () => {
+    render(
+      <PidChart
+        samples={[
+          {
+            timeSeconds: 0,
+            setpoint: 1,
+            processVariable: 0,
+            controllerOutput: 0,
+            error: 1,
+          },
+          {
+            timeSeconds: 1,
+            setpoint: 1,
+            processVariable: 0.82,
+            controllerOutput: 0.37,
+            error: 0.18,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Setpoint")).toBeInTheDocument();
+    expect(screen.getByText("Process variable")).toBeInTheDocument();
+    expect(screen.getByText("Controller output")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+
+    expect(screen.getAllByText("1.00")).toHaveLength(1);
+    expect(screen.getByText("0.82")).toBeInTheDocument();
+    expect(screen.getByText("0.37")).toBeInTheDocument();
+    expect(screen.getByText("0.18")).toBeInTheDocument();
+  });
+});

--- a/src/app/pid-controller/_components/__tests__/PidSimulatorWorkspace.test.tsx
+++ b/src/app/pid-controller/_components/__tests__/PidSimulatorWorkspace.test.tsx
@@ -36,6 +36,21 @@ describe("PidSimulatorWorkspace", () => {
     expect(screen.getByLabelText("Kd")).toHaveValue("2");
   });
 
+  it("keeps the selected preset label when tuning gains", () => {
+    render(<PidSimulatorWorkspace />);
+
+    fireEvent.change(screen.getByLabelText(/preset response/i), {
+      target: { value: "oscillatory" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Kp$/i), {
+      target: { value: "0.8" },
+    });
+
+    expect(screen.getByLabelText(/preset response/i)).toHaveValue(
+      "oscillatory"
+    );
+  });
+
   it("restarts the run when tuning changes", () => {
     render(<PidSimulatorWorkspace />);
 

--- a/src/app/pid-controller/_components/__tests__/PidSimulatorWorkspace.test.tsx
+++ b/src/app/pid-controller/_components/__tests__/PidSimulatorWorkspace.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { PidSimulatorWorkspace } from "../PidSimulatorWorkspace";
+
+describe("PidSimulatorWorkspace", () => {
+  it("renders controls and chart", () => {
+    render(<PidSimulatorWorkspace />);
+
+    expect(
+      screen.getByRole("img", { name: /pid simulator response chart/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/preset response/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Kp$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/max time \(s\)/i)).toHaveValue("20");
+    expect(screen.getByRole("button", { name: /pause/i })).toBeInTheDocument();
+  });
+
+  it("toggles run state and resets simulation", () => {
+    render(<PidSimulatorWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: /pause/i }));
+    expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /reset simulation/i }));
+    expect(screen.getByText(/steady-state error/i)).toBeInTheDocument();
+  });
+
+  it("applies selected preset values", () => {
+    render(<PidSimulatorWorkspace />);
+
+    fireEvent.change(screen.getByLabelText(/preset response/i), {
+      target: { value: "oscillatory" },
+    });
+
+    expect(screen.getByLabelText("Ki")).toHaveValue("1");
+    expect(screen.getByLabelText("Kd")).toHaveValue("2");
+  });
+
+  it("restarts the run when tuning changes", () => {
+    render(<PidSimulatorWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: /pause/i }));
+    expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/^Kp$/i), {
+      target: { value: "2.8" },
+    });
+
+    expect(screen.getByRole("button", { name: /pause/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/full step response stays in view/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/pid-controller/page.tsx
+++ b/src/app/pid-controller/page.tsx
@@ -1,0 +1,49 @@
+import { JsonLd } from "react-schemaorg";
+
+import { Metadata } from "next";
+
+import { WebPage } from "schema-dts";
+
+import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
+import { PageShell } from "@/components/PageShell";
+import { ResponsiveContainer } from "@/components/ResponsiveContainer";
+import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
+
+import { PidSimulatorWorkspace } from "./_components/PidSimulatorWorkspace";
+
+const title = "PID Controller Simulator | Alex Leung";
+const description =
+  "Interactive fixed-step PID simulation that demonstrates rise time, overshoot, oscillation, and settling behavior.";
+const path = "/pid-controller/";
+
+export const metadata: Metadata = buildPageMetadata({
+  title,
+  description,
+  path,
+});
+
+export default function PidControllerPage() {
+  return (
+    <>
+      <JsonLdBreadcrumbs
+        items={[
+          { name: "Home", item: "/" },
+          { name: "PID Controller", item: "/pid-controller/" },
+        ]}
+      />
+      <JsonLd<WebPage>
+        item={buildWebPageSchema({
+          path,
+          title,
+          description,
+        })}
+      />
+
+      <PageShell title="PID Controller" titleId="pid-controller">
+        <ResponsiveContainer element="section" className="space-y-6">
+          <PidSimulatorWorkspace />
+        </ResponsiveContainer>
+      </PageShell>
+    </>
+  );
+}

--- a/src/features/pid-simulator/__tests__/pidController.test.ts
+++ b/src/features/pid-simulator/__tests__/pidController.test.ts
@@ -1,0 +1,53 @@
+import { PidController } from "@/features/pid-simulator/pidController";
+
+const createController = (kp: number, ki: number, kd: number) =>
+  new PidController({
+    gains: { kp, ki, kd },
+    outputMin: -10,
+    outputMax: 10,
+    integralMin: -10,
+    integralMax: 10,
+  });
+
+describe("PidController", () => {
+  it("applies proportional term", () => {
+    const controller = createController(2, 0, 0);
+
+    const result = controller.step(1, 0.2, 0.1);
+
+    expect(result.terms.proportional).toBeCloseTo(1.6, 6);
+    expect(result.output).toBeCloseTo(1.6, 6);
+  });
+
+  it("accumulates integral term across steps", () => {
+    const controller = createController(0, 3, 0);
+
+    const first = controller.step(1, 0, 0.5);
+    const second = controller.step(1, 0, 0.5);
+
+    expect(first.output).toBeCloseTo(1.5, 6);
+    expect(second.output).toBeCloseTo(3, 6);
+  });
+
+  it("applies derivative action from error rate of change", () => {
+    const controller = createController(0, 0, 2);
+
+    controller.step(1, 0, 0.1);
+    const next = controller.step(1, 0.5, 0.1);
+
+    expect(next.terms.derivative).toBeCloseTo(-10, 6);
+    expect(next.output).toBeCloseTo(-10, 6);
+  });
+
+  it("combines all terms and supports reset", () => {
+    const controller = createController(1, 0.5, 0.1);
+
+    controller.step(1, 0, 0.2);
+    controller.reset();
+    const afterReset = controller.step(1, 0.5, 0.2);
+
+    expect(afterReset.terms.integral).toBeCloseTo(0.05, 6);
+    expect(afterReset.terms.derivative).toBeCloseTo(0, 6);
+    expect(afterReset.output).toBeCloseTo(0.55, 6);
+  });
+});

--- a/src/features/pid-simulator/__tests__/presets.test.ts
+++ b/src/features/pid-simulator/__tests__/presets.test.ts
@@ -1,0 +1,122 @@
+import { createFirstOrderPlant } from "@/features/pid-simulator/firstOrderPlant";
+import { PidController } from "@/features/pid-simulator/pidController";
+import {
+  getPresetById,
+  PID_SIMULATOR_PRESETS,
+} from "@/features/pid-simulator/presets";
+import {
+  computeControlBehaviorMetrics,
+  createInitialSimulationState,
+  stepSimulation,
+} from "@/features/pid-simulator/simulationEngine";
+
+describe("PID presets", () => {
+  const timeStepSeconds = 1 / 60;
+  const maxTimeSeconds = 20;
+  const plant = createFirstOrderPlant({
+    gain: 1,
+    timeConstantSeconds: 1.1,
+    initialOutput: 0,
+  });
+
+  const simulatePreset = (presetId: string) => {
+    const preset = getPresetById(presetId);
+    if (!preset) {
+      throw new Error(`Missing preset: ${presetId}`);
+    }
+
+    const controller = new PidController({
+      gains: preset.gains,
+      outputMin: -2,
+      outputMax: 2,
+      integralMin: -4,
+      integralMax: 4,
+    });
+
+    let state = createInitialSimulationState(plant, {
+      setpoint: preset.setpoint,
+      timeStepSeconds,
+      maxTimeSeconds,
+    });
+
+    for (let index = 0; index < maxTimeSeconds / timeStepSeconds; index += 1) {
+      state = stepSimulation(state, plant, controller, {
+        setpoint: preset.setpoint,
+        timeStepSeconds,
+        maxTimeSeconds,
+      });
+    }
+
+    let zeroCrossings = 0;
+    let previousError = state.samples[0].processVariable - preset.setpoint;
+
+    for (const sample of state.samples.slice(1)) {
+      const currentError = sample.processVariable - preset.setpoint;
+      if (
+        (previousError < 0 && currentError > 0) ||
+        (previousError > 0 && currentError < 0)
+      ) {
+        zeroCrossings += 1;
+      }
+      if (Math.abs(currentError) > 1e-8) {
+        previousError = currentError;
+      }
+    }
+
+    const tail = state.samples
+      .slice(-120)
+      .map((sample) => sample.processVariable);
+    const tailRange = Math.max(...tail) - Math.min(...tail);
+    const metrics = computeControlBehaviorMetrics(
+      state.samples,
+      preset.setpoint
+    );
+
+    return {
+      metrics,
+      zeroCrossings,
+      tailRange,
+      finalValue: state.samples.at(-1)?.processVariable ?? 0,
+    };
+  };
+
+  it("defines the required educational presets", () => {
+    expect(PID_SIMULATOR_PRESETS.map((preset) => preset.id)).toEqual([
+      "well-tuned",
+      "underdamped",
+      "overdamped",
+      "oscillatory",
+    ]);
+  });
+
+  it("resolves presets by id", () => {
+    const preset = getPresetById("oscillatory");
+
+    expect(preset).toBeDefined();
+    expect(preset?.gains.kd).toBe(2);
+  });
+
+  it("matches the intended response families", () => {
+    const wellTuned = simulatePreset("well-tuned");
+    const underdamped = simulatePreset("underdamped");
+    const overdamped = simulatePreset("overdamped");
+    const oscillatory = simulatePreset("oscillatory");
+
+    expect(wellTuned.metrics.overshootPercent).toBeLessThan(5);
+    expect(wellTuned.metrics.settlingTimeSeconds).not.toBeNull();
+    expect(wellTuned.metrics.settlingTimeSeconds).toBeLessThan(2);
+
+    expect(underdamped.metrics.overshootPercent).toBeGreaterThan(8);
+    expect(underdamped.zeroCrossings).toBeGreaterThanOrEqual(2);
+    expect(underdamped.metrics.settlingTimeSeconds).not.toBeNull();
+
+    expect(overdamped.zeroCrossings).toBe(0);
+    expect(overdamped.metrics.overshootPercent).toBeLessThan(0);
+    expect(overdamped.metrics.settlingTimeSeconds).toBeNull();
+    expect(overdamped.finalValue).toBeLessThan(1);
+
+    expect(oscillatory.zeroCrossings).toBeGreaterThanOrEqual(20);
+    expect(oscillatory.tailRange).toBeGreaterThan(0.04);
+    expect(oscillatory.metrics.settlingTimeSeconds).toBeNull();
+  });
+});

--- a/src/features/pid-simulator/__tests__/simulationEngine.test.ts
+++ b/src/features/pid-simulator/__tests__/simulationEngine.test.ts
@@ -1,0 +1,139 @@
+import { createFirstOrderPlant } from "@/features/pid-simulator/firstOrderPlant";
+import { PidController } from "@/features/pid-simulator/pidController";
+import {
+  computeControlBehaviorMetrics,
+  createInitialSimulationState,
+  stepSimulation,
+} from "@/features/pid-simulator/simulationEngine";
+
+describe("simulationEngine", () => {
+  const plant = createFirstOrderPlant({
+    gain: 1,
+    timeConstantSeconds: 1,
+    initialOutput: 0,
+  });
+
+  it("creates deterministic state transitions for identical inputs", () => {
+    const config = {
+      setpoint: 1,
+      timeStepSeconds: 0.1,
+      maxTimeSeconds: 10,
+    };
+
+    const run = () => {
+      const controller = new PidController({
+        gains: { kp: 2, ki: 0.6, kd: 0.1 },
+        outputMin: -10,
+        outputMax: 10,
+        integralMin: -10,
+        integralMax: 10,
+      });
+      let state = createInitialSimulationState(plant, config);
+      for (let index = 0; index < 25; index += 1) {
+        state = stepSimulation(state, plant, controller, config);
+      }
+      return state;
+    };
+
+    expect(run()).toEqual(run());
+  });
+
+  it("resets back to initial conditions", () => {
+    const config = {
+      setpoint: 1,
+      timeStepSeconds: 0.1,
+      maxTimeSeconds: 10,
+    };
+    const controller = new PidController({
+      gains: { kp: 2, ki: 0.6, kd: 0.1 },
+      outputMin: -10,
+      outputMax: 10,
+      integralMin: -10,
+      integralMax: 10,
+    });
+
+    let advanced = createInitialSimulationState(plant, config);
+    for (let index = 0; index < 10; index += 1) {
+      advanced = stepSimulation(advanced, plant, controller, config);
+    }
+
+    controller.reset();
+    const resetState = createInitialSimulationState(plant, config);
+
+    expect(advanced.timeSeconds).toBeGreaterThan(resetState.timeSeconds);
+    expect(resetState.timeSeconds).toBe(0);
+    expect(resetState.plantState.output).toBe(0);
+    expect(resetState.samples).toHaveLength(1);
+  });
+
+  it("computes control behavior metrics from samples", () => {
+    const samples = [
+      {
+        timeSeconds: 0,
+        setpoint: 1,
+        processVariable: 0,
+        controllerOutput: 0,
+        error: 1,
+      },
+      {
+        timeSeconds: 1,
+        setpoint: 1,
+        processVariable: 0.4,
+        controllerOutput: 0.6,
+        error: 0.6,
+      },
+      {
+        timeSeconds: 2,
+        setpoint: 1,
+        processVariable: 1.1,
+        controllerOutput: 0.3,
+        error: -0.1,
+      },
+      {
+        timeSeconds: 3,
+        setpoint: 1,
+        processVariable: 1.01,
+        controllerOutput: 0.2,
+        error: -0.01,
+      },
+      {
+        timeSeconds: 4,
+        setpoint: 1,
+        processVariable: 1.0,
+        controllerOutput: 0.1,
+        error: 0,
+      },
+    ];
+
+    const metrics = computeControlBehaviorMetrics(samples, 1);
+
+    expect(metrics.riseTimeSeconds).toBeCloseTo(1, 6);
+    expect(metrics.overshootPercent).toBeCloseTo(10, 6);
+    expect(metrics.settlingTimeSeconds).toBe(3);
+    expect(metrics.steadyStateError).toBeCloseTo(0, 6);
+  });
+
+  it("retains the full response history up to the configured max time", () => {
+    const config = {
+      setpoint: 1,
+      timeStepSeconds: 0.1,
+      maxTimeSeconds: 12,
+    };
+    const controller = new PidController({
+      gains: { kp: 2, ki: 0.6, kd: 0.1 },
+      outputMin: -10,
+      outputMax: 10,
+      integralMin: -10,
+      integralMax: 10,
+    });
+
+    let state = createInitialSimulationState(plant, config);
+    for (let index = 0; index < 50; index += 1) {
+      state = stepSimulation(state, plant, controller, config);
+    }
+
+    expect(state.samples[0]?.timeSeconds).toBe(0);
+    expect(state.samples).toHaveLength(51);
+    expect(state.samples.at(-1)?.timeSeconds).toBeCloseTo(5, 6);
+  });
+});

--- a/src/features/pid-simulator/__tests__/simulationEngine.test.ts
+++ b/src/features/pid-simulator/__tests__/simulationEngine.test.ts
@@ -136,4 +136,38 @@ describe("simulationEngine", () => {
     expect(state.samples).toHaveLength(51);
     expect(state.samples.at(-1)?.timeSeconds).toBeCloseTo(5, 6);
   });
+
+  it("records post-step error values in state samples", () => {
+    const config = {
+      setpoint: 1,
+      timeStepSeconds: 0.1,
+      maxTimeSeconds: 10,
+    };
+    const controller = new PidController({
+      gains: { kp: 2, ki: 0.6, kd: 0.1 },
+      outputMin: -10,
+      outputMax: 10,
+      integralMin: -10,
+      integralMax: 10,
+    });
+
+    const nextState = stepSimulation(
+      createInitialSimulationState(plant, config),
+      plant,
+      controller,
+      config
+    );
+
+    const lastSample = nextState.samples.at(-1);
+
+    expect(lastSample).toBeDefined();
+    expect(lastSample?.error).toBeCloseTo(
+      config.setpoint - nextState.plantState.output,
+      6
+    );
+    expect(nextState.error).toBeCloseTo(
+      config.setpoint - nextState.plantState.output,
+      6
+    );
+  });
 });

--- a/src/features/pid-simulator/firstOrderPlant.ts
+++ b/src/features/pid-simulator/firstOrderPlant.ts
@@ -1,0 +1,27 @@
+import { PlantModel, PlantState } from "@/features/pid-simulator/types";
+
+export type FirstOrderPlantConfig = {
+  gain: number;
+  timeConstantSeconds: number;
+  initialOutput: number;
+};
+
+export const createFirstOrderPlant = (
+  config: FirstOrderPlantConfig
+): PlantModel => ({
+  id: "first-order",
+  label: "First-order process",
+  description:
+    "Model: dy/dt = (-y + K·u) / τ, integrated with fixed-step explicit Euler.",
+  initialState: (): PlantState => ({
+    output: config.initialOutput,
+  }),
+  step: (state, controlSignal, dtSeconds) => {
+    const tau = Math.max(config.timeConstantSeconds, Number.EPSILON);
+    const dydt = (-state.output + config.gain * controlSignal) / tau;
+
+    return {
+      output: state.output + dydt * dtSeconds,
+    };
+  },
+});

--- a/src/features/pid-simulator/pidController.ts
+++ b/src/features/pid-simulator/pidController.ts
@@ -1,0 +1,73 @@
+import { PidControllerConfig } from "@/features/pid-simulator/types";
+import { clamp } from "@/features/pid-simulator/utils";
+
+export type PidTerms = {
+  proportional: number;
+  integral: number;
+  derivative: number;
+};
+
+export type PidStepResult = {
+  output: number;
+  error: number;
+  terms: PidTerms;
+};
+
+export class PidController {
+  private integralState = 0;
+  private previousError: number | null = null;
+
+  constructor(private config: PidControllerConfig) {}
+
+  setConfig(config: PidControllerConfig) {
+    this.config = config;
+    this.integralState = clamp(
+      this.integralState,
+      this.config.integralMin,
+      this.config.integralMax
+    );
+  }
+
+  reset() {
+    this.integralState = 0;
+    this.previousError = null;
+  }
+
+  step(
+    setpoint: number,
+    processVariable: number,
+    dtSeconds: number
+  ): PidStepResult {
+    const safeDt = dtSeconds > 0 ? dtSeconds : Number.EPSILON;
+    const error = setpoint - processVariable;
+
+    const proportional = this.config.gains.kp * error;
+
+    this.integralState = clamp(
+      this.integralState + error * safeDt,
+      this.config.integralMin,
+      this.config.integralMax
+    );
+    const integral = this.config.gains.ki * this.integralState;
+
+    const derivativeError =
+      this.previousError === null ? 0 : (error - this.previousError) / safeDt;
+    const derivative = this.config.gains.kd * derivativeError;
+
+    this.previousError = error;
+
+    return {
+      output: clamp(
+        proportional + integral + derivative,
+        this.config.outputMin,
+        this.config.outputMax
+      ),
+      error,
+      terms: {
+        proportional,
+        integral,
+        derivative,
+      },
+    };
+  }
+}

--- a/src/features/pid-simulator/presets.ts
+++ b/src/features/pid-simulator/presets.ts
@@ -1,0 +1,38 @@
+import { SimulatorPreset } from "@/features/pid-simulator/types";
+
+export const PID_SIMULATOR_DEFAULT_SETPOINT = 1;
+
+export const PID_SIMULATOR_PRESETS: readonly SimulatorPreset[] = [
+  {
+    id: "well-tuned",
+    name: "Well-tuned",
+    description: "Fast rise with slight overshoot and quick settling.",
+    gains: { kp: 4, ki: 3, kd: 0 },
+    setpoint: PID_SIMULATOR_DEFAULT_SETPOINT,
+  },
+  {
+    id: "underdamped",
+    name: "Underdamped",
+    description: "Overshoots the target and rings down before settling.",
+    gains: { kp: 0.6, ki: 1, kd: 0.8 },
+    setpoint: PID_SIMULATOR_DEFAULT_SETPOINT,
+  },
+  {
+    id: "overdamped",
+    name: "Overdamped",
+    description: "Avoids overshoot but approaches the target slowly.",
+    gains: { kp: 1.5, ki: 0.25, kd: 0 },
+    setpoint: PID_SIMULATOR_DEFAULT_SETPOINT,
+  },
+  {
+    id: "oscillatory",
+    name: "Oscillatory",
+    description:
+      "Aggressive corrections and saturation keep the response oscillating.",
+    gains: { kp: 0.6, ki: 1, kd: 2 },
+    setpoint: PID_SIMULATOR_DEFAULT_SETPOINT,
+  },
+] as const;
+
+export const getPresetById = (presetId: string): SimulatorPreset | undefined =>
+  PID_SIMULATOR_PRESETS.find((preset) => preset.id === presetId);

--- a/src/features/pid-simulator/simulationEngine.ts
+++ b/src/features/pid-simulator/simulationEngine.ts
@@ -1,0 +1,134 @@
+import {
+  ControlBehaviorMetrics,
+  PlantModel,
+  SimulationRuntimeConfig,
+  SimulationSample,
+  SimulationState,
+} from "@/features/pid-simulator/types";
+
+import { PidController } from "./pidController";
+
+const appendSample = (
+  samples: SimulationSample[],
+  sample: SimulationSample
+): SimulationSample[] => [...samples, sample];
+
+export const createInitialSimulationState = (
+  plant: PlantModel,
+  config: SimulationRuntimeConfig
+): SimulationState => {
+  const plantState = plant.initialState();
+  const error = config.setpoint - plantState.output;
+
+  return {
+    timeSeconds: 0,
+    plantState,
+    controllerOutput: 0,
+    error,
+    samples: [
+      {
+        timeSeconds: 0,
+        setpoint: config.setpoint,
+        processVariable: plantState.output,
+        controllerOutput: 0,
+        error,
+      },
+    ],
+  };
+};
+
+export const stepSimulation = (
+  state: SimulationState,
+  plant: PlantModel,
+  controller: PidController,
+  config: SimulationRuntimeConfig
+): SimulationState => {
+  const control = controller.step(
+    config.setpoint,
+    state.plantState.output,
+    config.timeStepSeconds
+  );
+  const nextPlantState = plant.step(
+    state.plantState,
+    control.output,
+    config.timeStepSeconds
+  );
+  const nextTimeSeconds = state.timeSeconds + config.timeStepSeconds;
+
+  const sample: SimulationSample = {
+    timeSeconds: nextTimeSeconds,
+    setpoint: config.setpoint,
+    processVariable: nextPlantState.output,
+    controllerOutput: control.output,
+    error: control.error,
+  };
+
+  return {
+    timeSeconds: nextTimeSeconds,
+    plantState: nextPlantState,
+    controllerOutput: control.output,
+    error: control.error,
+    samples: appendSample(state.samples, sample),
+  };
+};
+
+export const computeControlBehaviorMetrics = (
+  samples: SimulationSample[],
+  setpoint: number
+): ControlBehaviorMetrics => {
+  const lastSample = samples.at(-1);
+  const steadyStateError = lastSample
+    ? setpoint - lastSample.processVariable
+    : setpoint;
+
+  if (samples.length < 2 || Math.abs(setpoint) < Number.EPSILON) {
+    return {
+      riseTimeSeconds: null,
+      settlingTimeSeconds: null,
+      overshootPercent: null,
+      steadyStateError,
+    };
+  }
+
+  const tenPercent = setpoint * 0.1;
+  const ninetyPercent = setpoint * 0.9;
+
+  const firstAboveTen = samples.find(
+    (sample) => sample.processVariable >= tenPercent
+  );
+  const firstAboveNinety = samples.find(
+    (sample) => sample.processVariable >= ninetyPercent
+  );
+
+  const riseTimeSeconds =
+    firstAboveTen && firstAboveNinety
+      ? firstAboveNinety.timeSeconds - firstAboveTen.timeSeconds
+      : null;
+
+  const peak = samples.reduce(
+    (maxValue, sample) => Math.max(maxValue, sample.processVariable),
+    Number.NEGATIVE_INFINITY
+  );
+  const overshootPercent = ((peak - setpoint) / Math.abs(setpoint)) * 100;
+
+  const tolerance = Math.abs(setpoint) * 0.02;
+  let settlingTimeSeconds: number | null = null;
+
+  for (let index = 0; index < samples.length; index += 1) {
+    const tail = samples.slice(index);
+    const settled = tail.every(
+      (sample) => Math.abs(sample.processVariable - setpoint) <= tolerance
+    );
+    if (settled) {
+      settlingTimeSeconds = samples[index].timeSeconds;
+      break;
+    }
+  }
+
+  return {
+    riseTimeSeconds,
+    settlingTimeSeconds,
+    overshootPercent,
+    steadyStateError,
+  };
+};

--- a/src/features/pid-simulator/simulationEngine.ts
+++ b/src/features/pid-simulator/simulationEngine.ts
@@ -54,20 +54,21 @@ export const stepSimulation = (
     config.timeStepSeconds
   );
   const nextTimeSeconds = state.timeSeconds + config.timeStepSeconds;
+  const nextError = config.setpoint - nextPlantState.output;
 
   const sample: SimulationSample = {
     timeSeconds: nextTimeSeconds,
     setpoint: config.setpoint,
     processVariable: nextPlantState.output,
     controllerOutput: control.output,
-    error: control.error,
+    error: nextError,
   };
 
   return {
     timeSeconds: nextTimeSeconds,
     plantState: nextPlantState,
     controllerOutput: control.output,
-    error: control.error,
+    error: nextError,
     samples: appendSample(state.samples, sample),
   };
 };

--- a/src/features/pid-simulator/types.ts
+++ b/src/features/pid-simulator/types.ts
@@ -1,0 +1,72 @@
+export type SimulatorPresetId =
+  | "well-tuned"
+  | "underdamped"
+  | "overdamped"
+  | "oscillatory";
+
+export type PidGains = {
+  kp: number;
+  ki: number;
+  kd: number;
+};
+
+export type PidControllerConfig = {
+  gains: PidGains;
+  outputMin: number;
+  outputMax: number;
+  integralMin: number;
+  integralMax: number;
+};
+
+export type PlantState = {
+  output: number;
+};
+
+export type PlantModel = {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  initialState: () => PlantState;
+  step: (
+    state: PlantState,
+    controlSignal: number,
+    dtSeconds: number
+  ) => PlantState;
+};
+
+export type SimulationSample = {
+  timeSeconds: number;
+  setpoint: number;
+  processVariable: number;
+  controllerOutput: number;
+  error: number;
+};
+
+export type SimulationRuntimeConfig = {
+  setpoint: number;
+  timeStepSeconds: number;
+  maxTimeSeconds: number;
+};
+
+export type SimulationState = {
+  readonly timeSeconds: number;
+  readonly plantState: PlantState;
+  readonly controllerOutput: number;
+  readonly error: number;
+  readonly samples: SimulationSample[];
+};
+
+export type ControlBehaviorMetrics = {
+  riseTimeSeconds: number | null;
+  settlingTimeSeconds: number | null;
+  overshootPercent: number | null;
+  steadyStateError: number;
+};
+
+export type SimulatorPreset = {
+  id: SimulatorPresetId;
+  name: string;
+  description: string;
+  gains: PidGains;
+  setpoint: number;
+};

--- a/src/features/pid-simulator/utils.ts
+++ b/src/features/pid-simulator/utils.ts
@@ -1,0 +1,16 @@
+export const clamp = (value: number, min: number, max: number): number => {
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+};
+
+export const roundTo = (value: number, digits: number): number => {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+};


### PR DESCRIPTION
### Motivation
- Provide an interactive, browser-only PID controller simulator that works within the site's static-export constraints.
- Keep the simulator code modular and deterministic so the control logic, plant model, and UI can evolve independently.
- Publish the rewritten PID simulator work on a separate branch and PR instead of updating the existing PID PR.

### What changed
- Added a new `/pid-controller/` page with simulator workspace UI, controls, charting, and supporting tests.
- Added modular PID simulator engine code under `src/features/pid-simulator/`, including controller, plant, presets, types, utilities, and engine tests.
- Added supporting docs in `docs/pid-controller-simulator.md` and updated sitemap and related test coverage for the new route.

### Impact
- Visitors can experiment with PID tuning directly in the browser on a static site route.
- The simulator implementation is organized so future extensions can change plant/controller behavior without rewriting the page shell.

### Validation
- Passed `yarn lint`
- Passed `yarn typecheck`
- Passed `yarn test`
- Passed `yarn build`
- `yarn test:e2e` was attempted twice but blocked by Docker image pull failures from `mcr.microsoft.com` (`EOF` while resolving/pulling `mcr.microsoft.com/playwright:v1.58.2-noble`)
- `yarn test:e2e:host` was also attempted, but the wrapper requires `playwright install --with-deps`, which needs unavailable privileged system dependency installation in this environment
- Because of those environment blockers, Playwright smoke and visual coverage could not be completed locally before opening this PR

### Notes
- This PR is intentionally separate from #208 and is based on commit `5e668593cfeb99645ba1d99ce0605bff3a3b8ae7` on branch `codex/pid-simulator-refinements`.
