### PR TITLE
[codex] refresh now page copy

### DIFF
--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -16,7 +16,7 @@ import { SectionBlock } from "@/components/SectionBlock";
 import { getAllPosts } from "@/lib/blogApi";
 import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
 
-export const NOW_PAGE_LAST_UPDATED_ISO = "2026-03-13";
+export const NOW_PAGE_LAST_UPDATED_ISO = "2026-04-10";
 
 const nowPageLastUpdatedDate = new Date(
   `${NOW_PAGE_LAST_UPDATED_ISO}T00:00:00Z`
@@ -74,18 +74,13 @@ export default function NowPage() {
             <div className="text-body space-y-8 text-left leading-relaxed">
               <IconTextRow icon="🚀" title="Top of Mind" headingLevel="h2">
                 <p>
-                  I started playing with OpenClaw a bit. On Windows in WSL, I
-                  added some basic orchestration commands to manipulate a Docker
-                  container.
+                  I&apos;m planning for an upcoming move to San Francisco to
+                  start a new role at the end of April.
                 </p>
                 <p>
-                  I started the container with OpenClaw, ran{" "}
-                  <code>openclaw onboard</code>, and set things up with Gemini
-                  3.1 Pro Preview plus a WhatsApp connection.
-                </p>
-                <p>
-                  I&apos;ve only chatted with it briefly so far, and I
-                  haven&apos;t gone much further yet.
+                  There&apos;s a lot of logistics to sort through right now, so
+                  most of my attention has gone into getting ready for that
+                  transition.
                 </p>
               </IconTextRow>
 
@@ -95,16 +90,15 @@ export default function NowPage() {
                 headingLevel="h2"
               >
                 <p>
-                  I&apos;m currently on Chapter 8 of{" "}
+                  I&apos;m currently on Chapter 9 of{" "}
                   <ExternalLink href="https://www.deeplearningbook.org/">
                     <em>Deep Learning</em>
                   </ExternalLink>{" "}
                   by Goodfellow, Bengio, and Courville.
                 </p>
                 <p>
-                  I also started reading <em>Children of Time</em>{" "}
-                  {"on a colleague's recommendation."} The hook in Chapter 1.1
-                  pulled me in right away.
+                  I finished <em>Children of Time</em> and absolutely loved it.
+                  I want to pick up the next book once I have a bit more time.
                 </p>
                 <p>
                   <ExternalLink href="https://www.domainlanguage.com/ddd/">
@@ -117,9 +111,20 @@ export default function NowPage() {
               <IconTextRow icon="🎯" title="Current Goals" headingLevel="h2">
                 <ul className="list-outside list-disc space-y-1 pl-6">
                   <li>Finish and understand the Deep Learning book</li>
+                  <li>Get settled ahead of the move to San Francisco</li>
                   <li>Leveling up my tennis game</li>
                   <li>Get to A2 proficiency in Chinese</li>
                 </ul>
+              </IconTextRow>
+
+              <IconTextRow icon="🎬" title="Recently Watched" headingLevel="h2">
+                <p>
+                  I watched <em>Project Hail Mary</em> and really liked it.
+                </p>
+                <p>
+                  The movie was a good time, but I still enjoyed the detail and
+                  depth of the book more.
+                </p>
               </IconTextRow>
             </div>
 


### PR DESCRIPTION
## Summary
- refresh the `/now` page copy for April 2026
- add notes about the upcoming move to San Francisco and starting a new role at the end of April
- update reading and watching notes for *Deep Learning*, *Children of Time*, and *Project Hail Mary*

## Why
The now page was out of date and no longer matched current priorities or recent books and media.

## Impact
Visitors to the site now see a more accurate snapshot of current focus areas and recent interests.

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn test:e2e`
- `yarn test:e2e:visual`