### PR TITLE
Add Planning and Skill Authoring Guardrails to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,3 +170,8 @@ yarn deploy           # Build and deploy to GitHub Pages
 - Before changing labels or short copy in response to a brief user instruction like `do it`, state the chosen interpretation in a short update before editing if there were multiple plausible options in the immediately preceding discussion.
 - Do not add emphasis styling such as bold inline links unless the existing page already uses that pattern or the user asked for stronger emphasis.
 - Treat `meta keywords` as low-value by default. Only add them if the repo has a concrete downstream use for them.
+
+### Planning and Skill Authoring Guardrails (Agent Guidance)
+
+- For any request path that creates commits or pull requests (including the yeet skill), keep wording tool-agnostic: do not mention Codex or any other AI agent/model by name.
+- For planning or implementation documents, provide estimates as scope/effort (for example S/M/L or low/medium/high complexity) instead of timeline-based durations or dates.


### PR DESCRIPTION
### Motivation

- Introduce guidance for planning and skill-authoring workflows to ensure agent-created commits and planning docs remain tool-agnostic and use scope-based estimates instead of timeline dates.

### Description

- Add a new "Planning and Skill Authoring Guardrails (Agent Guidance)" section to `AGENTS.md` with two rules: avoid naming specific AI models/tools in commit/pr text and prefer scope/effort estimates (e.g., S/M/L or low/medium/high) over calendar-based durations.

### Testing

- No automated tests were modified or required for this documentation-only change; no test runs were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f1171c9c8323b8692391f9156e9b)