### PR TITLE
Clarify agent copy voice guidance

### DIFF
--- a/.agents/skills/blog-post-creator/SKILL.md
+++ b/.agents/skills/blog-post-creator/SKILL.md
@@ -11,8 +11,11 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 
 - Write analytical, structured, and practical prose.
 - Keep tone warm but understated: confident, relationship-aware, and forward-looking.
-- Keep prose professional with emotional intelligence.
+- Keep prose professional with emotional intelligence, but not sterile.
+- Write in first person when the post draws on the author's own experience, judgment, or learning.
+- Show experience through concrete observations, trade-offs, project details, and limitations rather than self-promotional claims.
 - Avoid theatrics, hype language, and performative emphasis.
+- Avoid recruiter-optimized framing, inflated positioning, and polished slogans; keep the authorial stance humble, grounded, and specific.
 - Do not assert significance with phrases like "this is important because", "this matters because", or similar authorial signposting; let significance emerge from the concrete facts, trade-offs, and consequences.
 - When the piece is intentionally reflective or artistic, allow a more lyrical register, but keep it anchored in concrete observation, personal judgment, or a clearly stated tension.
 
@@ -35,6 +38,8 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 14. Avoid draft-scaffolding transitions such as `the third thread is simpler`, `another point is`, or similar meta-organizing phrases when the section can just begin with the actual idea.
 15. When contrasting two things, make sure they are genuinely distinct. Do not restate the same concept twice with different wording just to make a sentence feel polished.
 16. Keep claims tightly bounded to what the user actually said. Avoid time-scale claims like `over time` or broader experiential conclusions unless the user explicitly established them.
+17. Do not turn learning notes, project writeups, or personal reflections into portfolio positioning. If a professional detail belongs, state it plainly as context.
+18. Keep titles and excerpts specific, modest, and representative of the post rather than optimized for authority or reach.
 
 ## Workflow
 
@@ -92,6 +97,7 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Keep claims bounded and testable; mark assumptions when needed.
 - Run an assumption audit: check that agency/ownership wording matches the user's input and that title/heading tone matches the user's preference for directness.
 - Run a practice audit: remove any implication that the author builds, tunes, deploys, or routinely uses systems unless the user explicitly stated that.
+- Run a voice audit: make sure the piece feels humble, grounded, clearly experienced through evidence, and free of recruiter-style positioning.
 - Run a vagueness audit: replace underspecified abstractions like "shift", "this", "that", "result", or "it" when the referent would be unclear in isolation.
 - Run a concreteness audit: replace broad framing lines with the underlying claim whenever possible, especially around technical mechanisms, implementation constraints, and UI behavior.
 - Run a transition audit: make sure each section clearly connects to the one before it; add a bridging sentence when the relationship is not obvious.
@@ -120,6 +126,7 @@ Use this skill to produce publish-ready markdown posts that match the patterns u
 - Ensure polished or slogan-like phrasing has been flattened into plain analytical prose.
 - For reflective/artistic pieces, ensure the abstraction is earned by concrete setup and not sustained for too long without grounding.
 - Ensure no inferred facts were introduced around who did what.
+- Ensure title, excerpt, and intro copy do not overstate the piece or frame the author as a brand.
 
 ## Quick Rewrite Patterns
 

--- a/.agents/skills/blog-post-creator/references/voice-and-structure.md
+++ b/.agents/skills/blog-post-creator/references/voice-and-structure.md
@@ -5,6 +5,8 @@
 - Use analytical, practical, and measured language.
 - Use first person singular when presenting experience and judgment.
 - Keep tone warm but restrained; avoid hype, slogans, and performative phrasing.
+- Keep the voice humble, grounded, and clearly experienced through concrete evidence rather than self-description.
+- Avoid recruiter-optimized or self-promotional framing; prefer factual context over authority claims.
 - Do not signal significance with lines like "this matters because"; make the stakes legible through concrete detail and consequence instead.
 - Explain trade-offs and constraints instead of presenting absolute claims.
 - Prefer direct mechanism over framing language; if a sentence can name the actual behavior, constraint, or operation, do that instead of abstract setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,12 +162,16 @@ yarn deploy           # Build and deploy to GitHub Pages
 
 ### Copy Editing Guardrails (Agent Guidance)
 
+- Target site voice: first-person where appropriate; humble, grounded, and clearly experienced; warm but understated; professional without becoming sterile. Confidence should come from evidence, specific work, and concrete observations rather than self-description or positioning claims.
 - Tone should be thoughtful, understated, concrete, and mildly warm. Prefer clear first-person language and specific descriptions over polished positioning copy.
 - Prefer revising existing copy over rewriting from scratch unless the current structure is actively causing clarity or tone problems.
 - Prefer site-representative language over recruiter-optimized phrasing in top-level labels such as homepage headlines, page titles, section names, metadata descriptions, `public/manifest.json`, `public/llms.txt`, RSS/feed text, and JSON-LD descriptions.
+- Treat visible pages and machine-facing summaries as one editorial system: navigation labels, CTA labels, blog titles/excerpts/intros, metadata, RSS/feed text, manifest text, `llms.txt`, and JSON-LD/schema text should feel consistent without becoming copy-pasted.
 - Preserve warmth and voice before adding positioning language. Avoid recruiter-buzzy or self-promotional filler such as `thought leader`, `world-class`, `high-impact`, `passionate`, `results-driven`, or similar phrasing. Avoid inflated claims or interpretive self-assessments when a simpler factual description will do.
 - Do not force SEO phrases into headings when they fit better in supporting copy or metadata descriptions.
 - Avoid repeating the same positioning claim across hero, section intros, metadata, manifest text, RSS text, `llms.txt`, and JSON-LD. Keep them directionally consistent without making them all identical.
+- For metadata and machine-facing summaries, prefer durable wording over quickly stale current-state details unless the surface is intentionally time-stamped, such as the body of the Now page.
+- Use credentials, project history, and domain experience as factual context when relevant, but avoid turning them into a pitch.
 - Prefer direct, literal phrasing over abstract framing when editing prose. If the concrete mechanism, limitation, UI behavior, or comparison can be named directly, name it.
 - Avoid draft-scaffolding phrases such as `the third thread`, `interesting middle ground`, or similar meta-organizing language when the actual point can be stated plainly.
 - Avoid rhetorical contrast templates like `it is one thing ... it is another ...` unless the user explicitly wants a more essayistic style.


### PR DESCRIPTION
## Summary
- make the repo-wide copy guidance explicit about the target voice: humble, grounded, clearly experienced through evidence, warm, and professional without becoming sterile
- clarify that visible pages and machine-facing summaries should follow one editorial system without repeating identical positioning copy
- extend the blog-post creator skill and voice reference so future post drafts avoid recruiter-style framing and show experience through concrete details

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- internal static-export href check (`41` HTML files)
- `yarn test:e2e`
- `yarn test:e2e:visual`