### PR TITLE
Add explicit Mandelbrot backend selection

### DIFF
--- a/src/app/experimental/mandelbrot/_components/MandelbrotCanvas.tsx
+++ b/src/app/experimental/mandelbrot/_components/MandelbrotCanvas.tsx
@@ -405,36 +405,38 @@ export function MandelbrotCanvas({
       ref={containerRef}
       className="relative min-h-[24rem] overflow-hidden rounded-xl border border-cyan-500/20 bg-slate-950 shadow-[0_24px_80px_rgba(8,145,178,0.18)]"
     >
-      <canvas
-        ref={gpuCanvasRef}
-        className="pointer-events-none absolute inset-0 h-full w-full"
-        aria-hidden="true"
-      />
+      <div className="absolute inset-0 z-0">
+        <canvas
+          ref={gpuCanvasRef}
+          className="pointer-events-none absolute inset-0 h-full w-full"
+          aria-hidden="true"
+        />
 
-      <canvas
-        ref={cpuCanvasRef}
-        className={`relative z-10 block h-full w-full touch-none ${
-          dragMode === "box-zoom"
-            ? "cursor-crosshair"
-            : "cursor-grab active:cursor-grabbing"
-        }`}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerLeave={handlePointerLeave}
-        aria-label="Mandelbrot set rendering canvas"
-      />
+        <canvas
+          ref={cpuCanvasRef}
+          className={`absolute inset-0 block h-full w-full touch-none ${
+            dragMode === "box-zoom"
+              ? "cursor-crosshair"
+              : "cursor-grab active:cursor-grabbing"
+          }`}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerLeave={handlePointerLeave}
+          aria-label="Mandelbrot set rendering canvas"
+        />
+      </div>
 
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.08),transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 z-10 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.08),transparent_55%)]" />
 
       {selectionRect ? (
         <div
-          className="pointer-events-none absolute border border-cyan-200 bg-cyan-300/15 shadow-[0_0_0_1px_rgba(103,232,249,0.4)]"
+          className="pointer-events-none absolute z-20 border border-cyan-200 bg-cyan-300/15 shadow-[0_0_0_1px_rgba(103,232,249,0.4)]"
           style={selectionStyles}
         />
       ) : null}
 
-      <div className="pointer-events-none absolute left-4 top-4 rounded-md border border-white/10 bg-slate-950/80 px-3 py-2 text-xs text-gray-200 backdrop-blur-sm">
+      <div className="pointer-events-none absolute left-4 top-4 z-30 rounded-md border border-white/10 bg-slate-950/80 px-3 py-2 text-xs text-gray-200 backdrop-blur-sm">
         <p className="font-semibold text-cyan-100">Plot controls</p>
         <p>Wheel to zoom at cursor.</p>
         <p>
@@ -444,7 +446,7 @@ export function MandelbrotCanvas({
         </p>
       </div>
 
-      <div className="absolute right-4 top-4 flex gap-2">
+      <div className="absolute right-4 top-4 z-30 flex gap-2">
         <button
           type="button"
           className="rounded-md border border-white/15 bg-slate-950/80 px-3 py-2 text-sm text-white backdrop-blur-sm transition hover:border-cyan-300 hover:text-cyan-100"
@@ -477,7 +479,7 @@ export function MandelbrotCanvas({
         </button>
       </div>
 
-      <div className="pointer-events-none absolute bottom-4 left-4 rounded-md border border-white/10 bg-slate-950/80 px-3 py-2 text-xs text-gray-200 backdrop-blur-sm">
+      <div className="pointer-events-none absolute bottom-4 left-4 z-30 rounded-md border border-white/10 bg-slate-950/80 px-3 py-2 text-xs text-gray-200 backdrop-blur-sm">
         <p className="font-semibold text-cyan-100">
           {renderState.phase === "ready"
             ? "Render ready"

--- a/src/app/experimental/mandelbrot/_components/MandelbrotCanvas.tsx
+++ b/src/app/experimental/mandelbrot/_components/MandelbrotCanvas.tsx
@@ -91,7 +91,8 @@ export function MandelbrotCanvas({
   onZoomOut,
   onReset,
 }: MandelbrotCanvasProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const cpuCanvasRef = useRef<HTMLCanvasElement>(null);
+  const gpuCanvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef(viewport);
   const dragSessionRef = useRef<DragSession | null>(null);
@@ -107,7 +108,8 @@ export function MandelbrotCanvas({
   canvasSizeRef.current = canvasSize;
 
   const renderState = useMandelbrotRender({
-    canvasRef,
+    cpuCanvasRef,
+    gpuCanvasRef,
     viewport,
     settings,
     size: canvasSize,
@@ -347,7 +349,7 @@ export function MandelbrotCanvas({
   }
 
   useEffect(() => {
-    const canvas = canvasRef.current;
+    const canvas = cpuCanvasRef.current;
 
     if (!canvas) {
       return;
@@ -404,8 +406,14 @@ export function MandelbrotCanvas({
       className="relative min-h-[24rem] overflow-hidden rounded-xl border border-cyan-500/20 bg-slate-950 shadow-[0_24px_80px_rgba(8,145,178,0.18)]"
     >
       <canvas
-        ref={canvasRef}
-        className={`block h-full w-full touch-none ${
+        ref={gpuCanvasRef}
+        className="pointer-events-none absolute inset-0 h-full w-full"
+        aria-hidden="true"
+      />
+
+      <canvas
+        ref={cpuCanvasRef}
+        className={`relative z-10 block h-full w-full touch-none ${
           dragMode === "box-zoom"
             ? "cursor-crosshair"
             : "cursor-grab active:cursor-grabbing"
@@ -478,6 +486,7 @@ export function MandelbrotCanvas({
               : "Rendering"}
         </p>
         <p>{renderState.message}</p>
+        <p>Backend: {renderState.backend === "webgpu" ? "WebGPU" : "CPU"}</p>
       </div>
     </div>
   );

--- a/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
+++ b/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
@@ -10,6 +10,7 @@ import {
   formatMagnification,
   formatPreciseDecimal,
 } from "@/features/mandelbrot/format";
+import { detectWebGpuAvailability } from "@/features/mandelbrot/gpu";
 import {
   createViewportHistory,
   pushViewport,
@@ -47,12 +48,20 @@ const DEFAULT_CANVAS_SIZE: PixelSize = {
   height: 600,
 };
 
-const DEFAULT_SETTINGS: MandelbrotSettings = {
+const DEFAULT_GPU_SETTINGS: MandelbrotSettings = {
   maxIterations: 2000,
   paletteId: "oceanic",
   coloringMode: "smooth",
   resolutionScale: 1,
-  renderBackendPreference: "webgpu",
+  renderBackendPreference: "auto",
+};
+
+const DEFAULT_CPU_SETTINGS: MandelbrotSettings = {
+  maxIterations: 180,
+  paletteId: "oceanic",
+  coloringMode: "smooth",
+  resolutionScale: 0.5,
+  renderBackendPreference: "auto",
 };
 
 const QUALITY_OPTIONS = [
@@ -65,6 +74,7 @@ const BACKEND_OPTIONS: ReadonlyArray<{
   value: RenderBackendPreference;
   label: string;
 }> = [
+  { value: "auto", label: "Auto" },
   { value: "webgpu", label: "WebGPU" },
   { value: "cpu", label: "CPU" },
 ];
@@ -84,27 +94,54 @@ export function MandelbrotExplorer() {
   const [canvasSize, setCanvasSize] = useState(DEFAULT_CANVAS_SIZE);
   const [dragMode, setDragMode] = useState<DragMode>("pan");
   const [hoverPoint, setHoverPoint] = useState<ComplexPoint | null>(null);
-  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
+  const [settings, setSettings] = useState(DEFAULT_CPU_SETTINGS);
+  const [hasInitializedSettings, setHasInitializedSettings] = useState(false);
 
   const activeViewport = previewViewport ?? history.present;
   const defaultViewport = createDefaultViewport(canvasSize);
   const magnification = magnificationFromViewport(activeViewport);
 
   useEffect(() => {
-    const currentSearchParams = Object.fromEntries(
-      new URLSearchParams(window.location.search).entries()
-    );
-    const parsedViewport = parseViewportFromQuery(
-      currentSearchParams,
-      DEFAULT_CANVAS_SIZE
-    );
+    let isMounted = true;
 
-    setSettings(parseSettingsFromQuery(currentSearchParams, DEFAULT_SETTINGS));
+    async function initializeExplorerState() {
+      const currentSearchParams = Object.fromEntries(
+        new URLSearchParams(window.location.search).entries()
+      );
+      const parsedViewport = parseViewportFromQuery(
+        currentSearchParams,
+        DEFAULT_CANVAS_SIZE
+      );
+      let defaultSettings = DEFAULT_CPU_SETTINGS;
 
-    if (parsedViewport) {
-      setHistory(createViewportHistory(parsedViewport));
-      setPreviewViewport(null);
+      try {
+        const gpuAvailability = await detectWebGpuAvailability();
+
+        defaultSettings = gpuAvailability.isAvailable
+          ? DEFAULT_GPU_SETTINGS
+          : DEFAULT_CPU_SETTINGS;
+      } catch {
+        defaultSettings = DEFAULT_CPU_SETTINGS;
+      }
+
+      if (!isMounted) {
+        return;
+      }
+
+      setSettings(parseSettingsFromQuery(currentSearchParams, defaultSettings));
+      setHasInitializedSettings(true);
+
+      if (parsedViewport) {
+        setHistory(createViewportHistory(parsedViewport));
+        setPreviewViewport(null);
+      }
     }
+
+    void initializeExplorerState();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   useEffect(() => {
@@ -126,11 +163,15 @@ export function MandelbrotExplorer() {
   }, [canvasSize.height, canvasSize.width]);
 
   useEffect(() => {
+    if (!hasInitializedSettings) {
+      return;
+    }
+
     const nextQuery = serializeExplorerState(activeViewport, settings);
     const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
 
     window.history.replaceState(null, "", nextUrl);
-  }, [activeViewport, pathname, settings]);
+  }, [activeViewport, hasInitializedSettings, pathname, settings]);
 
   function commitViewport(nextViewport: PreciseViewport) {
     setPreviewViewport(null);

--- a/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
+++ b/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
@@ -26,6 +26,7 @@ import {
   MandelbrotSettings,
   PixelSize,
   PreciseViewport,
+  RenderBackendPreference,
 } from "@/features/mandelbrot/types";
 import {
   parseSettingsFromQuery,
@@ -47,10 +48,11 @@ const DEFAULT_CANVAS_SIZE: PixelSize = {
 };
 
 const DEFAULT_SETTINGS: MandelbrotSettings = {
-  maxIterations: 180,
+  maxIterations: 2000,
   paletteId: "oceanic",
   coloringMode: "smooth",
-  resolutionScale: 0.5,
+  resolutionScale: 1,
+  renderBackendPreference: "webgpu",
 };
 
 const QUALITY_OPTIONS = [
@@ -58,6 +60,14 @@ const QUALITY_OPTIONS = [
   { value: 0.75, label: "75%" },
   { value: 1, label: "100%" },
 ] as const;
+
+const BACKEND_OPTIONS: ReadonlyArray<{
+  value: RenderBackendPreference;
+  label: string;
+}> = [
+  { value: "webgpu", label: "WebGPU" },
+  { value: "cpu", label: "CPU" },
+];
 
 const sectionTitleClass = "text-heading-sm text-white";
 const metaValueClass = "break-all text-sm text-cyan-100";
@@ -285,6 +295,26 @@ export function MandelbrotExplorer() {
               <h2 className={sectionTitleClass}>Render settings</h2>
               <div className="mt-3 grid gap-3">
                 <label className="text-sm text-gray-200">
+                  <span>Render backend</span>
+                  <select
+                    value={settings.renderBackendPreference}
+                    onChange={(event) =>
+                      setSettings((currentSettings) => ({
+                        ...currentSettings,
+                        renderBackendPreference: event.target
+                          .value as RenderBackendPreference,
+                      }))
+                    }
+                    className="mt-1 w-full rounded-md border border-white/15 bg-slate-950 px-3 py-2 text-white"
+                  >
+                    {BACKEND_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="text-sm text-gray-200">
                   <span>Max iterations</span>
                   <input
                     type="number"
@@ -467,8 +497,8 @@ export function MandelbrotExplorer() {
                 frames whenever the view changes.
               </li>
               <li>
-                The URL mirrors the current center, width, palette, quality, and
-                iteration budget for shareable deep links.
+                The URL mirrors the current center, width, backend, palette,
+                quality, and iteration budget for shareable deep links.
               </li>
             </ul>
           </Surface>

--- a/src/app/experimental/mandelbrot/_components/__tests__/MandelbrotExplorer.test.tsx
+++ b/src/app/experimental/mandelbrot/_components/__tests__/MandelbrotExplorer.test.tsx
@@ -28,7 +28,8 @@ describe("MandelbrotExplorer", () => {
       screen.getByLabelText("Mandelbrot set rendering canvas")
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
-    expect(screen.getByLabelText(/Max iterations/i)).toHaveValue(180);
+    expect(screen.getByLabelText(/Render backend/i)).toHaveValue("webgpu");
+    expect(screen.getByLabelText(/Max iterations/i)).toHaveValue(2000);
   });
 
   it("updates the viewport metadata when zoom controls are used", () => {
@@ -80,11 +81,15 @@ describe("MandelbrotExplorer", () => {
     fireEvent.change(screen.getByLabelText(/Max iterations/i), {
       target: { value: "320" },
     });
+    fireEvent.change(screen.getByLabelText(/Render backend/i), {
+      target: { value: "cpu" },
+    });
     fireEvent.change(screen.getByLabelText(/Render quality/i), {
       target: { value: "1" },
     });
 
     expect(screen.getByLabelText(/Max iterations/i)).toHaveValue(320);
+    expect(screen.getByLabelText(/Render backend/i)).toHaveValue("cpu");
     expect(screen.getByLabelText(/Render quality/i)).toHaveValue("1");
 
     await waitFor(() => {
@@ -92,6 +97,9 @@ describe("MandelbrotExplorer", () => {
     });
     expect(replaceStateSpy.mock.calls.at(-1)?.[2]?.toString()).toContain(
       "iter=320"
+    );
+    expect(replaceStateSpy.mock.calls.at(-1)?.[2]?.toString()).toContain(
+      "backend=cpu"
     );
 
     replaceStateSpy.mockRestore();

--- a/src/app/experimental/mandelbrot/_components/__tests__/MandelbrotExplorer.test.tsx
+++ b/src/app/experimental/mandelbrot/_components/__tests__/MandelbrotExplorer.test.tsx
@@ -6,30 +6,59 @@ import {
   waitFor,
 } from "@testing-library/react";
 
+import { detectWebGpuAvailability } from "@/features/mandelbrot/gpu";
+
 import { MandelbrotExplorer } from "../MandelbrotExplorer";
 
 jest.mock("next/navigation", () => ({
   usePathname: jest.fn(() => "/experimental/mandelbrot/"),
 }));
 
+jest.mock("@/features/mandelbrot/gpu", () => ({
+  ...jest.requireActual("@/features/mandelbrot/gpu"),
+  detectWebGpuAvailability: jest.fn(),
+}));
+
+const mockedDetectWebGpuAvailability = jest.mocked(detectWebGpuAvailability);
+
 describe("MandelbrotExplorer", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", "/experimental/mandelbrot/");
+    mockedDetectWebGpuAvailability.mockReset();
+    mockedDetectWebGpuAvailability.mockResolvedValue({
+      isAvailable: false,
+    });
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it("renders the canvas shell and explorer controls", () => {
+  it("renders the canvas shell and explorer controls", async () => {
     render(<MandelbrotExplorer />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Max iterations/i)).toHaveValue(180);
+    });
     expect(
       screen.getByLabelText("Mandelbrot set rendering canvas")
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
-    expect(screen.getByLabelText(/Render backend/i)).toHaveValue("webgpu");
-    expect(screen.getByLabelText(/Max iterations/i)).toHaveValue(2000);
+    expect(screen.getByLabelText(/Render backend/i)).toHaveValue("auto");
+  });
+
+  it("uses the higher quality defaults when WebGPU is available", async () => {
+    mockedDetectWebGpuAvailability.mockResolvedValue({
+      isAvailable: true,
+    });
+
+    render(<MandelbrotExplorer />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Max iterations/i)).toHaveValue(2000);
+    });
+    expect(screen.getByLabelText(/Render backend/i)).toHaveValue("auto");
+    expect(screen.getByLabelText(/Render quality/i)).toHaveValue("1");
   });
 
   it("updates the viewport metadata when zoom controls are used", () => {
@@ -78,6 +107,10 @@ describe("MandelbrotExplorer", () => {
 
     render(<MandelbrotExplorer />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Max iterations/i)).toHaveValue(180);
+    });
+
     fireEvent.change(screen.getByLabelText(/Max iterations/i), {
       target: { value: "320" },
     });
@@ -93,11 +126,10 @@ describe("MandelbrotExplorer", () => {
     expect(screen.getByLabelText(/Render quality/i)).toHaveValue("1");
 
     await waitFor(() => {
-      expect(replaceStateSpy).toHaveBeenCalled();
+      expect(replaceStateSpy.mock.calls.at(-1)?.[2]?.toString()).toContain(
+        "iter=320"
+      );
     });
-    expect(replaceStateSpy.mock.calls.at(-1)?.[2]?.toString()).toContain(
-      "iter=320"
-    );
     expect(replaceStateSpy.mock.calls.at(-1)?.[2]?.toString()).toContain(
       "backend=cpu"
     );

--- a/src/features/mandelbrot/__tests__/gpu.test.ts
+++ b/src/features/mandelbrot/__tests__/gpu.test.ts
@@ -1,0 +1,39 @@
+import Decimal from "decimal.js";
+
+import { canRenderViewportWithWebGpu } from "@/features/mandelbrot/gpu";
+
+describe("canRenderViewportWithWebGpu", () => {
+  it("keeps auto mode on WebGPU at the old relaxed boundary", () => {
+    expect(
+      canRenderViewportWithWebGpu(
+        {
+          centerX: new Decimal(-0.75),
+          centerY: new Decimal(0),
+          width: new Decimal("0.00005"),
+          height: new Decimal("0.00003125"),
+        },
+        {
+          width: 960,
+          height: 600,
+        }
+      )
+    ).toBe(true);
+  });
+
+  it("switches auto mode back to CPU once the pixel step drops below the float32 cushion", () => {
+    expect(
+      canRenderViewportWithWebGpu(
+        {
+          centerX: new Decimal(-0.75),
+          centerY: new Decimal(0),
+          width: new Decimal("0.00002"),
+          height: new Decimal("0.0000125"),
+        },
+        {
+          width: 960,
+          height: 600,
+        }
+      )
+    ).toBe(false);
+  });
+});

--- a/src/features/mandelbrot/__tests__/renderer.test.ts
+++ b/src/features/mandelbrot/__tests__/renderer.test.ts
@@ -4,10 +4,14 @@ import {
   detectWebGpuAvailability,
   renderMandelbrotWithWebGpu,
 } from "@/features/mandelbrot/gpu";
-import { renderMandelbrotWithStrategy } from "@/features/mandelbrot/renderer";
+import {
+  renderMandelbrotWithStrategy,
+  shouldAttemptWebGpu,
+} from "@/features/mandelbrot/renderer";
 import { RenderRequest } from "@/features/mandelbrot/types";
 
 jest.mock("@/features/mandelbrot/gpu", () => ({
+  ...jest.requireActual("@/features/mandelbrot/gpu"),
   detectWebGpuAvailability: jest.fn(),
   renderMandelbrotWithWebGpu: jest.fn(),
 }));
@@ -34,7 +38,7 @@ function createRenderRequest(): RenderRequest {
       paletteId: "oceanic",
       coloringMode: "smooth",
       resolutionScale: 1,
-      renderBackendPreference: "webgpu",
+      renderBackendPreference: "auto",
     },
     onChunk: jest.fn(),
     onProgress: jest.fn(),
@@ -47,7 +51,7 @@ describe("renderMandelbrotWithStrategy", () => {
     mockedRenderMandelbrotWithWebGpu.mockReset();
   });
 
-  it("uses the WebGPU backend when GPU rendering completes", async () => {
+  it("uses the WebGPU backend in auto mode when the viewport stays within the float32 cutoff", async () => {
     mockedDetectWebGpuAvailability.mockResolvedValue({
       isAvailable: true,
     });
@@ -66,7 +70,7 @@ describe("renderMandelbrotWithStrategy", () => {
     });
   });
 
-  it("falls back to the CPU renderer when WebGPU is unavailable", async () => {
+  it("falls back to the CPU renderer in auto mode when WebGPU is unavailable", async () => {
     mockedDetectWebGpuAvailability.mockResolvedValue({
       isAvailable: false,
       reason: "No compatible WebGPU adapter was found.",
@@ -83,7 +87,7 @@ describe("renderMandelbrotWithStrategy", () => {
     expect(request.onChunk).toHaveBeenCalled();
   });
 
-  it("falls back to the CPU renderer when WebGPU setup fails mid-render", async () => {
+  it("falls back to the CPU renderer when auto mode hits a WebGPU failure mid-render", async () => {
     mockedDetectWebGpuAvailability.mockResolvedValue({
       isAvailable: true,
     });
@@ -127,6 +131,23 @@ describe("renderMandelbrotWithStrategy", () => {
     expect(request.onChunk).not.toHaveBeenCalled();
   });
 
+  it("uses the CPU renderer directly in auto mode once the float32 cutoff is exceeded", async () => {
+    const request = createRenderRequest();
+
+    request.viewport.width = new Decimal("1e-7");
+    request.viewport.height = new Decimal("6.666666666666667e-8");
+
+    expect(shouldAttemptWebGpu(request, "auto")).toBe(false);
+
+    const result = await renderMandelbrotWithStrategy(request, "auto");
+
+    expect(result.backend).toBe("cpu");
+    expect(result.completed).toBe(true);
+    expect(mockedDetectWebGpuAvailability).not.toHaveBeenCalled();
+    expect(mockedRenderMandelbrotWithWebGpu).not.toHaveBeenCalled();
+    expect(request.onChunk).toHaveBeenCalled();
+  });
+
   it("uses the CPU renderer directly when CPU is explicitly selected", async () => {
     const request = createRenderRequest();
     request.settings.renderBackendPreference = "cpu";
@@ -137,5 +158,30 @@ describe("renderMandelbrotWithStrategy", () => {
     expect(result.completed).toBe(true);
     expect(mockedDetectWebGpuAvailability).not.toHaveBeenCalled();
     expect(mockedRenderMandelbrotWithWebGpu).not.toHaveBeenCalled();
+  });
+
+  it("still attempts WebGPU when WebGPU is explicitly selected beyond the auto cutoff", async () => {
+    mockedDetectWebGpuAvailability.mockResolvedValue({
+      isAvailable: true,
+    });
+    mockedRenderMandelbrotWithWebGpu.mockResolvedValue({
+      completed: true,
+      rendered: true,
+    });
+
+    const request = createRenderRequest();
+
+    request.viewport.width = new Decimal("1e-7");
+    request.viewport.height = new Decimal("6.666666666666667e-8");
+    request.settings.renderBackendPreference = "webgpu";
+
+    expect(shouldAttemptWebGpu(request, "webgpu")).toBe(true);
+
+    const result = await renderMandelbrotWithStrategy(request, "webgpu");
+
+    expect(result.backend).toBe("webgpu");
+    expect(result.completed).toBe(true);
+    expect(mockedDetectWebGpuAvailability).toHaveBeenCalled();
+    expect(mockedRenderMandelbrotWithWebGpu).toHaveBeenCalledWith(request);
   });
 });

--- a/src/features/mandelbrot/__tests__/renderer.test.ts
+++ b/src/features/mandelbrot/__tests__/renderer.test.ts
@@ -1,0 +1,141 @@
+import Decimal from "decimal.js";
+
+import {
+  detectWebGpuAvailability,
+  renderMandelbrotWithWebGpu,
+} from "@/features/mandelbrot/gpu";
+import { renderMandelbrotWithStrategy } from "@/features/mandelbrot/renderer";
+import { RenderRequest } from "@/features/mandelbrot/types";
+
+jest.mock("@/features/mandelbrot/gpu", () => ({
+  detectWebGpuAvailability: jest.fn(),
+  renderMandelbrotWithWebGpu: jest.fn(),
+}));
+
+const mockedDetectWebGpuAvailability = jest.mocked(detectWebGpuAvailability);
+const mockedRenderMandelbrotWithWebGpu = jest.mocked(
+  renderMandelbrotWithWebGpu
+);
+
+function createRenderRequest(): RenderRequest {
+  return {
+    viewport: {
+      centerX: new Decimal(-0.75),
+      centerY: new Decimal(0),
+      width: new Decimal(3),
+      height: new Decimal(2),
+    },
+    size: {
+      width: 6,
+      height: 4,
+    },
+    settings: {
+      maxIterations: 32,
+      paletteId: "oceanic",
+      coloringMode: "smooth",
+      resolutionScale: 1,
+      renderBackendPreference: "webgpu",
+    },
+    onChunk: jest.fn(),
+    onProgress: jest.fn(),
+  };
+}
+
+describe("renderMandelbrotWithStrategy", () => {
+  beforeEach(() => {
+    mockedDetectWebGpuAvailability.mockReset();
+    mockedRenderMandelbrotWithWebGpu.mockReset();
+  });
+
+  it("uses the WebGPU backend when GPU rendering completes", async () => {
+    mockedDetectWebGpuAvailability.mockResolvedValue({
+      isAvailable: true,
+    });
+    mockedRenderMandelbrotWithWebGpu.mockResolvedValue({
+      completed: true,
+      rendered: true,
+    });
+
+    const request = createRenderRequest();
+    const result = await renderMandelbrotWithStrategy(request);
+
+    expect(result).toEqual({
+      completed: true,
+      backend: "webgpu",
+      gpuFallbackReason: undefined,
+    });
+  });
+
+  it("falls back to the CPU renderer when WebGPU is unavailable", async () => {
+    mockedDetectWebGpuAvailability.mockResolvedValue({
+      isAvailable: false,
+      reason: "No compatible WebGPU adapter was found.",
+    });
+
+    const request = createRenderRequest();
+    const result = await renderMandelbrotWithStrategy(request);
+
+    expect(result.backend).toBe("cpu");
+    expect(result.completed).toBe(true);
+    expect(result.gpuFallbackReason).toBe(
+      "No compatible WebGPU adapter was found."
+    );
+    expect(request.onChunk).toHaveBeenCalled();
+  });
+
+  it("falls back to the CPU renderer when WebGPU setup fails mid-render", async () => {
+    mockedDetectWebGpuAvailability.mockResolvedValue({
+      isAvailable: true,
+    });
+    mockedRenderMandelbrotWithWebGpu.mockResolvedValue({
+      completed: false,
+      rendered: false,
+      fallbackReason: "WebGPU device was lost.",
+    });
+
+    const request = createRenderRequest();
+    const result = await renderMandelbrotWithStrategy(request);
+
+    expect(result.backend).toBe("cpu");
+    expect(result.completed).toBe(true);
+    expect(result.gpuFallbackReason).toBe("WebGPU device was lost.");
+    expect(request.onChunk).toHaveBeenCalled();
+  });
+
+  it("does not fall back to CPU after an aborted GPU render has already started", async () => {
+    mockedDetectWebGpuAvailability.mockResolvedValue({
+      isAvailable: true,
+    });
+    mockedRenderMandelbrotWithWebGpu.mockResolvedValue({
+      completed: false,
+      rendered: true,
+    });
+
+    const abortController = new AbortController();
+    const request = createRenderRequest();
+
+    abortController.abort();
+    request.signal = abortController.signal;
+
+    const result = await renderMandelbrotWithStrategy(request);
+
+    expect(result).toEqual({
+      completed: false,
+      backend: "webgpu",
+      gpuFallbackReason: undefined,
+    });
+    expect(request.onChunk).not.toHaveBeenCalled();
+  });
+
+  it("uses the CPU renderer directly when CPU is explicitly selected", async () => {
+    const request = createRenderRequest();
+    request.settings.renderBackendPreference = "cpu";
+
+    const result = await renderMandelbrotWithStrategy(request, "cpu");
+
+    expect(result.backend).toBe("cpu");
+    expect(result.completed).toBe(true);
+    expect(mockedDetectWebGpuAvailability).not.toHaveBeenCalled();
+    expect(mockedRenderMandelbrotWithWebGpu).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/mandelbrot/gpu.ts
+++ b/src/features/mandelbrot/gpu.ts
@@ -1,0 +1,886 @@
+import {
+  ColoringMode,
+  PaletteId,
+  RenderRequest,
+} from "@/features/mandelbrot/types";
+
+type WebGpu = {
+  getPreferredCanvasFormat?: () => string;
+  requestAdapter: () => Promise<WebGpuAdapter | null>;
+};
+
+type WebGpuAdapter = {
+  requestDevice: () => Promise<WebGpuDevice>;
+};
+
+type WebGpuDevice = {
+  createBindGroup: (descriptor: WebGpuBindGroupDescriptor) => WebGpuBindGroup;
+  createBindGroupLayout: (
+    descriptor: WebGpuBindGroupLayoutDescriptor
+  ) => WebGpuBindGroupLayout;
+  createBuffer: (descriptor: WebGpuBufferDescriptor) => WebGpuBuffer;
+  createCommandEncoder: () => WebGpuCommandEncoder;
+  createComputePipeline: (
+    descriptor: WebGpuComputePipelineDescriptor
+  ) => WebGpuComputePipeline;
+  createPipelineLayout: (
+    descriptor: WebGpuPipelineLayoutDescriptor
+  ) => WebGpuPipelineLayout;
+  createRenderPipeline: (
+    descriptor: WebGpuRenderPipelineDescriptor
+  ) => WebGpuRenderPipeline;
+  createShaderModule: (
+    descriptor: WebGpuShaderModuleDescriptor
+  ) => WebGpuShaderModule;
+  queue: WebGpuQueue;
+};
+
+type WebGpuQueue = {
+  submit: (commandBuffers: unknown[]) => void;
+  writeBuffer: (
+    buffer: WebGpuBuffer,
+    bufferOffset: number,
+    data: ArrayBufferLike | ArrayBufferView
+  ) => void;
+};
+
+type WebGpuBuffer = {
+  destroy: () => void;
+  getMappedRange: () => ArrayBufferLike;
+  mapAsync: (mode: number) => Promise<void>;
+  unmap: () => void;
+};
+
+type WebGpuCommandEncoder = {
+  beginComputePass: () => WebGpuComputePassEncoder;
+  beginRenderPass: (
+    descriptor: WebGpuRenderPassDescriptor
+  ) => WebGpuRenderPassEncoder;
+  copyBufferToBuffer: (
+    source: WebGpuBuffer,
+    sourceOffset: number,
+    destination: WebGpuBuffer,
+    destinationOffset: number,
+    size: number
+  ) => void;
+  finish: () => unknown;
+};
+
+type WebGpuComputePassEncoder = {
+  dispatchWorkgroups: (
+    workgroupCountX: number,
+    workgroupCountY?: number,
+    workgroupCountZ?: number
+  ) => void;
+  end: () => void;
+  setBindGroup: (index: number, bindGroup: WebGpuBindGroup) => void;
+  setPipeline: (pipeline: WebGpuComputePipeline) => void;
+};
+
+type WebGpuRenderPassEncoder = {
+  draw: (vertexCount: number, instanceCount?: number) => void;
+  end: () => void;
+  setBindGroup: (index: number, bindGroup: WebGpuBindGroup) => void;
+  setPipeline: (pipeline: WebGpuRenderPipeline) => void;
+};
+
+type WebGpuCanvasContext = {
+  configure: (descriptor: WebGpuCanvasConfiguration) => void;
+  getCurrentTexture: () => WebGpuTexture;
+};
+
+type WebGpuShaderModule = object;
+type WebGpuComputePipeline = object;
+type WebGpuRenderPipeline = object;
+type WebGpuBindGroupLayout = object;
+type WebGpuBindGroup = object;
+type WebGpuPipelineLayout = object;
+type WebGpuTextureView = object;
+
+type WebGpuTexture = {
+  createView: () => WebGpuTextureView;
+  destroy?: () => void;
+};
+
+type WebGpuBufferDescriptor = {
+  mappedAtCreation?: boolean;
+  size: number;
+  usage: number;
+};
+
+type WebGpuShaderModuleDescriptor = {
+  code: string;
+};
+
+type WebGpuBindGroupLayoutDescriptor = {
+  entries: ReadonlyArray<WebGpuBindGroupLayoutEntry>;
+};
+
+type WebGpuBindGroupLayoutEntry = {
+  binding: number;
+  buffer: {
+    type: "read-only-storage" | "storage";
+  };
+  visibility: number;
+};
+
+type WebGpuPipelineLayoutDescriptor = {
+  bindGroupLayouts: ReadonlyArray<WebGpuBindGroupLayout>;
+};
+
+type WebGpuComputePipelineDescriptor = {
+  compute: {
+    entryPoint: string;
+    module: WebGpuShaderModule;
+  };
+  layout: WebGpuPipelineLayout;
+};
+
+type WebGpuRenderPipelineDescriptor = {
+  fragment: {
+    entryPoint: string;
+    module: WebGpuShaderModule;
+    targets: ReadonlyArray<{
+      format: string;
+    }>;
+  };
+  layout: WebGpuPipelineLayout;
+  primitive: {
+    topology: "triangle-list";
+  };
+  vertex: {
+    entryPoint: string;
+    module: WebGpuShaderModule;
+  };
+};
+
+type WebGpuBindGroupDescriptor = {
+  entries: ReadonlyArray<WebGpuBindGroupEntry>;
+  layout: WebGpuBindGroupLayout;
+};
+
+type WebGpuBindGroupEntry = {
+  binding: number;
+  resource: {
+    buffer: WebGpuBuffer;
+  };
+};
+
+type WebGpuCanvasConfiguration = {
+  alphaMode: "opaque" | "premultiplied";
+  device: WebGpuDevice;
+  format: string;
+};
+
+type WebGpuRenderPassDescriptor = {
+  colorAttachments: ReadonlyArray<{
+    clearValue: {
+      a: number;
+      b: number;
+      g: number;
+      r: number;
+    };
+    loadOp: "clear" | "load";
+    storeOp: "store";
+    view: WebGpuTextureView;
+  }>;
+};
+
+export type WebGpuAvailability = {
+  isAvailable: boolean;
+  reason?: string;
+};
+
+export type WebGpuRenderResult = {
+  completed: boolean;
+  rendered: boolean;
+  fallbackReason?: string;
+};
+
+type WebGpuRendererState = {
+  canvasFormat: string;
+  bindGroupLayout: WebGpuBindGroupLayout;
+  device: WebGpuDevice;
+  pipeline: WebGpuComputePipeline;
+  presentationBindGroupLayout: WebGpuBindGroupLayout;
+  presentationPipeline: WebGpuRenderPipeline;
+};
+
+const GPU_BUFFER_USAGE_MAP_READ = 0x0001;
+const GPU_BUFFER_USAGE_COPY_SRC = 0x0004;
+const GPU_BUFFER_USAGE_COPY_DST = 0x0008;
+const GPU_BUFFER_USAGE_STORAGE = 0x0080;
+const GPU_SHADER_STAGE_COMPUTE = 0x0004;
+const GPU_MAP_MODE_READ = 0x0001;
+const WORKGROUP_SIZE = 8;
+const GPU_ROWS_PER_CHUNK = 24;
+const GPU_SHADER_STAGE_FRAGMENT = 0x0002;
+const DEFAULT_WEBGPU_CANVAS_FORMAT = "bgra8unorm";
+
+const PALETTE_IDS: Readonly<Record<PaletteId, number>> = {
+  oceanic: 0,
+  ember: 1,
+  glacier: 2,
+};
+
+const COLORING_MODE_IDS: Readonly<Record<ColoringMode, number>> = {
+  smooth: 0,
+  bands: 1,
+};
+
+const SHADER_CODE = /* wgsl */ `
+@group(0) @binding(0) var<storage, read> settings: array<u32>;
+@group(0) @binding(1) var<storage, read> viewport: array<f32>;
+@group(0) @binding(2) var<storage, read_write> pixels: array<u32>;
+
+const ESCAPE_RADIUS_SQUARED: f32 = 4.0;
+const LOG_2: f32 = 0.6931471805599453;
+
+fn interiorColor() -> vec3<u32> {
+  return vec3<u32>(4u, 8u, 22u);
+}
+
+fn paletteColorAt(paletteIndex: u32, value: f32) -> vec3<u32> {
+  let oceanic = array<vec3<f32>, 6>(
+    vec3<f32>(7.0, 12.0, 28.0),
+    vec3<f32>(15.0, 44.0, 78.0),
+    vec3<f32>(24.0, 88.0, 138.0),
+    vec3<f32>(53.0, 136.0, 186.0),
+    vec3<f32>(155.0, 209.0, 229.0),
+    vec3<f32>(246.0, 246.0, 210.0)
+  );
+  let ember = array<vec3<f32>, 6>(
+    vec3<f32>(24.0, 7.0, 30.0),
+    vec3<f32>(76.0, 15.0, 56.0),
+    vec3<f32>(145.0, 36.0, 49.0),
+    vec3<f32>(212.0, 86.0, 38.0),
+    vec3<f32>(247.0, 157.0, 61.0),
+    vec3<f32>(255.0, 233.0, 148.0)
+  );
+  let glacier = array<vec3<f32>, 6>(
+    vec3<f32>(7.0, 14.0, 28.0),
+    vec3<f32>(23.0, 54.0, 87.0),
+    vec3<f32>(45.0, 105.0, 134.0),
+    vec3<f32>(92.0, 165.0, 168.0),
+    vec3<f32>(170.0, 219.0, 202.0),
+    vec3<f32>(243.0, 250.0, 244.0)
+  );
+
+  let clamped = clamp(value, 0.0, 1.0);
+  let scaled = clamped * 5.0;
+  let leftIndex = min(u32(floor(scaled)), 5u);
+  let rightIndex = min(leftIndex + 1u, 5u);
+  let amount = scaled - f32(leftIndex);
+
+  var left = oceanic[leftIndex];
+  var right = oceanic[rightIndex];
+
+  if (paletteIndex == 1u) {
+    left = ember[leftIndex];
+    right = ember[rightIndex];
+  } else if (paletteIndex == 2u) {
+    left = glacier[leftIndex];
+    right = glacier[rightIndex];
+  }
+
+  let color = left + (right - left) * amount;
+
+  return vec3<u32>(
+    u32(round(color.x)),
+    u32(round(color.y)),
+    u32(round(color.z))
+  );
+}
+
+fn packColor(color: vec3<u32>) -> u32 {
+  return color.x | (color.y << 8u) | (color.z << 16u) | (255u << 24u);
+}
+
+@compute @workgroup_size(${WORKGROUP_SIZE}, ${WORKGROUP_SIZE}, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let width = settings[0];
+  let height = settings[1];
+
+  if (gid.x >= width || gid.y >= height) {
+    return;
+  }
+
+  let maxIterations = settings[2];
+  let paletteIndex = settings[3];
+  let coloringMode = settings[4];
+  let left = viewport[0];
+  let top = viewport[1];
+  let stepX = viewport[2];
+  let stepY = viewport[3];
+  let cx = left + stepX * (f32(gid.x) + 0.5);
+  let cy = top - stepY * (f32(gid.y) + 0.5);
+  let index = gid.y * width + gid.x;
+
+  var zx = 0.0;
+  var zy = 0.0;
+  var magnitudeSquared = 0.0;
+  var escaped = false;
+  var escapedIterations = maxIterations;
+  var smoothIteration = f32(maxIterations);
+
+  for (var iteration = 0u; iteration < maxIterations; iteration = iteration + 1u) {
+    let zxSquared = zx * zx;
+    let zySquared = zy * zy;
+    let nextZy = 2.0 * zx * zy + cy;
+    let nextZx = zxSquared - zySquared + cx;
+
+    zx = nextZx;
+    zy = nextZy;
+    magnitudeSquared = zx * zx + zy * zy;
+
+    if (magnitudeSquared > ESCAPE_RADIUS_SQUARED) {
+      escaped = true;
+      escapedIterations = iteration + 1u;
+
+      if (magnitudeSquared > 1.0) {
+        smoothIteration =
+          f32(escapedIterations) +
+          1.0 -
+          log(log(sqrt(magnitudeSquared))) / LOG_2;
+      } else {
+        smoothIteration = f32(escapedIterations);
+      }
+
+      break;
+    }
+  }
+
+  if (!escaped) {
+    pixels[index] = packColor(interiorColor());
+    return;
+  }
+
+  var normalizedValue = smoothIteration / f32(maxIterations);
+
+  if (coloringMode == 1u) {
+    normalizedValue = f32(escapedIterations) / f32(maxIterations);
+  }
+
+  pixels[index] = packColor(paletteColorAt(paletteIndex, normalizedValue));
+}
+`;
+
+const PRESENTATION_SHADER_CODE = /* wgsl */ `
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+@group(0) @binding(0) var<storage, read> settings: array<u32>;
+@group(0) @binding(1) var<storage, read> pixels: array<u32>;
+
+@vertex
+fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
+  let positions = array<vec2<f32>, 6>(
+    vec2<f32>(-1.0, 1.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(1.0, -1.0)
+  );
+  let uvs = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(1.0, 1.0)
+  );
+
+  var output: VertexOutput;
+  output.position = vec4<f32>(positions[vertexIndex], 0.0, 1.0);
+  output.uv = uvs[vertexIndex];
+  return output;
+}
+
+fn unpackColor(value: u32) -> vec4<f32> {
+  let red = f32(value & 255u) / 255.0;
+  let green = f32((value >> 8u) & 255u) / 255.0;
+  let blue = f32((value >> 16u) & 255u) / 255.0;
+  let alpha = f32((value >> 24u) & 255u) / 255.0;
+
+  return vec4<f32>(red, green, blue, alpha);
+}
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  let width = settings[0];
+  let height = settings[1];
+  let x = min(u32(clamp(input.uv.x, 0.0, 0.999999) * f32(width)), width - 1u);
+  let y = min(u32(clamp(input.uv.y, 0.0, 0.999999) * f32(height)), height - 1u);
+  let color = pixels[y * width + x];
+
+  return unpackColor(color);
+}
+`;
+
+let rendererStatePromise: Promise<WebGpuRendererState> | null = null;
+
+function getNavigatorGpu(): WebGpu | null {
+  if (typeof navigator === "undefined" || !("gpu" in navigator)) {
+    return null;
+  }
+
+  return (navigator as Navigator & { gpu?: WebGpu }).gpu ?? null;
+}
+
+function getCanvasWebGpuContext(
+  canvas: HTMLCanvasElement
+): WebGpuCanvasContext | null {
+  return (canvas.getContext("webgpu") as WebGpuCanvasContext | null) ?? null;
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+      return;
+    }
+
+    setTimeout(resolve, 0);
+  });
+}
+
+async function createRendererState(): Promise<WebGpuRendererState> {
+  const gpu = getNavigatorGpu();
+
+  if (!gpu) {
+    throw new Error("WebGPU API is unavailable in this browser.");
+  }
+
+  const adapter = await gpu.requestAdapter();
+
+  if (!adapter) {
+    throw new Error("No compatible WebGPU adapter was found.");
+  }
+
+  const device = await adapter.requestDevice();
+  const computeShaderModule = device.createShaderModule({
+    code: SHADER_CODE,
+  });
+  const presentationShaderModule = device.createShaderModule({
+    code: PRESENTATION_SHADER_CODE,
+  });
+  const bindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPU_SHADER_STAGE_COMPUTE,
+        buffer: {
+          type: "read-only-storage",
+        },
+      },
+      {
+        binding: 1,
+        visibility: GPU_SHADER_STAGE_COMPUTE,
+        buffer: {
+          type: "read-only-storage",
+        },
+      },
+      {
+        binding: 2,
+        visibility: GPU_SHADER_STAGE_COMPUTE,
+        buffer: {
+          type: "storage",
+        },
+      },
+    ],
+  });
+  const pipelineLayout = device.createPipelineLayout({
+    bindGroupLayouts: [bindGroupLayout],
+  });
+  const pipeline = device.createComputePipeline({
+    layout: pipelineLayout,
+    compute: {
+      module: computeShaderModule,
+      entryPoint: "main",
+    },
+  });
+  const presentationBindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPU_SHADER_STAGE_FRAGMENT,
+        buffer: {
+          type: "read-only-storage",
+        },
+      },
+      {
+        binding: 1,
+        visibility: GPU_SHADER_STAGE_FRAGMENT,
+        buffer: {
+          type: "read-only-storage",
+        },
+      },
+    ],
+  });
+  const presentationPipelineLayout = device.createPipelineLayout({
+    bindGroupLayouts: [presentationBindGroupLayout],
+  });
+  const canvasFormat =
+    gpu.getPreferredCanvasFormat?.() ?? DEFAULT_WEBGPU_CANVAS_FORMAT;
+  const presentationPipeline = device.createRenderPipeline({
+    layout: presentationPipelineLayout,
+    vertex: {
+      module: presentationShaderModule,
+      entryPoint: "vertexMain",
+    },
+    fragment: {
+      module: presentationShaderModule,
+      entryPoint: "fragmentMain",
+      targets: [
+        {
+          format: canvasFormat,
+        },
+      ],
+    },
+    primitive: {
+      topology: "triangle-list",
+    },
+  });
+
+  return {
+    canvasFormat,
+    bindGroupLayout,
+    device,
+    pipeline,
+    presentationBindGroupLayout,
+    presentationPipeline,
+  };
+}
+
+async function getRendererState(): Promise<WebGpuRendererState> {
+  if (!rendererStatePromise) {
+    rendererStatePromise = createRendererState().catch((error) => {
+      rendererStatePromise = null;
+      throw error;
+    });
+  }
+
+  return rendererStatePromise;
+}
+
+function unpackPixels(packedPixels: Uint32Array): Uint8ClampedArray {
+  const unpackedPixels = new Uint8ClampedArray(packedPixels.length * 4);
+
+  for (let index = 0; index < packedPixels.length; index += 1) {
+    const value = packedPixels[index];
+    const outputIndex = index * 4;
+
+    unpackedPixels[outputIndex] = value & 0xff;
+    unpackedPixels[outputIndex + 1] = (value >>> 8) & 0xff;
+    unpackedPixels[outputIndex + 2] = (value >>> 16) & 0xff;
+    unpackedPixels[outputIndex + 3] = (value >>> 24) & 0xff;
+  }
+
+  return unpackedPixels;
+}
+
+function presentPixelsToCanvas(
+  device: WebGpuDevice,
+  commandEncoder: WebGpuCommandEncoder,
+  canvas: HTMLCanvasElement,
+  canvasFormat: string,
+  presentationBindGroupLayout: WebGpuBindGroupLayout,
+  presentationPipeline: WebGpuRenderPipeline,
+  settingsBuffer: WebGpuBuffer,
+  outputBuffer: WebGpuBuffer
+): boolean {
+  const context = getCanvasWebGpuContext(canvas);
+
+  if (!context) {
+    return false;
+  }
+
+  context.configure({
+    device,
+    format: canvasFormat,
+    alphaMode: "opaque",
+  });
+
+  const presentationBindGroup = device.createBindGroup({
+    layout: presentationBindGroupLayout,
+    entries: [
+      {
+        binding: 0,
+        resource: {
+          buffer: settingsBuffer,
+        },
+      },
+      {
+        binding: 1,
+        resource: {
+          buffer: outputBuffer,
+        },
+      },
+    ],
+  });
+  const currentTextureView = context.getCurrentTexture().createView();
+  const renderPass = commandEncoder.beginRenderPass({
+    colorAttachments: [
+      {
+        view: currentTextureView,
+        clearValue: {
+          r: 0.011764705882352941,
+          g: 0.027450980392156862,
+          b: 0.07058823529411765,
+          a: 1,
+        },
+        loadOp: "clear",
+        storeOp: "store",
+      },
+    ],
+  });
+
+  renderPass.setPipeline(presentationPipeline);
+  renderPass.setBindGroup(0, presentationBindGroup);
+  renderPass.draw(6);
+  renderPass.end();
+
+  return true;
+}
+
+export async function detectWebGpuAvailability(): Promise<WebGpuAvailability> {
+  if (typeof navigator === "undefined") {
+    return {
+      isAvailable: false,
+      reason: "Navigator is unavailable in this environment.",
+    };
+  }
+
+  const gpu = getNavigatorGpu();
+
+  if (!gpu) {
+    return {
+      isAvailable: false,
+      reason: "WebGPU API is unavailable in this browser.",
+    };
+  }
+
+  const adapter = await gpu.requestAdapter();
+
+  if (!adapter) {
+    return {
+      isAvailable: false,
+      reason: "No compatible WebGPU adapter was found.",
+    };
+  }
+
+  return {
+    isAvailable: true,
+  };
+}
+
+export async function renderMandelbrotWithWebGpu(
+  renderRequest: RenderRequest
+): Promise<WebGpuRenderResult> {
+  if (renderRequest.signal?.aborted) {
+    return {
+      completed: false,
+      rendered: true,
+    };
+  }
+
+  try {
+    const {
+      canvasFormat,
+      device,
+      bindGroupLayout,
+      pipeline,
+      presentationBindGroupLayout,
+      presentationPipeline,
+    } = await getRendererState();
+
+    if (renderRequest.signal?.aborted) {
+      return {
+        completed: false,
+        rendered: true,
+      };
+    }
+
+    const safeWidth = Math.max(1, Math.round(renderRequest.size.width));
+    const safeHeight = Math.max(1, Math.round(renderRequest.size.height));
+    const left = renderRequest.viewport.centerX
+      .sub(renderRequest.viewport.width.div(2))
+      .toNumber();
+    const top = renderRequest.viewport.centerY
+      .add(renderRequest.viewport.height.div(2))
+      .toNumber();
+    const stepX = renderRequest.viewport.width.div(safeWidth).toNumber();
+    const stepY = renderRequest.viewport.height.div(safeHeight).toNumber();
+    const settingsData = new Uint32Array([
+      safeWidth,
+      safeHeight,
+      renderRequest.settings.maxIterations,
+      PALETTE_IDS[renderRequest.settings.paletteId],
+      COLORING_MODE_IDS[renderRequest.settings.coloringMode],
+    ]);
+    const viewportData = new Float32Array([left, top, stepX, stepY]);
+    const outputBytes = safeWidth * safeHeight * Uint32Array.BYTES_PER_ELEMENT;
+    const settingsBuffer = device.createBuffer({
+      size: settingsData.byteLength,
+      usage: GPU_BUFFER_USAGE_STORAGE | GPU_BUFFER_USAGE_COPY_DST,
+    });
+    const viewportBuffer = device.createBuffer({
+      size: viewportData.byteLength,
+      usage: GPU_BUFFER_USAGE_STORAGE | GPU_BUFFER_USAGE_COPY_DST,
+    });
+    const outputBuffer = device.createBuffer({
+      size: outputBytes,
+      usage: GPU_BUFFER_USAGE_STORAGE | GPU_BUFFER_USAGE_COPY_SRC,
+    });
+    const readbackBuffer = device.createBuffer({
+      size: outputBytes,
+      usage: GPU_BUFFER_USAGE_COPY_DST | GPU_BUFFER_USAGE_MAP_READ,
+    });
+
+    try {
+      const bindGroup = device.createBindGroup({
+        layout: bindGroupLayout,
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: settingsBuffer,
+            },
+          },
+          {
+            binding: 1,
+            resource: {
+              buffer: viewportBuffer,
+            },
+          },
+          {
+            binding: 2,
+            resource: {
+              buffer: outputBuffer,
+            },
+          },
+        ],
+      });
+
+      device.queue.writeBuffer(settingsBuffer, 0, settingsData);
+      device.queue.writeBuffer(viewportBuffer, 0, viewportData);
+      renderRequest.onProgress?.(0.15);
+
+      const commandEncoder = device.createCommandEncoder();
+      const passEncoder = commandEncoder.beginComputePass();
+
+      passEncoder.setPipeline(pipeline);
+      passEncoder.setBindGroup(0, bindGroup);
+      passEncoder.dispatchWorkgroups(
+        Math.ceil(safeWidth / WORKGROUP_SIZE),
+        Math.ceil(safeHeight / WORKGROUP_SIZE)
+      );
+      passEncoder.end();
+      const presentedDirectly =
+        renderRequest.gpuTargetCanvas &&
+        presentPixelsToCanvas(
+          device,
+          commandEncoder,
+          renderRequest.gpuTargetCanvas,
+          canvasFormat,
+          presentationBindGroupLayout,
+          presentationPipeline,
+          settingsBuffer,
+          outputBuffer
+        );
+
+      if (presentedDirectly) {
+        device.queue.submit([commandEncoder.finish()]);
+        renderRequest.onProgress?.(1);
+
+        return {
+          completed: true,
+          rendered: true,
+        };
+      }
+
+      commandEncoder.copyBufferToBuffer(
+        outputBuffer,
+        0,
+        readbackBuffer,
+        0,
+        outputBytes
+      );
+      device.queue.submit([commandEncoder.finish()]);
+      renderRequest.onProgress?.(0.45);
+
+      await readbackBuffer.mapAsync(GPU_MAP_MODE_READ);
+
+      if (renderRequest.signal?.aborted) {
+        return {
+          completed: false,
+          rendered: true,
+        };
+      }
+
+      const mappedRange = readbackBuffer.getMappedRange();
+      const packedPixels = new Uint32Array(mappedRange.slice(0));
+      const pixels = unpackPixels(packedPixels);
+
+      readbackBuffer.unmap();
+      renderRequest.onProgress?.(0.75);
+
+      for (
+        let startRow = 0;
+        startRow < safeHeight;
+        startRow += GPU_ROWS_PER_CHUNK
+      ) {
+        if (renderRequest.signal?.aborted) {
+          return {
+            completed: false,
+            rendered: true,
+          };
+        }
+
+        const rowCount = Math.min(GPU_ROWS_PER_CHUNK, safeHeight - startRow);
+        const pixelStart = startRow * safeWidth * 4;
+        const pixelEnd = pixelStart + safeWidth * rowCount * 4;
+
+        renderRequest.onChunk({
+          startRow,
+          rowCount,
+          pixels: pixels.slice(pixelStart, pixelEnd),
+        });
+        renderRequest.onProgress?.(
+          0.75 + ((startRow + rowCount) / safeHeight) * 0.25
+        );
+
+        await nextFrame();
+      }
+
+      return {
+        completed: true,
+        rendered: true,
+      };
+    } finally {
+      settingsBuffer.destroy();
+      viewportBuffer.destroy();
+      outputBuffer.destroy();
+
+      try {
+        readbackBuffer.unmap();
+      } catch {
+        // Ignore redundant unmap calls when the buffer was never mapped.
+      }
+
+      readbackBuffer.destroy();
+    }
+  } catch (error) {
+    return {
+      completed: false,
+      rendered: false,
+      fallbackReason:
+        error instanceof Error
+          ? error.message
+          : "WebGPU rendering failed unexpectedly.",
+    };
+  }
+}

--- a/src/features/mandelbrot/gpu.ts
+++ b/src/features/mandelbrot/gpu.ts
@@ -216,6 +216,9 @@ const WORKGROUP_SIZE = 8;
 const GPU_ROWS_PER_CHUNK = 24;
 const GPU_SHADER_STAGE_FRAGMENT = 0x0002;
 const DEFAULT_WEBGPU_CANVAS_FORMAT = "bgra8unorm";
+const FLOAT32_SIGNIFICAND_BITS = 23;
+const FLOAT32_MIN_SUBNORMAL = 2 ** -149;
+const AUTO_WEBGPU_ULP_CUSHION = 0.25;
 
 const PALETTE_IDS: Readonly<Record<PaletteId, number>> = {
   oceanic: 0,
@@ -227,6 +230,61 @@ const COLORING_MODE_IDS: Readonly<Record<ColoringMode, number>> = {
   smooth: 0,
   bands: 1,
 };
+
+function estimateFloat32Ulp(value: number): number {
+  const magnitude = Math.abs(value);
+
+  if (!Number.isFinite(magnitude)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  if (magnitude === 0) {
+    return FLOAT32_MIN_SUBNORMAL;
+  }
+
+  return 2 ** (Math.floor(Math.log2(magnitude)) - FLOAT32_SIGNIFICAND_BITS);
+}
+
+export function canRenderViewportWithWebGpu(
+  viewport: RenderRequest["viewport"],
+  size: RenderRequest["size"]
+): boolean {
+  const safeWidth = Math.max(1, Math.round(size.width));
+  const safeHeight = Math.max(1, Math.round(size.height));
+  const left = viewport.centerX.sub(viewport.width.div(2)).toNumber();
+  const right = viewport.centerX.add(viewport.width.div(2)).toNumber();
+  const top = viewport.centerY.add(viewport.height.div(2)).toNumber();
+  const bottom = viewport.centerY.sub(viewport.height.div(2)).toNumber();
+  const stepX = viewport.width.div(safeWidth).abs().toNumber();
+  const stepY = viewport.height.div(safeHeight).abs().toNumber();
+
+  if (
+    !Number.isFinite(left) ||
+    !Number.isFinite(right) ||
+    !Number.isFinite(top) ||
+    !Number.isFinite(bottom) ||
+    !Number.isFinite(stepX) ||
+    !Number.isFinite(stepY) ||
+    stepX <= 0 ||
+    stepY <= 0
+  ) {
+    return false;
+  }
+
+  // Clamp the coordinate scale to at least 1 so auto mode does not stay on
+  // WebGPU too aggressively when the view is numerically close to the origin.
+  const coordinateMagnitude = Math.max(
+    1,
+    Math.abs(left),
+    Math.abs(right),
+    Math.abs(top),
+    Math.abs(bottom)
+  );
+  const float32Ulp = estimateFloat32Ulp(coordinateMagnitude);
+  const smallestPixelStep = Math.min(stepX, stepY);
+
+  return smallestPixelStep >= float32Ulp * AUTO_WEBGPU_ULP_CUSHION;
+}
 
 const SHADER_CODE = /* wgsl */ `
 @group(0) @binding(0) var<storage, read> settings: array<u32>;

--- a/src/features/mandelbrot/renderer.ts
+++ b/src/features/mandelbrot/renderer.ts
@@ -1,10 +1,18 @@
 import {
+  detectWebGpuAvailability,
+  renderMandelbrotWithWebGpu,
+} from "@/features/mandelbrot/gpu";
+import {
   iterateMandelbrot,
   iterateMandelbrotNumber,
   shouldUseNumberIteration,
 } from "@/features/mandelbrot/mandelbrot";
 import { colorEscapeResult } from "@/features/mandelbrot/palettes";
-import { RenderRequest } from "@/features/mandelbrot/types";
+import {
+  RenderBackend,
+  RenderBackendPreference,
+  RenderRequest,
+} from "@/features/mandelbrot/types";
 import {
   configurePrecisionForWidth,
   mapPixelCenterToComplex,
@@ -13,6 +21,12 @@ import {
 
 const DECIMAL_ROWS_PER_CHUNK = 6;
 const NUMBER_ROWS_PER_CHUNK = 20;
+
+export type RenderExecutionResult = {
+  completed: boolean;
+  backend: RenderBackend;
+  gpuFallbackReason?: string;
+};
 
 function nextFrame(): Promise<void> {
   return new Promise((resolve) => {
@@ -97,6 +111,61 @@ export async function renderMandelbrot({
   }
 
   return true;
+}
+
+export async function renderMandelbrotWithStrategy(
+  request: RenderRequest,
+  backendPreference: RenderBackendPreference = "webgpu"
+): Promise<RenderExecutionResult> {
+  if (backendPreference === "webgpu") {
+    const gpuAvailability = await detectWebGpuAvailability();
+
+    if (gpuAvailability.isAvailable) {
+      const gpuRenderResult = await renderMandelbrotWithWebGpu(request);
+
+      if (gpuRenderResult.rendered) {
+        return {
+          completed: gpuRenderResult.completed,
+          backend: "webgpu",
+          gpuFallbackReason: gpuRenderResult.fallbackReason,
+        };
+      }
+
+      if (request.signal?.aborted) {
+        return {
+          completed: false,
+          backend: "cpu",
+          gpuFallbackReason: gpuRenderResult.fallbackReason,
+        };
+      }
+
+      const completedWithCpu = await renderMandelbrot(request);
+
+      return {
+        completed: completedWithCpu,
+        backend: "cpu",
+        gpuFallbackReason:
+          gpuRenderResult.fallbackReason ??
+          "WebGPU rendering failed, so the CPU renderer took over.",
+      };
+    }
+
+    const completedWithCpu = await renderMandelbrot(request);
+
+    return {
+      completed: completedWithCpu,
+      backend: "cpu",
+      gpuFallbackReason: gpuAvailability.reason,
+    };
+  }
+
+  const completedWithCpu = await renderMandelbrot(request);
+
+  return {
+    completed: completedWithCpu,
+    backend: "cpu",
+    gpuFallbackReason: undefined,
+  };
 }
 
 function renderDecimalPixel(

--- a/src/features/mandelbrot/renderer.ts
+++ b/src/features/mandelbrot/renderer.ts
@@ -1,4 +1,5 @@
 import {
+  canRenderViewportWithWebGpu,
   detectWebGpuAvailability,
   renderMandelbrotWithWebGpu,
 } from "@/features/mandelbrot/gpu";
@@ -27,6 +28,24 @@ export type RenderExecutionResult = {
   backend: RenderBackend;
   gpuFallbackReason?: string;
 };
+
+export function shouldAttemptWebGpu(
+  request: Pick<RenderRequest, "viewport" | "size">,
+  backendPreference: RenderBackendPreference = "auto"
+): boolean {
+  if (backendPreference === "cpu") {
+    return false;
+  }
+
+  if (backendPreference === "webgpu") {
+    return true;
+  }
+
+  return (
+    shouldUseNumberIteration(request.viewport.width) &&
+    canRenderViewportWithWebGpu(request.viewport, request.size)
+  );
+}
 
 function nextFrame(): Promise<void> {
   return new Promise((resolve) => {
@@ -115,9 +134,9 @@ export async function renderMandelbrot({
 
 export async function renderMandelbrotWithStrategy(
   request: RenderRequest,
-  backendPreference: RenderBackendPreference = "webgpu"
+  backendPreference: RenderBackendPreference = "auto"
 ): Promise<RenderExecutionResult> {
-  if (backendPreference === "webgpu") {
+  if (shouldAttemptWebGpu(request, backendPreference)) {
     const gpuAvailability = await detectWebGpuAvailability();
 
     if (gpuAvailability.isAvailable) {

--- a/src/features/mandelbrot/types.ts
+++ b/src/features/mandelbrot/types.ts
@@ -35,7 +35,7 @@ export type PaletteId = "oceanic" | "ember" | "glacier";
 export type ColoringMode = "smooth" | "bands";
 export type DragMode = "pan" | "box-zoom";
 export type RenderBackend = "cpu" | "webgpu";
-export type RenderBackendPreference = "cpu" | "webgpu";
+export type RenderBackendPreference = "auto" | "cpu" | "webgpu";
 
 export type MandelbrotSettings = {
   maxIterations: number;

--- a/src/features/mandelbrot/types.ts
+++ b/src/features/mandelbrot/types.ts
@@ -34,12 +34,15 @@ export type SelectionRect = {
 export type PaletteId = "oceanic" | "ember" | "glacier";
 export type ColoringMode = "smooth" | "bands";
 export type DragMode = "pan" | "box-zoom";
+export type RenderBackend = "cpu" | "webgpu";
+export type RenderBackendPreference = "cpu" | "webgpu";
 
 export type MandelbrotSettings = {
   maxIterations: number;
   paletteId: PaletteId;
   coloringMode: ColoringMode;
   resolutionScale: number;
+  renderBackendPreference: RenderBackendPreference;
 };
 
 export type EscapeResult = {
@@ -58,6 +61,7 @@ export type RenderRequest = {
   viewport: PreciseViewport;
   size: PixelSize;
   settings: MandelbrotSettings;
+  gpuTargetCanvas?: HTMLCanvasElement | null;
   signal?: AbortSignal;
   onChunk: (chunk: RenderChunk) => void;
   onProgress?: (progress: number) => void;

--- a/src/features/mandelbrot/urlState.ts
+++ b/src/features/mandelbrot/urlState.ts
@@ -4,6 +4,7 @@ import {
   PaletteId,
   PixelSize,
   PreciseViewport,
+  RenderBackendPreference,
 } from "@/features/mandelbrot/types";
 import { createViewport } from "@/features/mandelbrot/viewport";
 
@@ -17,6 +18,10 @@ const VALID_PALETTES: ReadonlySet<PaletteId> = new Set([
 const VALID_COLORING_MODES: ReadonlySet<ColoringMode> = new Set([
   "smooth",
   "bands",
+]);
+const VALID_RENDER_BACKENDS: ReadonlySet<RenderBackendPreference> = new Set([
+  "webgpu",
+  "cpu",
 ]);
 
 export function parseViewportFromQuery(
@@ -55,6 +60,7 @@ export function parseSettingsFromQuery(
   const resolutionScale = Number.parseFloat(String(searchParams.quality ?? ""));
   const paletteId = searchParams.palette;
   const coloringMode = searchParams.mode;
+  const renderBackendPreference = searchParams.backend;
 
   return {
     maxIterations:
@@ -75,6 +81,13 @@ export function parseSettingsFromQuery(
       Number.isFinite(resolutionScale) && resolutionScale >= 0.25
         ? Math.min(resolutionScale, 1)
         : fallback.resolutionScale,
+    renderBackendPreference:
+      typeof renderBackendPreference === "string" &&
+      VALID_RENDER_BACKENDS.has(
+        renderBackendPreference as RenderBackendPreference
+      )
+        ? (renderBackendPreference as RenderBackendPreference)
+        : fallback.renderBackendPreference,
   };
 }
 
@@ -91,6 +104,7 @@ export function serializeExplorerState(
   searchParams.set("palette", settings.paletteId);
   searchParams.set("mode", settings.coloringMode);
   searchParams.set("quality", settings.resolutionScale.toFixed(2));
+  searchParams.set("backend", settings.renderBackendPreference);
 
   return searchParams.toString();
 }

--- a/src/features/mandelbrot/urlState.ts
+++ b/src/features/mandelbrot/urlState.ts
@@ -20,6 +20,7 @@ const VALID_COLORING_MODES: ReadonlySet<ColoringMode> = new Set([
   "bands",
 ]);
 const VALID_RENDER_BACKENDS: ReadonlySet<RenderBackendPreference> = new Set([
+  "auto",
   "webgpu",
   "cpu",
 ]);

--- a/src/features/mandelbrot/useMandelbrotRender.ts
+++ b/src/features/mandelbrot/useMandelbrotRender.ts
@@ -2,7 +2,10 @@
 
 import { RefObject, useEffect, useState } from "react";
 
-import { renderMandelbrotWithStrategy } from "@/features/mandelbrot/renderer";
+import {
+  renderMandelbrotWithStrategy,
+  shouldAttemptWebGpu,
+} from "@/features/mandelbrot/renderer";
 import {
   MandelbrotSettings,
   PixelSize,
@@ -139,7 +142,13 @@ export function useMandelbrotRender({
         const buffer = document.createElement("canvas");
         const bufferSize = renderSizeForScale(size, scale);
         const bufferContext = buffer.getContext("2d");
-        const preferGpu = settings.renderBackendPreference === "webgpu";
+        const shouldUseGpu = shouldAttemptWebGpu(
+          {
+            viewport,
+            size: bufferSize,
+          },
+          settings.renderBackendPreference
+        );
 
         if (!bufferContext) {
           throw new Error("Unable to create an offscreen render buffer.");
@@ -148,7 +157,7 @@ export function useMandelbrotRender({
         buffer.width = bufferSize.width;
         buffer.height = bufferSize.height;
 
-        if (!preferGpu) {
+        if (!shouldUseGpu) {
           bufferContext.drawImage(
             renderingCanvas,
             0,
@@ -160,7 +169,7 @@ export function useMandelbrotRender({
           renderingContext.clearRect(0, 0, size.width, size.height);
         }
 
-        activeBackend = preferGpu ? "webgpu" : "cpu";
+        activeBackend = shouldUseGpu ? "webgpu" : "cpu";
 
         setRenderState({
           phase,

--- a/src/features/mandelbrot/useMandelbrotRender.ts
+++ b/src/features/mandelbrot/useMandelbrotRender.ts
@@ -2,11 +2,12 @@
 
 import { RefObject, useEffect, useState } from "react";
 
-import { renderMandelbrot } from "@/features/mandelbrot/renderer";
+import { renderMandelbrotWithStrategy } from "@/features/mandelbrot/renderer";
 import {
   MandelbrotSettings,
   PixelSize,
   PreciseViewport,
+  RenderBackend,
 } from "@/features/mandelbrot/types";
 
 export type RenderPhase = "idle" | "preview" | "refining" | "ready" | "error";
@@ -15,10 +16,12 @@ export type RenderState = {
   phase: RenderPhase;
   progress: number;
   message: string;
+  backend: RenderBackend;
 };
 
 type UseMandelbrotRenderInput = {
-  canvasRef: RefObject<HTMLCanvasElement | null>;
+  cpuCanvasRef: RefObject<HTMLCanvasElement | null>;
+  gpuCanvasRef: RefObject<HTMLCanvasElement | null>;
   viewport: PreciseViewport;
   settings: MandelbrotSettings;
   size: PixelSize;
@@ -32,7 +35,8 @@ function renderSizeForScale(size: PixelSize, scale: number): PixelSize {
 }
 
 export function useMandelbrotRender({
-  canvasRef,
+  cpuCanvasRef,
+  gpuCanvasRef,
   viewport,
   settings,
   size,
@@ -41,12 +45,14 @@ export function useMandelbrotRender({
     phase: "idle",
     progress: 0,
     message: "Waiting for canvas size.",
+    backend: "cpu",
   });
 
   useEffect(() => {
-    const canvas = canvasRef.current;
+    const canvas = cpuCanvasRef.current;
+    const gpuCanvas = gpuCanvasRef.current;
 
-    if (!canvas || size.width <= 0 || size.height <= 0) {
+    if (!canvas || !gpuCanvas || size.width <= 0 || size.height <= 0) {
       return;
     }
 
@@ -57,6 +63,7 @@ export function useMandelbrotRender({
         phase: "error",
         progress: 0,
         message: "Canvas 2D rendering is unavailable in this browser.",
+        backend: "cpu",
       });
       return;
     }
@@ -69,31 +76,49 @@ export function useMandelbrotRender({
         : [settings.resolutionScale];
     const renderingCanvas = canvas;
     const renderingContext = context;
+    const renderingGpuCanvas = gpuCanvas;
 
     let isMounted = true;
 
     async function runRender() {
+      let activeBackend: RenderBackend = "cpu";
       const previousFrame =
-        renderingCanvas.width > 0 && renderingCanvas.height > 0
+        (renderingCanvas.width > 0 && renderingCanvas.height > 0) ||
+        (renderingGpuCanvas.width > 0 && renderingGpuCanvas.height > 0)
           ? document.createElement("canvas")
           : null;
 
       if (previousFrame) {
-        previousFrame.width = renderingCanvas.width;
-        previousFrame.height = renderingCanvas.height;
-        previousFrame
-          .getContext("2d")
-          ?.drawImage(
-            renderingCanvas,
-            0,
-            0,
-            previousFrame.width,
-            previousFrame.height
-          );
+        previousFrame.width = Math.max(
+          renderingCanvas.width,
+          renderingGpuCanvas.width
+        );
+        previousFrame.height = Math.max(
+          renderingCanvas.height,
+          renderingGpuCanvas.height
+        );
+        const previousFrameContext = previousFrame.getContext("2d");
+
+        previousFrameContext?.drawImage(
+          renderingGpuCanvas,
+          0,
+          0,
+          previousFrame.width,
+          previousFrame.height
+        );
+        previousFrameContext?.drawImage(
+          renderingCanvas,
+          0,
+          0,
+          previousFrame.width,
+          previousFrame.height
+        );
       }
 
       renderingCanvas.width = size.width;
       renderingCanvas.height = size.height;
+      renderingGpuCanvas.width = size.width;
+      renderingGpuCanvas.height = size.height;
 
       if (previousFrame) {
         renderingContext.drawImage(
@@ -114,6 +139,7 @@ export function useMandelbrotRender({
         const buffer = document.createElement("canvas");
         const bufferSize = renderSizeForScale(size, scale);
         const bufferContext = buffer.getContext("2d");
+        const preferGpu = settings.renderBackendPreference === "webgpu";
 
         if (!bufferContext) {
           throw new Error("Unable to create an offscreen render buffer.");
@@ -122,13 +148,19 @@ export function useMandelbrotRender({
         buffer.width = bufferSize.width;
         buffer.height = bufferSize.height;
 
-        bufferContext.drawImage(
-          renderingCanvas,
-          0,
-          0,
-          bufferSize.width,
-          bufferSize.height
-        );
+        if (!preferGpu) {
+          bufferContext.drawImage(
+            renderingCanvas,
+            0,
+            0,
+            bufferSize.width,
+            bufferSize.height
+          );
+        } else {
+          renderingContext.clearRect(0, 0, size.width, size.height);
+        }
+
+        activeBackend = preferGpu ? "webgpu" : "cpu";
 
         setRenderState({
           phase,
@@ -137,41 +169,51 @@ export function useMandelbrotRender({
             phase === "preview"
               ? "Rendering preview..."
               : `Rendering ${bufferSize.width}×${bufferSize.height} frame...`,
+          backend: activeBackend,
         });
 
-        const completed = await renderMandelbrot({
-          viewport,
-          size: bufferSize,
-          settings,
-          signal: abortController.signal,
-          onChunk: (chunk) => {
-            const imageData = new ImageData(
-              new Uint8ClampedArray(chunk.pixels),
-              bufferSize.width,
-              chunk.rowCount
-            );
+        const renderResult = await renderMandelbrotWithStrategy(
+          {
+            viewport,
+            size: bufferSize,
+            settings,
+            gpuTargetCanvas: renderingGpuCanvas,
+            signal: abortController.signal,
+            onChunk: (chunk) => {
+              activeBackend = "cpu";
 
-            bufferContext.putImageData(imageData, 0, chunk.startRow);
-            renderingContext.imageSmoothingEnabled = scale >= 0.75;
-            renderingContext.drawImage(buffer, 0, 0, size.width, size.height);
+              const imageData = new ImageData(
+                new Uint8ClampedArray(chunk.pixels),
+                bufferSize.width,
+                chunk.rowCount
+              );
+
+              bufferContext.putImageData(imageData, 0, chunk.startRow);
+              renderingContext.imageSmoothingEnabled = scale >= 0.75;
+              renderingContext.drawImage(buffer, 0, 0, size.width, size.height);
+            },
+            onProgress: (progress) => {
+              if (!isMounted) {
+                return;
+              }
+
+              setRenderState({
+                phase,
+                progress,
+                message:
+                  phase === "preview"
+                    ? "Rendering preview..."
+                    : `Rendering ${bufferSize.width}×${bufferSize.height} frame...`,
+                backend: activeBackend,
+              });
+            },
           },
-          onProgress: (progress) => {
-            if (!isMounted) {
-              return;
-            }
+          settings.renderBackendPreference
+        );
 
-            setRenderState({
-              phase,
-              progress,
-              message:
-                phase === "preview"
-                  ? "Rendering preview..."
-                  : `Rendering ${bufferSize.width}×${bufferSize.height} frame...`,
-            });
-          },
-        });
+        activeBackend = renderResult.backend;
 
-        if (!completed || abortController.signal.aborted) {
+        if (!renderResult.completed || abortController.signal.aborted) {
           return;
         }
       }
@@ -181,6 +223,7 @@ export function useMandelbrotRender({
           phase: "ready",
           progress: 1,
           message: `Ready at ${Math.round(settings.resolutionScale * 100)}% render scale.`,
+          backend: activeBackend,
         });
       }
     }
@@ -194,6 +237,7 @@ export function useMandelbrotRender({
         phase: "error",
         progress: 0,
         message: "Rendering failed unexpectedly.",
+        backend: "cpu",
       });
     });
 
@@ -201,7 +245,7 @@ export function useMandelbrotRender({
       isMounted = false;
       abortController.abort();
     };
-  }, [canvasRef, settings, size.height, size.width, viewport]);
+  }, [cpuCanvasRef, gpuCanvasRef, settings, size.height, size.width, viewport]);
 
   return renderState;
 }


### PR DESCRIPTION
## Summary
- Add a `Render backend` setting for the Mandelbrot explorer, defaulting to `WebGPU`
- Persist the backend choice in the URL and thread it through render state
- Keep the existing GPU fallback behavior when WebGPU is unavailable or fails

## Testing
- Unit tests
- UI tests