### PR TITLE
[codex] Fix maintainability regressions in content and tools

### DIFF
--- a/src/features/load-flow/graph/toLoadFlowCase.ts
+++ b/src/features/load-flow/graph/toLoadFlowCase.ts
@@ -25,6 +25,8 @@ export const toLoadFlowCase = (state: LoadFlowEditorState): LoadFlowCase => {
       r: branch.r,
       x: branch.x,
       bHalf: branch.bHalf,
+      tapRatio: branch.tapRatio,
+      phaseShiftDeg: branch.phaseShiftDeg,
       thermalLimitMVA: branch.thermalLimitMVA,
       status: branch.status,
     };

--- a/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
+++ b/src/features/load-flow/state/__tests__/loadFlowStore.test.ts
@@ -127,6 +127,8 @@ describe("loadFlowStore", () => {
           r: 0.01,
           x: 0.05,
           bHalf: 0.01,
+          tapRatio: 1.02,
+          phaseShiftDeg: 7.5,
         },
       ],
       generators: [
@@ -151,6 +153,12 @@ describe("loadFlowStore", () => {
       expect.objectContaining({
         voltageMagnitudeSetpoint: 1.04,
         voltageAngleSetpointDeg: 2.5,
+      })
+    );
+    expect(snapshot.branches[0]).toEqual(
+      expect.objectContaining({
+        tapRatio: 1.02,
+        phaseShiftDeg: 7.5,
       })
     );
     expect(snapshot.generators).toHaveLength(1);

--- a/src/features/load-flow/state/loadFlowStore.ts
+++ b/src/features/load-flow/state/loadFlowStore.ts
@@ -26,6 +26,8 @@ export interface LineEdge {
   r: number;
   x: number;
   bHalf: number;
+  tapRatio?: number;
+  phaseShiftDeg?: number;
   thermalLimitMVA?: number;
   status?: "IN_SERVICE" | "OUT_OF_SERVICE";
 }
@@ -376,6 +378,8 @@ export const replaceEditorStateFromLoadFlowCase = (
         r: branch.r,
         x: branch.x,
         bHalf: branch.bHalf ?? 0,
+        tapRatio: branch.tapRatio,
+        phaseShiftDeg: branch.phaseShiftDeg,
         thermalLimitMVA: branch.thermalLimitMVA,
         status: branch.status,
       },

--- a/src/features/mandelbrot/__tests__/viewport.test.ts
+++ b/src/features/mandelbrot/__tests__/viewport.test.ts
@@ -77,4 +77,24 @@ describe("mandelbrot viewport math", () => {
     expect(zoomed.width.toExponential()).toBe("5e-81");
     expect(magnificationFromViewport(zoomed).toExponential()).toBe("7e+80");
   });
+
+  it("rejects zero or negative viewport widths", () => {
+    expect(() =>
+      createViewport({
+        centerX: "0",
+        centerY: "0",
+        width: "0",
+        size,
+      })
+    ).toThrow(/Viewport width must be finite and greater than zero/);
+
+    expect(() =>
+      createViewport({
+        centerX: "0",
+        centerY: "0",
+        width: "-1",
+        size,
+      })
+    ).toThrow(/Viewport width must be finite and greater than zero/);
+  });
 });

--- a/src/features/mandelbrot/viewport.ts
+++ b/src/features/mandelbrot/viewport.ts
@@ -76,6 +76,9 @@ export function createViewport({
   size,
 }: ViewportInput): PreciseViewport {
   const preciseWidth = precise(width);
+  if (!preciseWidth.isFinite() || preciseWidth.lte(0)) {
+    throw new Error("Viewport width must be finite and greater than zero.");
+  }
   configurePrecisionForWidth(preciseWidth);
 
   return {

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -15,15 +15,33 @@ function setupTempPosts(markdownBySlug: Record<string, string>): string {
   return tempDir;
 }
 
-async function loadBlogApiAtCwd(cwd: string) {
+async function loadBlogApiAtCwd(
+  cwd: string,
+  options?: { nodeEnv?: string }
+) {
   jest.resetModules();
   const cwdSpy = jest.spyOn(process, "cwd").mockReturnValue(cwd);
-  const blogApi = await import("@/lib/blogApi");
+  const previousNodeEnv = process.env.NODE_ENV;
 
-  cwdSpy.mockRestore();
+  if (options?.nodeEnv !== undefined) {
+    process.env.NODE_ENV = options.nodeEnv;
+  }
 
-  return blogApi;
+  try {
+    const blogApi = await import("@/lib/blogApi");
+
+    return blogApi;
+  } finally {
+    cwdSpy.mockRestore();
+    process.env.NODE_ENV = previousNodeEnv;
+  }
 }
+
+afterEach(() => {
+  process.env.NODE_ENV = "test";
+  jest.restoreAllMocks();
+  jest.resetModules();
+});
 
 describe("blogApi front matter validation", () => {
   test("parses required front matter and applies defaults", async () => {
@@ -184,8 +202,26 @@ Body`,
     getPostBySlug("second", ["slug"]);
 
     expect(readFileSpy).toHaveBeenCalledTimes(2);
+  });
 
-    readFileSpy.mockRestore();
+  test("reloads post content on each call during development", async () => {
+    const tempDir = setupTempPosts({
+      draft: `---\ntitle: "Original"\ndate: "2026-02-17"\n---\nBody`,
+    });
+    const postPath = path.join(tempDir, "content", "posts", "draft.md");
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir, {
+      nodeEnv: "development",
+    });
+
+    expect(getPostBySlug("draft")?.title).toBe("Original");
+
+    fs.writeFileSync(
+      postPath,
+      `---\ntitle: "Updated"\ndate: "2026-02-17"\n---\nBody`,
+      "utf8"
+    );
+
+    expect(getPostBySlug("draft")?.title).toBe("Updated");
   });
 
   test("returns null when slug resolves to a directory", async () => {

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -15,10 +15,7 @@ function setupTempPosts(markdownBySlug: Record<string, string>): string {
   return tempDir;
 }
 
-async function loadBlogApiAtCwd(
-  cwd: string,
-  options?: { nodeEnv?: string }
-) {
+async function loadBlogApiAtCwd(cwd: string, options?: { nodeEnv?: string }) {
   jest.resetModules();
   const cwdSpy = jest.spyOn(process, "cwd").mockReturnValue(cwd);
   const previousNodeEnv = process.env.NODE_ENV;

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -18,10 +18,11 @@ function setupTempPosts(markdownBySlug: Record<string, string>): string {
 async function loadBlogApiAtCwd(cwd: string, options?: { nodeEnv?: string }) {
   jest.resetModules();
   const cwdSpy = jest.spyOn(process, "cwd").mockReturnValue(cwd);
-  const previousNodeEnv = process.env.NODE_ENV;
+  const env = process.env as Record<string, string | undefined>;
+  const previousNodeEnv = env.NODE_ENV;
 
   if (options?.nodeEnv !== undefined) {
-    process.env.NODE_ENV = options.nodeEnv;
+    env.NODE_ENV = options.nodeEnv;
   }
 
   try {
@@ -30,12 +31,13 @@ async function loadBlogApiAtCwd(cwd: string, options?: { nodeEnv?: string }) {
     return blogApi;
   } finally {
     cwdSpy.mockRestore();
-    process.env.NODE_ENV = previousNodeEnv;
+    env.NODE_ENV = previousNodeEnv;
   }
 }
 
 afterEach(() => {
-  process.env.NODE_ENV = "test";
+  const env = process.env as Record<string, string | undefined>;
+  env.NODE_ENV = "test";
   jest.restoreAllMocks();
   jest.resetModules();
 });

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 const postsDirectory = join(process.cwd(), "content/posts");
 const postBySlugCache = new Map<string, Post | null>();
 const postSlugPattern = /^[a-z0-9-]+$/i;
+const usePersistentCache = process.env.NODE_ENV !== "development";
 
 let allPostsCache: Post[] | null = null;
 
@@ -182,6 +183,10 @@ function parsePostBySlug(slug: string): Post | null {
 function getCachedPostBySlug(slug: string): Post | null {
   const realSlug = slug.replace(/\.md$/, "");
 
+  if (!usePersistentCache) {
+    return parsePostBySlug(realSlug);
+  }
+
   if (postBySlugCache.has(realSlug)) {
     return postBySlugCache.get(realSlug) ?? null;
   }
@@ -194,6 +199,20 @@ function getCachedPostBySlug(slug: string): Post | null {
 }
 
 function getCachedAllPosts(): Post[] {
+  if (!usePersistentCache) {
+    const posts = getPostSlugs()
+      .map((slug) => parsePostBySlug(slug))
+      .filter((post): post is Post => post !== null)
+      .sort(
+        (post1, post2) =>
+          new Date(post2.date).getTime() - new Date(post1.date).getTime()
+      );
+
+    assertUniqueSeriesOrder(posts);
+
+    return posts;
+  }
+
   if (allPostsCache) {
     return allPostsCache;
   }


### PR DESCRIPTION
## Summary
- preserve transformer branch fields when round-tripping load-flow editor state to and from solver cases
- reject non-positive Mandelbrot viewport widths and cover the guard with focused tests
- disable persistent blog content caching in development and add regression tests for front matter defaults, invalid metadata, and live-reload behavior
- fix follow-up blog API test formatting and `process.env` typing so the branch passes the current lint/typecheck toolchain

## Why
Recent maintainability work exposed a few regressions where state was dropped during serialization, invalid viewport input could slip through, and blog content stayed stale in development because cached post results were reused across reads.

## Impact
- load-flow editor snapshots preserve transformer tap ratio and phase shift values
- Mandelbrot viewport creation fails fast on invalid widths instead of building unusable state
- blog content reads reflect on-disk edits during development while keeping production caching behavior unchanged

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- Playwright smoke/visual checks skipped per user instruction
