### PR TITLE
[codex] Simplify interactive workspace state

### DIFF
--- a/src/app/event-loop/_components/EventLoopVisualizer.tsx
+++ b/src/app/event-loop/_components/EventLoopVisualizer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { CallStackPanel } from "@/features/event-loop/components/CallStackPanel";
 import { QueueColumn } from "@/features/event-loop/components/QueueColumn";
@@ -47,31 +47,16 @@ export function EventLoopVisualizer() {
     };
   }, [isPlaying, speedMs, state.completed]);
 
-  const nextHint = useMemo(() => {
-    const activeFrame = state.callStack.at(-1);
-    if (activeFrame) {
-      return `Executing ${activeFrame.label} on the ${activeFrame.source} queue.`;
-    }
-
-    if (state.microtaskQueue.length > 0) {
-      return "Call stack is empty, so the runtime will run the next microtask.";
-    }
-
-    if (state.taskQueue.length > 0) {
-      return "No microtasks remain, so the runtime will run the next task.";
-    }
-
-    if (state.timers.length > 0) {
-      return "No runnable work yet; clock advances until a timer is due.";
-    }
-
-    return "All queues are empty. Execution is complete.";
-  }, [
-    state.callStack,
-    state.microtaskQueue.length,
-    state.taskQueue.length,
-    state.timers.length,
-  ]);
+  const activeFrame = state.callStack.at(-1);
+  const nextHint = activeFrame
+    ? `Executing ${activeFrame.label} on the ${activeFrame.source} queue.`
+    : state.microtaskQueue.length > 0
+      ? "Call stack is empty, so the runtime will run the next microtask."
+      : state.taskQueue.length > 0
+        ? "No microtasks remain, so the runtime will run the next task."
+        : state.timers.length > 0
+          ? "No runnable work yet; clock advances until a timer is due."
+          : "All queues are empty. Execution is complete.";
 
   return (
     <section className="mt-6 rounded-xl border border-gray-700 bg-gray-950/70 p-6 shadow-sm">

--- a/src/app/mandelbrot/_components/MandelbrotExplorer.tsx
+++ b/src/app/mandelbrot/_components/MandelbrotExplorer.tsx
@@ -64,13 +64,11 @@ const metaValueClass = "break-all text-sm text-cyan-100";
 const toolbarButtonClass =
   "rounded-md border border-white/15 px-3 py-2 text-sm text-white transition hover:border-cyan-300 hover:text-cyan-100 disabled:cursor-not-allowed disabled:opacity-40";
 
-function createInitialHistory(): ViewportHistory {
-  return createViewportHistory(createDefaultViewport(DEFAULT_CANVAS_SIZE));
-}
-
 export function MandelbrotExplorer() {
   const pathname = usePathname();
-  const [history, setHistory] = useState(() => createInitialHistory());
+  const [history, setHistory] = useState<ViewportHistory>(() =>
+    createViewportHistory(createDefaultViewport(DEFAULT_CANVAS_SIZE))
+  );
   const [previewViewport, setPreviewViewport] =
     useState<PreciseViewport | null>(null);
   const [canvasSize, setCanvasSize] = useState(DEFAULT_CANVAS_SIZE);

--- a/src/app/pid-controller/_components/PidSimulatorWorkspace.tsx
+++ b/src/app/pid-controller/_components/PidSimulatorWorkspace.tsx
@@ -29,6 +29,11 @@ const DEFAULT_MAX_TIME_SECONDS = 20;
 const TIME_EPSILON = FIXED_DT_SECONDS / 2;
 
 const firstPreset = PID_SIMULATOR_PRESETS[0];
+const plant = createFirstOrderPlant({
+  gain: 1,
+  timeConstantSeconds: 1.1,
+  initialOutput: 0,
+});
 
 const buildControllerConfig = (
   kp: number,
@@ -43,16 +48,6 @@ const buildControllerConfig = (
 });
 
 export function PidSimulatorWorkspace() {
-  const plant = useMemo(
-    () =>
-      createFirstOrderPlant({
-        gain: 1,
-        timeConstantSeconds: 1.1,
-        initialOutput: 0,
-      }),
-    []
-  );
-
   const [presetId, setPresetId] = useState<SimulatorPresetId>(firstPreset.id);
   const [kp, setKp] = useState(firstPreset.gains.kp);
   const [ki, setKi] = useState(firstPreset.gains.ki);
@@ -212,7 +207,7 @@ export function PidSimulatorWorkspace() {
     return () => {
       window.cancelAnimationFrame(rafId);
     };
-  }, [isRunning, maxTimeSeconds, plant, setpoint, simulationSpeed]);
+  }, [isRunning, maxTimeSeconds, setpoint, simulationSpeed]);
 
   useEffect(() => {
     simulationStateRef.current = simulationState;

--- a/src/features/pid-simulator/simulationEngine.ts
+++ b/src/features/pid-simulator/simulationEngine.ts
@@ -8,11 +8,6 @@ import {
 
 import { PidController } from "./pidController";
 
-const appendSample = (
-  samples: SimulationSample[],
-  sample: SimulationSample
-): SimulationSample[] => [...samples, sample];
-
 export const createInitialSimulationState = (
   plant: PlantModel,
   config: SimulationRuntimeConfig
@@ -69,7 +64,7 @@ export const stepSimulation = (
     plantState: nextPlantState,
     controllerOutput: control.output,
     error: nextError,
-    samples: appendSample(state.samples, sample),
+    samples: [...state.samples, sample],
   };
 };
 


### PR DESCRIPTION
## Summary
- remove unnecessary `useMemo` and helper wrappers in the interactive workspace components
- inline simple derived values and initializers where React memoization was not buying anything
- simplify PID simulation sample accumulation and stabilize the shared plant instance outside the component

## Why
These interactive workspaces had a few small abstractions and memoized values that made the code harder to scan without changing behavior. This keeps the state and render flow more direct.

## Impact
The event loop, Mandelbrot, and PID controller workspaces keep the same behavior, but the components are easier to read and maintain.

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- Playwright smoke/visual checks skipped per explicit user instruction
