### PR TITLE
[codex] Refine blog skill tone guidance

### DIFF
--- a/.agents/skills/blog-post-creator/SKILL.md
+++ b/.agents/skills/blog-post-creator/SKILL.md
@@ -29,7 +29,7 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 8. When drafting a new post from notes, include cover prompts by default; only skip prompts if the user explicitly asks for post-only output.
 9. Do not imply hands-on practice the user did not claim. If the input is about reading, reflection, or conceptual learning, keep claims at the level of understanding, interpretation, or future curiosity unless the user explicitly said they build, tune, deploy, or regularly use the systems being discussed.
 10. Avoid formulaic heading scaffolds as a dominant pattern. Do not default multiple sections in a post to `What`, `How`, `Why`, `When`, `Where`, `The Goal`, `The Implementation`, or similar organizational labels when a more specific idea-title is available.
-11. Avoid explicitly telling the reader that a topic is meaningful, important, or significant. Show that through specificity, stakes, consequences, and judgment instead of declaring it.
+11. Avoid explicitly telling the reader that a topic is meaningful, important, or significant unless the user explicitly wants that rhetorical style. Otherwise, show that through specificity, stakes, consequences, and judgment instead of declaring it.
 
 ## Workflow
 

--- a/.agents/skills/blog-post-creator/SKILL.md
+++ b/.agents/skills/blog-post-creator/SKILL.md
@@ -13,6 +13,7 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Keep tone warm but understated: confident, relationship-aware, and forward-looking.
 - Keep prose professional with emotional intelligence.
 - Avoid theatrics, hype language, and performative emphasis.
+- Do not assert significance with phrases like "this is important because", "this matters because", or similar authorial signposting; let significance emerge from the concrete facts, trade-offs, and consequences.
 - When the piece is intentionally reflective or artistic, allow a more lyrical register, but keep it anchored in concrete observation, personal judgment, or a clearly stated tension.
 
 ## Hard Constraints
@@ -28,6 +29,7 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 8. When drafting a new post from notes, include cover prompts by default; only skip prompts if the user explicitly asks for post-only output.
 9. Do not imply hands-on practice the user did not claim. If the input is about reading, reflection, or conceptual learning, keep claims at the level of understanding, interpretation, or future curiosity unless the user explicitly said they build, tune, deploy, or regularly use the systems being discussed.
 10. Avoid formulaic heading scaffolds as a dominant pattern. Do not default multiple sections in a post to `What`, `How`, `Why`, `When`, `Where`, `The Goal`, `The Implementation`, or similar organizational labels when a more specific idea-title is available.
+11. Avoid explicitly telling the reader that a topic is meaningful, important, or significant. Show that through specificity, stakes, consequences, and judgment instead of declaring it.
 
 ## Workflow
 
@@ -78,6 +80,7 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 6. Run final checks.
 - Ensure the argument is cohesive from opening to close.
 - Remove hype language and repeated one-sentence paragraph cadence.
+- Remove authorial "this matters/this is important" assertions unless the user explicitly wants that rhetorical style.
 - Verify section headings are specific and reflect actual content.
 - Run a heading-shape audit: if several headings in the same draft begin with `What`, `How`, `Why`, `When`, `Where`, or generic labels like `The Goal`, rewrite them unless that repetition is clearly intentional.
 - Keep claims bounded and testable; mark assumptions when needed.
@@ -120,6 +123,7 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 ## Voice Anti-Patterns
 
 - Avoid vague evaluative phrasing like "this was a big shift" when the object of the shift can be named directly.
+- Avoid significance-signposting such as "this is important because", "this matters because", or "what makes this meaningful is"; replace it with the concrete observation, stake, or consequence itself.
 - Avoid "this changes how I use X" unless the user explicitly said they use or build with `X`.
 - Avoid polished summary phrases like "clear statistical story" or "substantial result" when plainer analytical language would do.
 - Avoid endings that merely restate the thesis in more elevated language.

--- a/.agents/skills/blog-post-creator/references/voice-and-structure.md
+++ b/.agents/skills/blog-post-creator/references/voice-and-structure.md
@@ -5,6 +5,7 @@
 - Use analytical, practical, and measured language.
 - Use first person singular when presenting experience and judgment.
 - Keep tone warm but restrained; avoid hype, slogans, and performative phrasing.
+- Do not signal significance with lines like "this matters because"; make the stakes legible through concrete detail and consequence instead.
 - Explain trade-offs and constraints instead of presenting absolute claims.
 
 ## Cadence Guardrails
@@ -17,7 +18,7 @@
 ## Common Post Shapes
 
 1. Technical implementation post
-- Opening: define the problem and why it mattered.
+- Opening: define the problem and the relevant context or consequence.
 - Middle sections: explain approach, what changed, and why design choices were made.
 - Trade-offs: call out cost, complexity, or limitations.
 - Close: summarize durable takeaway or operating principle.


### PR DESCRIPTION
## What changed
- updated the `blog-post-creator` skill to explicitly avoid authorial significance-signposting such as "this matters because" and "this is important because"
- reinforced the rule in the main skill guidance, final checks, and anti-pattern list
- aligned the supporting voice reference so post-shape guidance emphasizes context and consequence instead of declaring importance

## Why
- keeps generated blog drafts closer to the site's understated voice
- pushes the skill to show significance through concrete detail, trade-offs, and consequences rather than asserting it directly

## Impact
- blog drafts and rewrites produced with this skill should avoid a recurring tone pattern you called out
- the guidance is now consistent across both the primary skill file and the voice reference it points to

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test` (passed on rerun after one transient Jest worker segfault)
- `yarn build`
- `yarn test:e2e`
- `yarn test:e2e:visual` (passed on rerun after one transient Docker/Next font-fetch startup failure)
