### PR TITLE
Ban and remove TypeScript type assertions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,26 @@ export default [
     rules: {
       ...tsPlugin.configs.recommended.rules,
       ...prettierConfig.rules,
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        { assertionStyle: "never" },
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "TSAsExpression[typeAnnotation.type='TSTypeReference'][typeAnnotation.typeName.name='const']",
+          message:
+            "Do not use const assertions. Prefer explicit readonly types, `satisfies`, or typed helpers.",
+        },
+        {
+          selector:
+            "TSTypeAssertion[typeAnnotation.type='TSTypeReference'][typeAnnotation.typeName.name='const']",
+          message:
+            "Do not use const assertions. Prefer explicit readonly types, `satisfies`, or typed helpers.",
+        },
+      ],
+      "@typescript-eslint/prefer-as-const": "off",
       "prettier/prettier": "error",
     },
   },

--- a/src/app/blog/tags/[tag]/__tests__/page.test.tsx
+++ b/src/app/blog/tags/[tag]/__tests__/page.test.tsx
@@ -43,7 +43,10 @@ jest.mock("@/lib/blogApi", () => ({
 
     return posts.map((post) =>
       Object.fromEntries(
-        fields.map((field) => [field, post[field as keyof typeof post]])
+        fields.map((field) => {
+          const valuesByField: Record<string, unknown> = post;
+          return [field, valuesByField[field]];
+        })
       )
     );
   }),

--- a/src/app/experimental/learning-dynamics/_components/LearningDynamicsLab.tsx
+++ b/src/app/experimental/learning-dynamics/_components/LearningDynamicsLab.tsx
@@ -93,6 +93,10 @@ function getConfigById(configs: RunConfig[], runId: RunId): RunConfig {
   return config;
 }
 
+function isSurfaceId(value: string): value is SurfaceId {
+  return SURFACES.some((surface) => surface.id === value);
+}
+
 export function LearningDynamicsLab() {
   const [surfaceId, setSurfaceId] = useState<SurfaceId>(DEFAULT_SURFACE_ID);
   const surface = getSurfaceById(surfaceId);
@@ -205,9 +209,15 @@ export function LearningDynamicsLab() {
                 <select
                   value={surfaceId}
                   className="rounded-md border border-white/12 bg-slate-950/80 px-3 py-2 text-sm text-white outline-none transition-colors focus:border-cyan-300"
-                  onChange={(event) =>
-                    handleSurfaceChange(event.target.value as SurfaceId)
-                  }
+                  onChange={(event) => {
+                    const nextSurfaceId = event.target.value;
+
+                    if (!isSurfaceId(nextSurfaceId)) {
+                      return;
+                    }
+
+                    handleSurfaceChange(nextSurfaceId);
+                  }}
                 >
                   {SURFACES.map((candidateSurface) => (
                     <option

--- a/src/app/experimental/learning-dynamics/_components/RunSettingsCard.tsx
+++ b/src/app/experimental/learning-dynamics/_components/RunSettingsCard.tsx
@@ -2,12 +2,19 @@
 
 import { OptimizerId, RunConfig } from "@/features/optimizer-lab/types";
 
-const OPTIMIZER_LABELS: Record<OptimizerId, string> = {
-  sgd: "SGD",
-  momentum: "Momentum",
-  rmsprop: "RMSProp",
-  adam: "Adam",
-};
+const OPTIMIZER_OPTIONS: ReadonlyArray<{
+  id: OptimizerId;
+  label: string;
+}> = [
+  { id: "sgd", label: "SGD" },
+  { id: "momentum", label: "Momentum" },
+  { id: "rmsprop", label: "RMSProp" },
+  { id: "adam", label: "Adam" },
+];
+
+function isOptimizerId(value: string): value is OptimizerId {
+  return OPTIMIZER_OPTIONS.some((option) => option.id === value);
+}
 
 type RunSettingsCardProps = {
   config: RunConfig;
@@ -80,15 +87,19 @@ export function RunSettingsCard({ config, onChange }: RunSettingsCardProps) {
           <select
             value={config.optimizerId}
             className="rounded-md border border-white/12 bg-slate-950/80 px-3 py-2 text-sm text-white outline-none transition-colors focus:border-cyan-300"
-            onChange={(event) =>
-              onChange({
-                optimizerId: event.target.value as OptimizerId,
-              })
-            }
+            onChange={(event) => {
+              const optimizerId = event.target.value;
+
+              if (!isOptimizerId(optimizerId)) {
+                return;
+              }
+
+              onChange({ optimizerId });
+            }}
           >
-            {Object.entries(OPTIMIZER_LABELS).map(([optimizerId, label]) => (
-              <option key={optimizerId} value={optimizerId}>
-                {label}
+            {OPTIMIZER_OPTIONS.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
               </option>
             ))}
           </select>

--- a/src/app/experimental/learning-dynamics/_components/__tests__/LearningDynamicsLab.test.tsx
+++ b/src/app/experimental/learning-dynamics/_components/__tests__/LearningDynamicsLab.test.tsx
@@ -11,13 +11,11 @@ describe("LearningDynamicsLab", () => {
     originalRequestAnimationFrame = window.requestAnimationFrame;
     originalCancelAnimationFrame = window.cancelAnimationFrame;
 
-    window.requestAnimationFrame = ((callback: FrameRequestCallback) =>
-      window.setTimeout(
-        () => callback(Date.now()),
-        16
-      )) as typeof window.requestAnimationFrame;
-    window.cancelAnimationFrame = ((handle: number) =>
-      window.clearTimeout(handle)) as typeof window.cancelAnimationFrame;
+    window.requestAnimationFrame = (callback) =>
+      window.setTimeout(() => callback(Date.now()), 16);
+    window.cancelAnimationFrame = (handle) => {
+      window.clearTimeout(handle);
+    };
   });
 
   afterEach(() => {

--- a/src/app/experimental/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/experimental/load-flow/_components/LoadFlowWorkspace.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 
 import { SingleLineDiagram } from "@/app/experimental/load-flow/_components/SingleLineDiagram";
 import { toLoadFlowCase } from "@/features/load-flow/graph/toLoadFlowCase";
-import { BusType } from "@/features/load-flow/model/types";
+import { Branch, BusType } from "@/features/load-flow/model/types";
 import {
   getReferenceScenarioById,
   LOAD_FLOW_REFERENCE_SCENARIOS,
@@ -22,7 +22,11 @@ import {
 } from "@/features/load-flow/state/loadFlowStore";
 
 const BUS_TYPE_OPTIONS: BusType[] = ["SLACK", "PV", "PQ"];
-const BRANCH_STATUS_OPTIONS = ["IN_SERVICE", "OUT_OF_SERVICE"] as const;
+type BranchStatus = NonNullable<Branch["status"]>;
+const BRANCH_STATUS_OPTIONS: readonly BranchStatus[] = [
+  "IN_SERVICE",
+  "OUT_OF_SERVICE",
+];
 
 const parseFiniteNumber = (value: string): number | null => {
   const parsed = Number.parseFloat(value);
@@ -32,9 +36,7 @@ const parseFiniteNumber = (value: string): number | null => {
 const isBusType = (value: string): value is BusType =>
   BUS_TYPE_OPTIONS.some((type) => type === value);
 
-const isBranchStatus = (
-  value: string
-): value is (typeof BRANCH_STATUS_OPTIONS)[number] =>
+const isBranchStatus = (value: string): value is BranchStatus =>
   BRANCH_STATUS_OPTIONS.some((status) => status === value);
 
 export function LoadFlowWorkspace() {

--- a/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
+++ b/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
@@ -61,11 +61,14 @@ const DEFAULT_CPU_SETTINGS: MandelbrotSettings = {
   renderBackendPreference: "auto",
 };
 
-const QUALITY_OPTIONS = [
+const QUALITY_OPTIONS: ReadonlyArray<{
+  value: number;
+  label: string;
+}> = [
   { value: 0.5, label: "50%" },
   { value: 0.75, label: "75%" },
   { value: 1, label: "100%" },
-] as const;
+];
 
 const BACKEND_OPTIONS: ReadonlyArray<{
   value: RenderBackendPreference;
@@ -75,11 +78,32 @@ const BACKEND_OPTIONS: ReadonlyArray<{
   { value: "webgpu", label: "WebGPU" },
   { value: "cpu", label: "CPU" },
 ];
+const COLORING_MODE_OPTIONS: ReadonlyArray<{
+  value: ColoringMode;
+  label: string;
+}> = [
+  { value: "smooth", label: "Smooth escape" },
+  { value: "bands", label: "Banding" },
+];
 
 const sectionTitleClass = "text-heading-sm text-white";
 const metaValueClass = "break-all text-sm text-cyan-100";
 const toolbarButtonClass =
   "rounded-md border border-white/15 px-3 py-2 text-sm text-white transition hover:border-cyan-300 hover:text-cyan-100 disabled:cursor-not-allowed disabled:opacity-40";
+
+function isRenderBackendPreference(
+  value: string
+): value is RenderBackendPreference {
+  return BACKEND_OPTIONS.some((option) => option.value === value);
+}
+
+function isPaletteId(value: string): value is MandelbrotSettings["paletteId"] {
+  return PALETTE_OPTIONS.some((option) => option.id === value);
+}
+
+function isColoringMode(value: string): value is ColoringMode {
+  return COLORING_MODE_OPTIONS.some((option) => option.value === value);
+}
 
 export function MandelbrotExplorer() {
   const [history, setHistory] = useState<ViewportHistory>(() =>
@@ -322,13 +346,18 @@ export function MandelbrotExplorer() {
                   <span>Render backend</span>
                   <select
                     value={settings.renderBackendPreference}
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      const renderBackendPreference = event.target.value;
+
+                      if (!isRenderBackendPreference(renderBackendPreference)) {
+                        return;
+                      }
+
                       setSettings((currentSettings) => ({
                         ...currentSettings,
-                        renderBackendPreference: event.target
-                          .value as RenderBackendPreference,
-                      }))
-                    }
+                        renderBackendPreference,
+                      }));
+                    }}
                     className="mt-1 w-full rounded-md border border-white/15 bg-slate-950 px-3 py-2 text-white"
                   >
                     {BACKEND_OPTIONS.map((option) => (
@@ -356,13 +385,18 @@ export function MandelbrotExplorer() {
                   <span>Color palette</span>
                   <select
                     value={settings.paletteId}
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      const paletteId = event.target.value;
+
+                      if (!isPaletteId(paletteId)) {
+                        return;
+                      }
+
                       setSettings((currentSettings) => ({
                         ...currentSettings,
-                        paletteId: event.target
-                          .value as MandelbrotSettings["paletteId"],
-                      }))
-                    }
+                        paletteId,
+                      }));
+                    }}
                     className="mt-1 w-full rounded-md border border-white/15 bg-slate-950 px-3 py-2 text-white"
                   >
                     {PALETTE_OPTIONS.map((option) => (
@@ -376,16 +410,25 @@ export function MandelbrotExplorer() {
                   <span>Coloring mode</span>
                   <select
                     value={settings.coloringMode}
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      const coloringMode = event.target.value;
+
+                      if (!isColoringMode(coloringMode)) {
+                        return;
+                      }
+
                       setSettings((currentSettings) => ({
                         ...currentSettings,
-                        coloringMode: event.target.value as ColoringMode,
-                      }))
-                    }
+                        coloringMode,
+                      }));
+                    }}
                     className="mt-1 w-full rounded-md border border-white/15 bg-slate-950 px-3 py-2 text-white"
                   >
-                    <option value="smooth">Smooth escape</option>
-                    <option value="bands">Banding</option>
+                    {COLORING_MODE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
                   </select>
                 </label>
                 <label className="text-sm text-gray-200">

--- a/src/app/experimental/pid-controller/_components/PidChart.tsx
+++ b/src/app/experimental/pid-controller/_components/PidChart.tsx
@@ -90,7 +90,7 @@ export function PidChart({ samples }: PidChartProps) {
   );
   const errorPath = toPath(samples, (sample) => sample.error, scaleX, scaleY);
   const latestSample = samples.at(-1) ?? samples[0];
-  const legendItems: readonly LegendItem[] = [
+  const legendItems: ReadonlyArray<LegendItem> = [
     {
       label: "Setpoint",
       stroke: "#f59e0b",
@@ -116,7 +116,7 @@ export function PidChart({ samples }: PidChartProps) {
       strokeDasharray: "5 3",
       value: latestSample.error,
     },
-  ] as const;
+  ];
 
   return (
     <figure className="rounded-lg border border-gray-700 bg-black/40 p-3">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,6 +8,11 @@ import { getAllTags, getTagPath } from "@/lib/tags";
 
 export const dynamic = "force-static";
 
+type SitemapEntry = MetadataRoute.Sitemap[number];
+const MONTHLY: SitemapEntry["changeFrequency"] = "monthly";
+const WEEKLY: SitemapEntry["changeFrequency"] = "weekly";
+const YEARLY: SitemapEntry["changeFrequency"] = "yearly";
+
 const PAGE_LAST_MODIFIED: Record<string, string> = {
   about: "2026-02-14",
   now: NOW_PAGE_LAST_UPDATED_ISO,
@@ -23,21 +28,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
     lastModified: new Date(
       post.updated || post.date || PAGE_LAST_MODIFIED.about
     ),
-    changeFrequency: "monthly" as const,
+    changeFrequency: MONTHLY,
     priority: 0.7,
   }));
 
   const experimentalPages = EXPERIMENTS.map((experiment) => ({
     url: toCanonical(experiment.path),
     lastModified: new Date(experiment.lastModified),
-    changeFrequency: "monthly" as const,
+    changeFrequency: MONTHLY,
     priority: 0.7,
   }));
 
   const tagPages = tags.map((tag) => ({
     url: toCanonical(getTagPath(tag.name)),
     lastModified: new Date(tag.latestModified),
-    changeFrequency: "monthly" as const,
+    changeFrequency: MONTHLY,
     priority: 0.6,
   }));
 
@@ -56,37 +61,37 @@ export default function sitemap(): MetadataRoute.Sitemap {
     {
       url: toCanonical("/"),
       lastModified: latestPostUpdate,
-      changeFrequency: "monthly",
+      changeFrequency: MONTHLY,
       priority: 1,
     },
     {
       url: toCanonical("/about"),
       lastModified: new Date(PAGE_LAST_MODIFIED.about),
-      changeFrequency: "monthly",
+      changeFrequency: MONTHLY,
       priority: 0.8,
     },
     {
       url: toCanonical("/now"),
       lastModified: new Date(PAGE_LAST_MODIFIED.now),
-      changeFrequency: "monthly",
+      changeFrequency: MONTHLY,
       priority: 0.8,
     },
     {
       url: toCanonical("/blog"),
       lastModified: latestPostUpdate,
-      changeFrequency: "weekly",
+      changeFrequency: WEEKLY,
       priority: 0.8,
     },
     {
       url: toCanonical(EXPERIMENTS_HUB.path),
       lastModified: new Date(EXPERIMENTS_HUB.lastModified),
-      changeFrequency: "monthly",
+      changeFrequency: MONTHLY,
       priority: 0.7,
     },
     {
       url: toCanonical("/contact"),
       lastModified: new Date(PAGE_LAST_MODIFIED.contact),
-      changeFrequency: "yearly",
+      changeFrequency: YEARLY,
       priority: 0.5,
     },
     ...experimentalPages,

--- a/src/components/__tests__/Card.test.tsx
+++ b/src/components/__tests__/Card.test.tsx
@@ -13,7 +13,8 @@ describe("Card", () => {
   it("should merge custom className with base styles", () => {
     const { container } = render(<Card className="custom-class">Content</Card>);
 
-    const card = container.firstChild as HTMLElement;
+    const card = container.firstElementChild;
+    expect(card).not.toBeNull();
     expect(card).toHaveClass("p-6", "custom-class");
   });
 });

--- a/src/components/__tests__/FollowItSubscribeForm.test.tsx
+++ b/src/components/__tests__/FollowItSubscribeForm.test.tsx
@@ -53,10 +53,10 @@ describe("FollowItSubscribeForm", () => {
     fireEvent.change(emailInput, {
       target: { value: "alex@example.com" },
     });
-    const form = container.querySelector("form");
+    const form = container.querySelector<HTMLFormElement>("form");
 
     expect(form).not.toBeNull();
-    fireEvent.submit(form as HTMLFormElement);
+    fireEvent.submit(form!);
 
     expect(
       screen.getByRole("button", { name: /subscribing\.\.\./i })

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -9,9 +9,11 @@ jest.mock("next/navigation", () => ({
   usePathname: jest.fn(),
 }));
 
+const mockUsePathname = jest.mocked(usePathname);
+
 describe("Header", () => {
   beforeEach(() => {
-    (usePathname as jest.Mock).mockReturnValue("/");
+    mockUsePathname.mockReturnValue("/");
   });
 
   afterEach(() => {
@@ -89,7 +91,7 @@ describe("Header", () => {
 
     it("should close menu when pathname changes", async () => {
       let pathname = "/";
-      (usePathname as jest.Mock).mockImplementation(() => pathname);
+      mockUsePathname.mockImplementation(() => pathname);
 
       const { rerender } = render(<Header />);
       const button = screen.getByRole("button", { name: "Open menu" });
@@ -108,7 +110,7 @@ describe("Header", () => {
 
   describe("Active Link Detection", () => {
     it("should mark current page link as active", () => {
-      (usePathname as jest.Mock).mockReturnValue("/about/");
+      mockUsePathname.mockReturnValue("/about/");
       render(<Header />);
 
       const aboutLink = screen.getByText("About");
@@ -119,7 +121,7 @@ describe("Header", () => {
     });
 
     it("should handle trailing slashes in pathname matching", () => {
-      (usePathname as jest.Mock).mockReturnValue("/about");
+      mockUsePathname.mockReturnValue("/about");
       render(<Header />);
 
       const aboutLink = screen.getByText("About");
@@ -127,7 +129,7 @@ describe("Header", () => {
     });
 
     it("should mark home link active only on exact home path", () => {
-      (usePathname as jest.Mock).mockReturnValue("/");
+      mockUsePathname.mockReturnValue("/");
       render(<Header />);
 
       const homeLink = screen.getByText("Home");
@@ -135,7 +137,7 @@ describe("Header", () => {
     });
 
     it("should set aria-current on active links across desktop and mobile nav", () => {
-      (usePathname as jest.Mock).mockReturnValue("/about/");
+      mockUsePathname.mockReturnValue("/about/");
       render(<Header />);
 
       const button = screen.getByRole("button", { name: "Open menu" });
@@ -151,7 +153,7 @@ describe("Header", () => {
     });
 
     it("should keep section navigation active on experiment child routes", () => {
-      (usePathname as jest.Mock).mockReturnValue("/experimental/mandelbrot/");
+      mockUsePathname.mockReturnValue("/experimental/mandelbrot/");
       render(<Header />);
 
       const experimentsLink = screen.getByText("Experiments");
@@ -160,7 +162,7 @@ describe("Header", () => {
     });
 
     it("should keep blog navigation active on tag archive routes", () => {
-      (usePathname as jest.Mock).mockReturnValue("/blog/tags/ai/");
+      mockUsePathname.mockReturnValue("/blog/tags/ai/");
       render(<Header />);
 
       const blogLink = screen.getByText("Blog");

--- a/src/constants/experiments.ts
+++ b/src/constants/experiments.ts
@@ -9,14 +9,19 @@ export type ExperimentEntry = {
 
 const EXPERIMENT_LAST_MODIFIED_ISO = "2026-04-20";
 
-export const EXPERIMENTS_HUB = {
+type ExperimentsHub = Pick<
+  ExperimentEntry,
+  "description" | "lastModified" | "pageTitle" | "path" | "title"
+>;
+
+export const EXPERIMENTS_HUB: ExperimentsHub = {
   description:
     "Interactive browser-based tools for exploring systems, control, numerical methods, and runtime behavior.",
   path: "/experimental/",
   title: "Experiments | Alex Leung",
   pageTitle: "Experiments",
   lastModified: EXPERIMENT_LAST_MODIFIED_ISO,
-} as const;
+};
 
 export function buildExperimentBreadcrumbItems(
   pageTitle: string,
@@ -75,4 +80,4 @@ export const EXPERIMENTS: readonly ExperimentEntry[] = [
     path: "/experimental/pid-controller/",
     lastModified: EXPERIMENT_LAST_MODIFIED_ISO,
   },
-] as const;
+];

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -1,4 +1,11 @@
-export const NAV_LINKS = [
+type NavLink = {
+  id: string;
+  href: string;
+  canonicalPath: string;
+  label: string;
+};
+
+export const NAV_LINKS: readonly NavLink[] = [
   { id: "home", href: "/", canonicalPath: "/", label: "Home" },
   { id: "about", href: "/about/", canonicalPath: "/about", label: "About" },
   { id: "now", href: "/now/", canonicalPath: "/now", label: "Now" },
@@ -15,4 +22,4 @@ export const NAV_LINKS = [
     canonicalPath: "/contact",
     label: "Contact",
   },
-] as const;
+];

--- a/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
+++ b/src/features/load-flow/solver/__tests__/runLoadFlow.test.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_LOAD_FLOW_CASE } from "@/features/load-flow/model/defaults";
+import { Bus } from "@/features/load-flow/model/types";
 
 import { LOAD_FLOW_REFERENCE_SCENARIOS } from "../referenceScenarios";
 import { runLoadFlow } from "../runLoadFlow";
@@ -82,17 +83,15 @@ describe("runLoadFlow", () => {
   });
 
   it("reports island diagnostics for disconnected networks", () => {
+    const islandedBus: Bus = {
+      id: "bus-2",
+      name: "Islanded bus",
+      baseKV: 13.8,
+      type: "PQ",
+    };
     const islandedCase = {
       ...DEFAULT_LOAD_FLOW_CASE,
-      buses: [
-        ...DEFAULT_LOAD_FLOW_CASE.buses,
-        {
-          id: "bus-2",
-          name: "Islanded bus",
-          baseKV: 13.8,
-          type: "PQ" as const,
-        },
-      ],
+      buses: [...DEFAULT_LOAD_FLOW_CASE.buses, islandedBus],
     };
 
     const result = runLoadFlow(islandedCase);

--- a/src/features/mandelbrot/gpu.ts
+++ b/src/features/mandelbrot/gpu.ts
@@ -480,18 +480,36 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 
 let rendererStatePromise: Promise<WebGpuRendererState> | null = null;
 
+type WebGpuNavigator = Navigator & {
+  gpu?: WebGpu;
+};
+
+function hasNavigatorGpu(value: Navigator): value is WebGpuNavigator {
+  return "gpu" in value;
+}
+
+function isWebGpuCanvasContext(value: unknown): value is WebGpuCanvasContext {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "configure" in value &&
+    "getCurrentTexture" in value
+  );
+}
+
 function getNavigatorGpu(): WebGpu | null {
-  if (typeof navigator === "undefined" || !("gpu" in navigator)) {
+  if (typeof navigator === "undefined" || !hasNavigatorGpu(navigator)) {
     return null;
   }
 
-  return (navigator as Navigator & { gpu?: WebGpu }).gpu ?? null;
+  return navigator.gpu ?? null;
 }
 
 function getCanvasWebGpuContext(
   canvas: HTMLCanvasElement
 ): WebGpuCanvasContext | null {
-  return (canvas.getContext("webgpu") as WebGpuCanvasContext | null) ?? null;
+  const context = canvas.getContext("webgpu");
+  return isWebGpuCanvasContext(context) ? context : null;
 }
 
 function nextFrame(): Promise<void> {

--- a/src/features/mandelbrot/urlState.ts
+++ b/src/features/mandelbrot/urlState.ts
@@ -10,20 +10,34 @@ import { createViewport } from "@/features/mandelbrot/viewport";
 
 type QueryRecord = Record<string, string | string[] | undefined>;
 
-const VALID_PALETTES: ReadonlySet<PaletteId> = new Set([
-  "oceanic",
-  "ember",
-  "glacier",
-]);
-const VALID_COLORING_MODES: ReadonlySet<ColoringMode> = new Set([
-  "smooth",
-  "bands",
-]);
-const VALID_RENDER_BACKENDS: ReadonlySet<RenderBackendPreference> = new Set([
-  "auto",
-  "webgpu",
-  "cpu",
-]);
+const VALID_PALETTES: Readonly<Record<PaletteId, true>> = {
+  oceanic: true,
+  ember: true,
+  glacier: true,
+};
+const VALID_COLORING_MODES: Readonly<Record<ColoringMode, true>> = {
+  smooth: true,
+  bands: true,
+};
+const VALID_RENDER_BACKENDS: Readonly<Record<RenderBackendPreference, true>> = {
+  auto: true,
+  webgpu: true,
+  cpu: true,
+};
+
+function isPaletteId(value: string): value is PaletteId {
+  return Object.hasOwn(VALID_PALETTES, value);
+}
+
+function isColoringMode(value: string): value is ColoringMode {
+  return Object.hasOwn(VALID_COLORING_MODES, value);
+}
+
+function isRenderBackendPreference(
+  value: string
+): value is RenderBackendPreference {
+  return Object.hasOwn(VALID_RENDER_BACKENDS, value);
+}
 
 export function parseViewportFromQuery(
   searchParams: QueryRecord,
@@ -69,14 +83,12 @@ export function parseSettingsFromQuery(
         ? Math.min(maxIterations, 4000)
         : fallback.maxIterations,
     paletteId:
-      typeof paletteId === "string" &&
-      VALID_PALETTES.has(paletteId as PaletteId)
-        ? (paletteId as PaletteId)
+      typeof paletteId === "string" && isPaletteId(paletteId)
+        ? paletteId
         : fallback.paletteId,
     coloringMode:
-      typeof coloringMode === "string" &&
-      VALID_COLORING_MODES.has(coloringMode as ColoringMode)
-        ? (coloringMode as ColoringMode)
+      typeof coloringMode === "string" && isColoringMode(coloringMode)
+        ? coloringMode
         : fallback.coloringMode,
     resolutionScale:
       Number.isFinite(resolutionScale) && resolutionScale >= 0.25
@@ -84,10 +96,8 @@ export function parseSettingsFromQuery(
         : fallback.resolutionScale,
     renderBackendPreference:
       typeof renderBackendPreference === "string" &&
-      VALID_RENDER_BACKENDS.has(
-        renderBackendPreference as RenderBackendPreference
-      )
-        ? (renderBackendPreference as RenderBackendPreference)
+      isRenderBackendPreference(renderBackendPreference)
+        ? renderBackendPreference
         : fallback.renderBackendPreference,
   };
 }

--- a/src/features/pid-simulator/presets.ts
+++ b/src/features/pid-simulator/presets.ts
@@ -32,7 +32,7 @@ export const PID_SIMULATOR_PRESETS: readonly SimulatorPreset[] = [
     gains: { kp: 0.6, ki: 1, kd: 2 },
     setpoint: PID_SIMULATOR_DEFAULT_SETPOINT,
   },
-] as const;
+];
 
 export const getPresetById = (presetId: string): SimulatorPreset | undefined =>
   PID_SIMULATOR_PRESETS.find((preset) => preset.id === presetId);

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -2,6 +2,8 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 
+type NodeEnv = "development" | "production" | "test";
+
 function setupTempPosts(markdownBySlug: Record<string, string>): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "blog-api-test-"));
   const postsDir = path.join(tempDir, "content", "posts");
@@ -15,15 +17,13 @@ function setupTempPosts(markdownBySlug: Record<string, string>): string {
   return tempDir;
 }
 
-async function loadBlogApiAtCwd(cwd: string, options?: { nodeEnv?: string }) {
+async function loadBlogApiAtCwd(cwd: string, options?: { nodeEnv?: NodeEnv }) {
   jest.resetModules();
   const cwdSpy = jest.spyOn(process, "cwd").mockReturnValue(cwd);
-  const env = process.env as Record<string, string | undefined>;
-  const previousNodeEnv = env.NODE_ENV;
-
-  if (options?.nodeEnv !== undefined) {
-    env.NODE_ENV = options.nodeEnv;
-  }
+  const envSpy = jest.replaceProperty(process, "env", {
+    ...process.env,
+    NODE_ENV: options?.nodeEnv ?? process.env.NODE_ENV ?? "test",
+  });
 
   try {
     const blogApi = await import("@/lib/blogApi");
@@ -31,13 +31,11 @@ async function loadBlogApiAtCwd(cwd: string, options?: { nodeEnv?: string }) {
     return blogApi;
   } finally {
     cwdSpy.mockRestore();
-    env.NODE_ENV = previousNodeEnv;
+    envSpy.restore();
   }
 }
 
 afterEach(() => {
-  const env = process.env as Record<string, string | undefined>;
-  env.NODE_ENV = "test";
   jest.restoreAllMocks();
   jest.resetModules();
 });
@@ -161,10 +159,12 @@ describe("blogApi front matter validation", () => {
     });
 
     const { getAllPosts } = await loadBlogApiAtCwd(tempDir);
+    const invokeGetAllPostsWithRuntimeFields = (fields: readonly string[]) =>
+      Reflect.apply(getAllPosts, undefined, [fields]);
 
-    expect(() => getAllPosts(["slug", "notAField" as never])).toThrow(
-      /Unsupported post field requested: notAField/
-    );
+    expect(() =>
+      invokeGetAllPostsWithRuntimeFields(["slug", "notAField"])
+    ).toThrow(/Unsupported post field requested: notAField/);
   });
 
   test("throws when seriesOrder duplicates within the same series", async () => {

--- a/src/lib/__tests__/feed.test.ts
+++ b/src/lib/__tests__/feed.test.ts
@@ -16,11 +16,13 @@ jest.mock(
   { virtual: true }
 );
 
+const mockFeed = jest.mocked(Feed);
+
 describe("buildRssFeedXml", () => {
   beforeEach(() => {
     mockAddItem.mockClear();
     mockRss2.mockClear();
-    (Feed as unknown as jest.Mock).mockClear();
+    mockFeed.mockClear();
   });
 
   it("configures feed metadata and adds canonical post items", () => {

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -11,7 +11,10 @@ const usePersistentCache = process.env.NODE_ENV !== "development";
 
 let allPostsCache: Post[] | null = null;
 
-const POST_FIELDS = [
+const defineLiteralArray = <const T extends readonly string[]>(values: T) =>
+  values;
+
+const POST_FIELDS = defineLiteralArray([
   "slug",
   "title",
   "date",
@@ -24,7 +27,8 @@ const POST_FIELDS = [
   "readingTimeMinutes",
   "draft",
   "content",
-] as const;
+]);
+const POST_FIELD_SET: ReadonlySet<string> = new Set(POST_FIELDS);
 
 type PostField = (typeof POST_FIELDS)[number];
 
@@ -68,36 +72,40 @@ function assertValidDate(date: string, slug: string, key: "date" | "updated") {
   }
 }
 
-function resolvePostQuery<T extends PostField>(
-  fieldsOrOptions?: readonly T[] | PostQueryOptions,
+function isFieldList(
+  value: readonly string[] | PostQueryOptions | undefined
+): value is readonly string[] {
+  return Array.isArray(value);
+}
+
+function resolvePostQuery(
+  fieldsOrOptions?: readonly string[] | PostQueryOptions,
   maybeOptions?: PostQueryOptions
 ): {
-  fields: readonly T[] | undefined;
+  fields: readonly PostField[] | undefined;
   options: PostQueryOptions | undefined;
 } {
-  if (!Array.isArray(fieldsOrOptions)) {
+  if (!isFieldList(fieldsOrOptions)) {
     return {
       fields: undefined,
-      options: fieldsOrOptions as PostQueryOptions | undefined,
+      options: fieldsOrOptions,
     };
   }
 
-  const invalidField = fieldsOrOptions.find(
-    (field) => !POST_FIELDS.includes(field as PostField)
-  );
+  const invalidField = fieldsOrOptions.find((field) => !isPostField(field));
 
   if (invalidField) {
     throw new Error(`Unsupported post field requested: ${invalidField}`);
   }
 
   return {
-    fields: fieldsOrOptions,
+    fields: fieldsOrOptions.filter(isPostField),
     options: maybeOptions,
   };
 }
 
 function parseFrontMatter(
-  data: Record<string, unknown>,
+  data: unknown,
   slug: string
 ): z.infer<typeof PostFrontMatterSchema> {
   const parsed = PostFrontMatterSchema.safeParse(data);
@@ -151,10 +159,7 @@ function parsePostBySlug(slug: string): Post | null {
 
   const fileContents = fs.readFileSync(fullPath, "utf8");
   const { data, content } = matter(fileContents);
-  const frontMatter = parseFrontMatter(
-    data as Record<string, unknown>,
-    realSlug
-  );
+  const frontMatter = parseFrontMatter(data, realSlug);
 
   assertValidDate(frontMatter.date, realSlug, "date");
 
@@ -283,18 +288,12 @@ function getRelatedScore(target: Post, candidate: Post): number {
   return tagScore + seriesScore + recencyScore;
 }
 
-function pickPostFields<T extends PostField>(
-  post: Post,
-  fields: readonly T[]
-): Pick<Post, T> {
-  return fields.reduce(
-    (acc, field) => {
-      acc[field] = post[field] as Pick<Post, T>[T];
+function isPostField(field: string): field is PostField {
+  return POST_FIELD_SET.has(field);
+}
 
-      return acc;
-    },
-    {} as Pick<Post, T>
-  );
+function pickPostFields<T extends PostField>(post: Post, fields: readonly T[]) {
+  return Object.fromEntries(fields.map((field) => [field, post[field]]));
 }
 
 function getPostSlugs() {
@@ -310,9 +309,9 @@ export function getPostBySlug<T extends PostField>(
   fields: readonly T[],
   options?: PostQueryOptions
 ): Pick<Post, T> | null;
-export function getPostBySlug<T extends PostField>(
+export function getPostBySlug(
   slug: string,
-  fieldsOrOptions?: readonly T[] | PostQueryOptions,
+  fieldsOrOptions?: readonly string[] | PostQueryOptions,
   maybeOptions?: PostQueryOptions
 ) {
   const post = getCachedPostBySlug(slug);
@@ -336,8 +335,8 @@ export function getAllPosts<T extends PostField>(
   fields: readonly T[],
   options?: PostQueryOptions
 ): Array<Pick<Post, T>>;
-export function getAllPosts<T extends PostField>(
-  fieldsOrOptions?: readonly T[] | PostQueryOptions,
+export function getAllPosts(
+  fieldsOrOptions?: readonly string[] | PostQueryOptions,
   maybeOptions?: PostQueryOptions
 ) {
   const { fields, options } = resolvePostQuery(fieldsOrOptions, maybeOptions);

--- a/src/lib/imageVariantManifest.ts
+++ b/src/lib/imageVariantManifest.ts
@@ -19,7 +19,7 @@ type ImageVariantManifest = {
   sources: Record<string, SourceInfo>;
 };
 
-const manifest = imageVariantManifest as ImageVariantManifest;
+const manifest: ImageVariantManifest = imageVariantManifest;
 
 function ensureStringArray(
   value: unknown,

--- a/src/lib/localImageMetadata.ts
+++ b/src/lib/localImageMetadata.ts
@@ -1,17 +1,23 @@
 import { getImageVariant, type VariantInfo } from "@/lib/imageVariantManifest";
 
+type StaticImageProfile = {
+  source: string;
+  orderedVariants: readonly string[];
+  fallbackVariant: string;
+};
+
 const staticImageProfiles = {
   aboutPortrait: {
     source: "/assets/about_portrait.webp",
-    orderedVariants: ["sm", "md", "lg"] as const,
+    orderedVariants: ["sm", "md", "lg"],
     fallbackVariant: "md",
   },
   background: {
     source: "/assets/background.webp",
-    orderedVariants: ["mobile", "tablet", "desktop"] as const,
+    orderedVariants: ["mobile", "tablet", "desktop"],
     fallbackVariant: "tablet",
   },
-} as const;
+} satisfies Record<string, StaticImageProfile>;
 
 export type StaticImageProfileName = keyof typeof staticImageProfiles;
 

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -1,4 +1,4 @@
-import type { Root } from "hast";
+import type { Element, Root, RootContent } from "hast";
 import type { Schema } from "hast-util-sanitize";
 import rehypeKatex from "rehype-katex";
 import rehypePrettyCode from "rehype-pretty-code";
@@ -77,17 +77,17 @@ const sanitizeSchema: Schema = {
   ],
 };
 
-type HastNode = {
-  type: string;
-  tagName?: string;
-  properties?: Record<string, unknown>;
-  children?: HastNode[];
-};
+function visitElements(
+  nodes: readonly RootContent[],
+  visitor: (node: Element) => void
+) {
+  for (const node of nodes) {
+    if (node.type !== "element") {
+      continue;
+    }
 
-function visitNodes(node: HastNode, visitor: (node: HastNode) => void) {
-  visitor(node);
-  for (const child of node.children ?? []) {
-    visitNodes(child, visitor);
+    visitor(node);
+    visitElements(node.children, visitor);
   }
 }
 
@@ -95,8 +95,8 @@ function rehypeResponsiveImages() {
   const inlineContentVariantProfile = getInlineContentVariantProfile();
 
   return (tree: Root) => {
-    visitNodes(tree as unknown as HastNode, (node) => {
-      if (node.type !== "element" || node.tagName !== "img") {
+    visitElements(tree.children, (node) => {
+      if (node.tagName !== "img") {
         return;
       }
 

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -16,12 +16,12 @@ import {
 
 function expectSchemaArray<T>(value: unknown): readonly T[] {
   expect(Array.isArray(value)).toBe(true);
-  return value as readonly T[];
-}
 
-function expectSchemaObject<T>(value: T): Exclude<T, string> {
-  expect(typeof value).toBe("object");
-  return value as Exclude<T, string>;
+  if (!Array.isArray(value)) {
+    throw new Error("Expected schema array");
+  }
+
+  return value;
 }
 
 describe("seo jsonld builders", () => {
@@ -182,11 +182,13 @@ describe("seo jsonld builders", () => {
   });
 
   it("builds person schema with richer identity metadata", () => {
-    const person = expectSchemaObject(
-      buildPersonSchema({
-        description: "Person description",
-      })
-    );
+    const person = buildPersonSchema({
+      description: "Person description",
+    });
+    expect(typeof person).toBe("object");
+    if (typeof person !== "object" || person === null) {
+      throw new Error("Expected person schema object");
+    }
 
     expect(person.givenName).toBe("Alex");
     expect(person.familyName).toBe("Leung");
@@ -228,11 +230,13 @@ describe("seo jsonld builders", () => {
   });
 
   it("builds professional service schema with service areas", () => {
-    const service = expectSchemaObject(
-      buildProfessionalServiceSchema({
-        description: "Personal website of Alex Leung",
-      })
-    );
+    const service = buildProfessionalServiceSchema({
+      description: "Personal website of Alex Leung",
+    });
+    expect(typeof service).toBe("object");
+    if (typeof service !== "object" || service === null) {
+      throw new Error("Expected service schema object");
+    }
 
     expect(service["@type"]).toBe("Service");
     expect(service.name).toBe(

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -1,8 +1,11 @@
 import type {
+  AdministrativeArea,
   Article,
   BlogPosting,
+  City,
   CollectionPage,
   ContactPage,
+  Country,
   ItemList,
   Occupation,
   Person,
@@ -22,6 +25,15 @@ const WEBSITE_ID = "/#website";
 const SITE_NAVIGATION_ID = "/#site-navigation";
 const ABOUT_PATH = "/about";
 const SITE_ROOT = toAbsoluteUrl("/").replace(/\/$/, "");
+const SCHEMA_CONTEXT: "https://schema.org" = "https://schema.org";
+const PERSON_TYPE: "Person" = "Person";
+const ADMINISTRATIVE_AREA_TYPE: "AdministrativeArea" = "AdministrativeArea";
+const COUNTRY_TYPE: "Country" = "Country";
+const CITY_TYPE: "City" = "City";
+const WEBSITE_TYPE: "WebSite" = "WebSite";
+const WEBPAGE_TYPE: "WebPage" = "WebPage";
+const SITE_NAVIGATION_ELEMENT_TYPE: "SiteNavigationElement" =
+  "SiteNavigationElement";
 const SOCIAL_PROFILES = [
   "https://www.linkedin.com/in/aclyx",
   "https://github.com/aclyx",
@@ -30,8 +42,45 @@ const SOCIAL_PROFILES = [
   "https://www.instagram.com/rootpanda",
   "https://scholar.google.ca/citations?user=NcOOsPIAAAAJ",
 ];
-const PERSON_REFERENCE = {
-  "@type": "Person" as const,
+type PersonReference = {
+  "@type": "Person";
+  "@id": string;
+  name: string;
+  url: string;
+  image: string;
+  sameAs: string[];
+};
+
+type BasePageSchema<TPageType extends string> = {
+  "@context": "https://schema.org";
+  "@type": TPageType;
+  "@id": string;
+  url: string;
+  name: string;
+  description: string;
+  inLanguage: string;
+  isPartOf: Pick<WebSite, "@type" | "@id">;
+};
+
+type BasePostSchema = {
+  canonicalPostUrl: string;
+  schema: {
+    url: string;
+    headline: string;
+    description?: string;
+    keywords?: string;
+    image?: string[];
+    datePublished: string;
+    dateModified: string;
+    author: PersonReference;
+    publisher: PersonReference;
+    inLanguage: string;
+    mainEntityOfPage: Pick<WebPage, "@type" | "@id">;
+  };
+};
+
+const PERSON_REFERENCE: PersonReference = {
+  "@type": PERSON_TYPE,
   "@id": toAbsoluteUrl(PERSON_ID),
   name: "Alex Leung",
   url: toCanonical(ABOUT_PATH),
@@ -39,39 +88,39 @@ const PERSON_REFERENCE = {
   sameAs: SOCIAL_PROFILES,
 };
 
-const GEO_SERVICE_AREAS = [
+const GEO_SERVICE_AREAS: ReadonlyArray<AdministrativeArea | Country | City> = [
   {
-    "@type": "AdministrativeArea" as const,
+    "@type": ADMINISTRATIVE_AREA_TYPE,
     name: "Ontario",
     sameAs: "https://en.wikipedia.org/wiki/Ontario",
   },
   {
-    "@type": "Country" as const,
+    "@type": COUNTRY_TYPE,
     name: "Canada",
     sameAs: "https://en.wikipedia.org/wiki/Canada",
   },
   {
-    "@type": "Country" as const,
+    "@type": COUNTRY_TYPE,
     name: "United States",
     sameAs: "https://en.wikipedia.org/wiki/United_States",
   },
   {
-    "@type": "AdministrativeArea" as const,
+    "@type": ADMINISTRATIVE_AREA_TYPE,
     name: "California",
     sameAs: "https://en.wikipedia.org/wiki/California",
   },
   {
-    "@type": "City" as const,
+    "@type": CITY_TYPE,
     name: "Waterloo",
     sameAs: "https://en.wikipedia.org/wiki/Waterloo,_Ontario",
   },
   {
-    "@type": "City" as const,
+    "@type": CITY_TYPE,
     name: "Toronto",
     sameAs: "https://en.wikipedia.org/wiki/Toronto",
   },
   {
-    "@type": "City" as const,
+    "@type": CITY_TYPE,
     name: "San Francisco",
     sameAs: "https://en.wikipedia.org/wiki/San_Francisco",
   },
@@ -97,9 +146,9 @@ function buildBasePageSchema<TPageType extends string>({
   pageType: TPageType;
   path: string;
   title: string;
-}) {
+}): BasePageSchema<TPageType> {
   return {
-    "@context": "https://schema.org" as const,
+    "@context": SCHEMA_CONTEXT,
     "@type": pageType,
     "@id": toCanonical(path),
     url: toCanonical(path),
@@ -107,13 +156,13 @@ function buildBasePageSchema<TPageType extends string>({
     description,
     inLanguage: "en-CA",
     isPartOf: {
-      "@type": "WebSite" as const,
+      "@type": WEBSITE_TYPE,
       "@id": toAbsoluteUrl(WEBSITE_ID),
     },
   };
 }
 
-function buildBasePostSchema(input: PostSchemaInput) {
+function buildBasePostSchema(input: PostSchemaInput): BasePostSchema {
   const canonicalPostUrl = toCanonical(`/blog/${input.slug}`);
 
   return {
@@ -130,7 +179,7 @@ function buildBasePostSchema(input: PostSchemaInput) {
       publisher: PERSON_REFERENCE,
       inLanguage: "en-CA",
       mainEntityOfPage: {
-        "@type": "WebPage" as const,
+        "@type": WEBPAGE_TYPE,
         "@id": canonicalPostUrl,
       },
     },
@@ -235,7 +284,7 @@ export function buildBlogItemListSchema(
   path = "/blog"
 ): WithContext<ItemList> {
   return {
-    "@context": "https://schema.org" as const,
+    "@context": SCHEMA_CONTEXT,
     "@type": "ItemList",
     "@id": `${toCanonical(path)}#itemlist`,
     itemListElement: posts.map((post, index) => ({
@@ -254,7 +303,7 @@ export function buildBlogPostingSchema(
   const { canonicalPostUrl, schema } = buildBasePostSchema(input);
 
   return {
-    "@context": "https://schema.org" as const,
+    "@context": SCHEMA_CONTEXT,
     "@type": "BlogPosting",
     "@id": `${canonicalPostUrl}#blogposting`,
     ...schema,
@@ -272,7 +321,7 @@ export function buildArticleSchema(
   const { canonicalPostUrl, schema } = buildBasePostSchema(input);
 
   return {
-    "@context": "https://schema.org" as const,
+    "@context": SCHEMA_CONTEXT,
     "@type": "Article",
     "@id": `${canonicalPostUrl}#article`,
     ...schema,
@@ -294,7 +343,7 @@ export function buildPersonSchema(input: {
   };
 
   return {
-    "@context": "https://schema.org" as const,
+    "@context": SCHEMA_CONTEXT,
     "@type": "Person",
     "@id": toAbsoluteUrl(PERSON_ID),
     name: "Alex Leung",
@@ -419,7 +468,7 @@ export function buildProfessionalServiceSchema(input: {
   description: string;
 }): WithContext<Service> {
   return {
-    "@context": "https://schema.org" as const,
+    "@context": SCHEMA_CONTEXT,
     "@type": "Service",
     "@id": toAbsoluteUrl("/#service"),
     name: "Software Engineering, AI Systems, and Product Engineering",
@@ -435,7 +484,7 @@ export function buildWebsiteSchema(input: {
   description: string;
 }): WithContext<WebSite> {
   return {
-    "@context": "https://schema.org" as const,
+    "@context": SCHEMA_CONTEXT,
     "@type": "WebSite",
     "@id": toAbsoluteUrl(WEBSITE_ID),
     url: SITE_ROOT,
@@ -475,17 +524,17 @@ export function buildWebsiteSchema(input: {
 
 export function buildSiteNavigationSchema(): WithContext<SiteNavigationElement> {
   return {
-    "@context": "https://schema.org" as const,
-    "@type": "SiteNavigationElement",
+    "@context": SCHEMA_CONTEXT,
+    "@type": SITE_NAVIGATION_ELEMENT_TYPE,
     "@id": toAbsoluteUrl(SITE_NAVIGATION_ID),
     name: "Main navigation",
     url: SITE_ROOT,
     isPartOf: {
-      "@type": "WebSite",
+      "@type": WEBSITE_TYPE,
       "@id": toAbsoluteUrl(WEBSITE_ID),
     },
     hasPart: NAV_LINKS.map((item) => ({
-      "@type": "SiteNavigationElement" as const,
+      "@type": SITE_NAVIGATION_ELEMENT_TYPE,
       "@id": toAbsoluteUrl(`/#site-navigation-${item.id}`),
       name: item.label,
       url: toCanonical(item.canonicalPath),


### PR DESCRIPTION
## Summary
- enforce a repository-wide ban on TypeScript type assertions, including `as const`
- refactor source and test code to use guards, typed helpers, and `satisfies` instead of assertions
- remove the remaining assertion sites so the repository no longer needs any eslint disable exceptions

## Why
- the repository allowed ad hoc assertions because ESLint was only using the default TypeScript rules
- banning assertions at lint time makes future regressions fail fast and keeps runtime narrowing explicit

## Impact
- invalid UI and query-string values are narrowed through runtime guards instead of casts
- tests and schema helpers use typed mocks and object checks rather than assertion escapes
- the repository now has zero TypeScript type assertions

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn test:e2e`
- `yarn test:e2e:visual`
