### PR TITLE
Clean up documentation inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ Personal website and writing hub for Alex Leung. Built with Next.js 16, React 19
 - `yarn lint:fix` — auto-fix lint/format issues
 - `yarn test` — run Jest tests
 - `yarn test:e2e` — run Playwright smoke tests in Docker against the exported site
+- `yarn test:e2e:host` — run Playwright smoke tests directly on the host when Docker is unavailable
 - `yarn test:e2e:visual` — run Playwright visual regression tests in Docker
+- `yarn test:e2e:visual:host` — run Playwright visual regression tests directly on the host when Docker is unavailable
 - `yarn test:e2e:visual:update` — regenerate Playwright visual snapshots in Docker
+- `yarn test:e2e:visual:update:host` — regenerate Playwright visual snapshots directly on the host when Docker is unavailable
 - `yarn typecheck` — run TypeScript check (`tsc --noEmit`)
 - `yarn test:watch` — run tests in watch mode
 - `yarn test:coverage` — run tests with coverage
@@ -60,69 +63,19 @@ Google Analytics is gated behind `NEXT_PUBLIC_ENABLE_ANALYTICS=true`, so analyti
 
 ## End-to-End Testing
 
-Playwright runs in the official Playwright Docker image by default via `docker compose`, and the suite targets the static export rather than `yarn dev`. That keeps browser/system dependencies pinned and matches the GitHub Pages deployment model without the Next.js dev indicator. When Docker is unavailable, use the host-mode wrappers instead of the Docker commands so the same suites can still run in cloud agent environments.
+Playwright targets the static export rather than `yarn dev`. Use Docker commands by default, and use the host-mode wrappers when Docker is unavailable.
 
-The smoke suite currently runs across desktop Chrome, desktop Safari/WebKit, Android Chrome, and Mobile Safari. The visual suite runs on desktop Chromium plus a single mobile Chromium lane so mobile layout regressions are covered without exploding the snapshot matrix.
+```bash
+yarn test:e2e
+yarn test:e2e:visual
+PLAYWRIGHT_BASE_URL=https://alexleung.ca yarn test:e2e
+```
 
-1. Run smoke tests against a locally built export:
-
-   ```bash
-   yarn test:e2e
-   ```
-
-   If Docker is unavailable:
-
-   ```bash
-   yarn test:e2e:host
-   ```
-
-2. Run visual regression tests or intentionally refresh their snapshots:
-
-   ```bash
-   yarn test:e2e:visual
-   yarn test:e2e:visual:update
-   ```
-
-   If Docker is unavailable:
-
-   ```bash
-   yarn test:e2e:visual:host
-   yarn test:e2e:visual:update:host
-   ```
-
-3. To retarget the same smoke suite at a deployed site, provide `PLAYWRIGHT_BASE_URL`:
-
-   ```bash
-   PLAYWRIGHT_BASE_URL=https://alexleung.ca yarn test:e2e
-   ```
+See [`docs/playwright-testing-design.md`](./docs/playwright-testing-design.md) for the current browser matrix, host-mode wrappers, visual snapshot workflow, and CI behavior.
 
 ## Codespaces: Lighthouse Setup
 
-In GitHub Codespaces, `yarn perf:lighthouse` may fail by default because:
-
-- no Chrome binary is preinstalled in the container
-- required shared libraries for headless Chrome are missing
-
-Use this one-time setup:
-
-```bash
-sudo apt-get install -y --no-install-recommends \
-  libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libxkbcommon0 \
-  libatspi2.0-0t64 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
-  libgbm1 libasound2t64
-
-yarn dlx @puppeteer/browsers install chrome@stable --path ./.cache/puppeteer-browsers
-export CHROME_PATH="$(ls -1d .cache/puppeteer-browsers/chrome/linux-*/chrome-linux64/chrome | tail -n1)"
-```
-
-Then run:
-
-```bash
-yarn build
-yarn perf:lighthouse
-```
-
-If you want `CHROME_PATH` to persist across terminals in Codespaces, add the export line to `~/.bashrc`.
+Codespaces may need extra Chrome runtime setup before `yarn perf:lighthouse` can run. See [`docs/codespaces.md`](./docs/codespaces.md) for the current one-time setup and troubleshooting notes.
 
 ## Image Variant Automation
 
@@ -213,11 +166,16 @@ The optimizer visualizer keeps the numerical pieces independent from React. Each
 
 ## Documentation Map
 
-- `docs/README.md` — docs directory guide and consolidation notes
-- `docs/architecture-seo-status.md` — canonical architecture + SEO status snapshot
-- `docs/codespaces.md` — detailed Codespaces troubleshooting for Lighthouse prerequisites
-- `docs/playwright-testing-design.md` — current Playwright E2E and visual testing setup
-- `docs/typography-audit.md` — typography findings and implementation guardrails
+- [`docs/README.md`](./docs/README.md) — docs directory guide and document inventory
+- [`docs/architecture-seo-status.md`](./docs/architecture-seo-status.md) — architecture and SEO status snapshot
+- [`docs/blog-notification-report.md`](./docs/blog-notification-report.md) — RSS and follow.it notification runbook
+- [`docs/codespaces.md`](./docs/codespaces.md) — Codespaces Lighthouse troubleshooting
+- [`docs/playwright-testing-design.md`](./docs/playwright-testing-design.md) — Playwright smoke, visual, host-mode, and CI workflow
+- [`docs/typography-audit.md`](./docs/typography-audit.md) — typography audit history and current prose guardrails
+- [`docs/event-loop-visualizer.md`](./docs/event-loop-visualizer.md) — event loop visualizer model notes
+- [`docs/pid-controller-simulator.md`](./docs/pid-controller-simulator.md) — PID simulator architecture notes
+- [`docs/load-flow-implementation-plan.md`](./docs/load-flow-implementation-plan.md) — load-flow implementation status and remaining slices
+- [`docs/industrial-ee-browser-utilities-plan.md`](./docs/industrial-ee-browser-utilities-plan.md) — parked planning reference for possible future engineering utilities
 
 ## Licensing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,32 @@
 # Documentation Directory Guide
 
-This folder contains active, maintainer-facing documentation that supports implementation and operational decisions.
+This folder contains maintainer-facing documentation that supports implementation, operations, and project memory. Prefer short status/runbook docs for active concerns; keep larger planning artifacts clearly labeled when they are parked or historical.
 
-## Active Document Index
+## Document Index
 
-| File                           | Purpose                                                                       | Update cadence                                                        |
-| ------------------------------ | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `architecture-seo-status.md`   | Canonical status snapshot for technical architecture and SEO                  | After meaningful architecture, metadata, schema, or IA changes        |
-| `blog-notification-report.md`  | Current notification architecture and operational runbook for new-post alerts | When notification provider, subscribe UX, or feed workflow changes    |
-| `codespaces.md`                | Codespaces-specific Lighthouse setup and troubleshooting details              | When Codespaces base image or Lighthouse prerequisites change         |
-| `typography-audit.md`          | Typography findings and guardrails for app/component edits                    | After typography-system or prose-behavior changes                     |
-| `playwright-testing-design.md` | Current hermetic Playwright smoke + visual testing setup and workflow         | When E2E test architecture, CI strategy, or baseline workflow changes |
+### Active Status And Runbooks
+
+| File                           | Purpose                                                               | Update cadence                                                        |
+| ------------------------------ | --------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `architecture-seo-status.md`   | Status snapshot for technical architecture and SEO                    | After meaningful architecture, metadata, schema, or IA changes        |
+| `blog-notification-report.md`  | Notification architecture and operational runbook for new-post alerts | When notification provider, subscribe UX, or feed workflow changes    |
+| `codespaces.md`                | Codespaces-specific Lighthouse setup and troubleshooting details      | When Codespaces base image or Lighthouse prerequisites change         |
+| `playwright-testing-design.md` | Hermetic Playwright smoke + visual testing setup and workflow         | When E2E test architecture, CI strategy, or baseline workflow changes |
+| `typography-audit.md`          | Typography audit history and current prose guardrails                 | After typography-system or prose-behavior changes                     |
+
+### Feature Notes
+
+| File                               | Purpose                                                     | Update cadence                                              |
+| ---------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
+| `event-loop-visualizer.md`         | Event loop visualizer model notes and simplifications       | When the model, scheduler, or examples change materially    |
+| `pid-controller-simulator.md`      | PID simulator architecture, math model, and extension notes | When simulator model, presets, or stepping behavior changes |
+| `load-flow-implementation-plan.md` | Load-flow implementation status and remaining work          | When load-flow routing, solver scope, or UI scope changes   |
+
+### Parked Planning References
+
+| File                                      | Purpose                                               | Update cadence                          |
+| ----------------------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| `industrial-ee-browser-utilities-plan.md` | Parked plan for possible future engineering utilities | Only when the plan becomes active again |
 
 ## Scope Rules
 
@@ -25,7 +41,6 @@ This folder contains active, maintainer-facing documentation that supports imple
 - `README.md` (primary project entrypoint)
 - `LICENSE` and `LICENSE-CONTENT`
 - `AGENTS.md`
-- `CLAUDE.md` and `GEMINI.md`
 
 ### Keep outside `/docs`
 
@@ -36,4 +51,5 @@ This folder contains active, maintainer-facing documentation that supports imple
 
 - Prefer concise, status-driven docs over speculative planning notes.
 - Keep one canonical document per concern.
+- Give planning or historical docs an explicit status note near the top.
 - Remove or merge docs when they become duplicative or stale.

--- a/docs/industrial-ee-browser-utilities-plan.md
+++ b/docs/industrial-ee-browser-utilities-plan.md
@@ -1,5 +1,7 @@
 # Industrial Electrical Engineering Browser Utilities – Implementation Plan
 
+Status: **parked planning reference**. This document captures a possible future product direction, not an active implementation plan for the current site. Revisit and revalidate the research, safety, and legal assumptions before using it to drive work.
+
 ## Purpose and Scope
 
 Create four browser-hosted industrial electrical engineering utilities with a shared architecture, validation model, and testing strategy:

--- a/docs/load-flow-implementation-plan.md
+++ b/docs/load-flow-implementation-plan.md
@@ -1,8 +1,8 @@
-# Load Flow Tool (`/load-flow`) – Concrete Implementation Plan
+# Load Flow Tool (`/experimental/load-flow/`) – Implementation Status
 
 ## Goals
 
-Build a fully client-side AC power flow analysis tool at `/load-flow` that supports interactive one-line diagram modeling and robust load-flow solving for:
+Build a fully client-side AC power flow analysis tool at `/experimental/load-flow/` that supports interactive one-line diagram modeling and robust load-flow solving for:
 
 - Bus voltages (`|V|`) and voltage angles (`θ`)
 - Active and reactive power (`P`, `Q`) injections and branch flows
@@ -17,13 +17,15 @@ Build a fully client-side AC power flow analysis tool at `/load-flow` that suppo
 
 This plan is intentionally modular so the solver can be extracted into a separate library later with minimal refactoring.
 
+Status: **active feature note plus remaining-work plan**. The route, editor shell, single-line diagram, reference scenarios, Newton-Raphson solver path, IEEE case loading, and basic results table are implemented. Treat the remaining PR plan as a backlog, not as a full description of the current baseline.
+
 ---
 
-## Progress Update (April 1, 2026)
+## Implementation Status (April 2026)
 
-Completed across the first two slices (PR 1 + PR 2 scope):
+Implemented baseline:
 
-- ✅ Added `/load-flow` route shell and initial workspace layout.
+- ✅ Added `/experimental/load-flow/` route shell and workspace layout.
 - ✅ Added initial domain model contracts under `src/features/load-flow/model/` (`types.ts`, `defaults.ts`, `validation.ts`).
 - ✅ Added validator unit tests covering baseline pre-solve checks.
 - ✅ Follow-up review hardening: added duplicate bus-ID validation and route coverage tests for the `/experimental/load-flow/` shell.
@@ -32,7 +34,11 @@ Completed across the first two slices (PR 1 + PR 2 scope):
 - ✅ Added normalized editor store helpers under `src/features/load-flow/state/loadFlowStore.ts`.
 - ✅ Added serialization path from editor graph state to `LoadFlowCase` shape (`toLoadFlowCase`).
 - ✅ Added store unit tests for deterministic bus defaults and bus/line serialization behavior.
-- ✅ Added an interactive SVG single-line diagram panel in `/load-flow` with clickable buses/branches and selected-element highlighting.
+- ✅ Added an interactive SVG single-line diagram panel in `/experimental/load-flow/` with clickable buses/branches, selected-element highlighting, bus dragging, auto-layout, and result overlays.
+- ✅ Added `src/features/load-flow/solver/` with algorithm selection, flat-start initialization, Newton-Raphson solving, diagnostics, and branch-flow outputs.
+- ✅ Added built-in 2-bus and 3-bus scenarios plus IEEE 9/14/30/57/118-bus reference scenarios.
+- ✅ Defaulted reference scenario selection to `IEEE 14-Bus` on initial load.
+- ✅ Added solve result rendering for bus voltage angle/magnitude and net P/Q injections.
 
 ## Feedback Follow-ups (April 2, 2026)
 
@@ -49,33 +55,34 @@ Completed across the first two slices (PR 1 + PR 2 scope):
 
 Next recommended slice:
 
-- Build PR 3 solver skeleton: add `graphToCase.ts`, Ybus assembly, and first Newton-Raphson solve loop with deterministic mini-case tests.
+- Move from solver skeleton work to remaining user-facing gaps: generator/load/shunt editing, solver settings controls, branch-flow result tables, validation/diagnostics polish, and import/export.
 
 ---
 
-## Assessment Snapshot (April 1, 2026)
+## Assessment Snapshot (April 2026)
 
 ### 1) UI layer vs core engine separation
 
-Current status: **partially good, but not complete**.
+Current status: **mostly good for the current feature size**.
 
-- Good: the editor state is already in a pure store module (`state/loadFlowStore.ts`), and domain DTOs are in `model/types.ts`.
-- Gap: graph serialization was previously colocated in the UI/editor state module, which couples editor concerns to solve-case DTO concerns.
-- Remediation in this slice: move serialization to `graph/toLoadFlowCase.ts` and keep `state/` focused on editor interactions only.
+- Good: editor state is in `state/loadFlowStore.ts`, domain DTOs are in `model/types.ts`, and graph serialization lives in `graph/toLoadFlowCase.ts`.
+- Remaining gap: generator/load/shunt editing exists in the data model but not as first-class editor UI.
 
 ### 2) Engine implementation plan quality
 
-Current status: **high-level plan existed; algorithm and initialization decisions were under-specified**.
+Current status: **solver facade and first Newton-Raphson path exist**.
 
 - Newton-Raphson remains the primary path for correctness and mixed bus-type robustness.
-- Add explicit strategy for optional algorithm fallback and deterministic initialization policy.
-- Add typed solver options and diagnostics interfaces now so solver internals can evolve without breaking UI contracts.
+- Algorithm selection is intentionally narrow: `NEWTON_RAPHSON` is the only implemented algorithm.
+- Initialization is intentionally narrow: `FLAT_START` is the only implemented mode.
+- Typed solver options and diagnostics are present, but the UI does not yet expose solver settings.
 
 ### 3) Planned directory structure
 
-Current status: **planned in prose, not represented in code yet**.
+Current status: **represented in code, with a flatter solver layout than the original sketch**.
 
-- Remediation in this slice: introduce `graph/` and `solver/` scaffolding directories with typed entrypoints for algorithm selection, initialization, and execution facade.
+- `model/`, `graph/`, `solver/`, and `state/` exist under `src/features/load-flow/`.
+- The original `solver/core` and `solver/io` subdirectories were not introduced; solver modules currently live directly under `solver/`.
 
 ## Non-Goals (Initial Scope)
 
@@ -88,30 +95,52 @@ Current status: **planned in prose, not represented in code yet**.
 
 ## Architecture Overview
 
-### High-level module split
+### Current module split
 
-Proposed directory structure:
+Current directory structure:
 
 ```text
 src/
   app/
-    load-flow/
-      page.tsx
-      _components/
-        LoadFlowWorkspace.tsx
-        CanvasPanel.tsx
-        PalettePanel.tsx
-        PropertiesPanel.tsx
-        SolvePanel.tsx
-        ResultsPanel.tsx
+    experimental/
+      load-flow/
+        page.tsx
+        _components/
+          LoadFlowWorkspace.tsx
+          SingleLineDiagram.tsx
+          __tests__/
   features/
     load-flow/
-      model/
-        types.ts
-        validation.ts
-        defaults.ts
       graph/
         toLoadFlowCase.ts
+      model/
+        defaults.ts
+        types.ts
+        validation.ts
+        __tests__/
+      solver/
+        algorithmSelection.ts
+        complex.ts
+        ieeeReferenceScenarios.ts
+        initialization.ts
+        newtonRaphsonSolver.ts
+        referenceScenarios.ts
+        runLoadFlow.ts
+        types.ts
+        __tests__/
+      state/
+        loadFlowStore.ts
+        __tests__/
+```
+
+Earlier sketches included a deeper `solver/core` and `solver/io` split. The current flatter layout is acceptable while the engine is still small.
+
+Possible future structure if solver size grows:
+
+```text
+src/
+  features/
+    load-flow/
       solver/
         core/
           newtonRaphson.ts
@@ -123,29 +152,20 @@ src/
         io/
           resultTypes.ts
           runLoadFlow.ts
-      state/
-        loadFlowStore.ts
-      workers/
-        loadFlow.worker.ts
-      ui/
-        nodeRenderers.tsx
-        edgeRenderers.tsx
-      __tests__/
-        ...
 ```
 
 ### Solver extraction readiness
 
-From day one, keep the solver side-effect free and UI-agnostic:
+Keep the solver side-effect free and UI-agnostic:
 
 - No React imports in solver modules
 - Pass plain serializable DTOs into solver entrypoints
 - Return structured result objects + diagnostics
-- Keep solver in `src/features/load-flow/solver/core/*`
+- Keep editor concerns in `state/` and graph-to-case adaptation in `graph/`
 
 Future extraction path:
 
-1. Move `solver/core` + `model/types` subset to `packages/load-flow-engine`
+1. Move solver modules + `model/types` subset to `packages/load-flow-engine`
 2. Keep existing `runLoadFlow` wrapper as adapter layer
 3. Preserve API contract (`LoadFlowCase -> LoadFlowResult`)
 
@@ -246,7 +266,9 @@ Follow-up expansion criteria:
 - Singular Jacobian handling with user-readable error
 - Deterministic convergence report (iteration log + max mismatch per iteration)
 
-### Outputs
+### Target outputs
+
+Current implementation returns bus solutions, branch-flow solutions, and solver diagnostics. Constraint summaries remain planned.
 
 - Bus solved voltage magnitude/angle
 - Net bus `P/Q` injections
@@ -256,19 +278,20 @@ Follow-up expansion criteria:
 
 ---
 
-## UI/UX Plan for `/load-flow`
+## UI/UX Plan for `/experimental/load-flow/`
 
-### Canvas interactions
+### Current interactions
 
-- Drag from palette to create nodes/devices
-- Connect buses with line edges
-- Attach generators/loads/shunts to buses
+- Add buses from the palette
+- Connect the first two buses with a line element
+- Drag buses directly in the single-line diagram
 - Select element to edit properties in right panel
 
-### Required user controls
+### Remaining user controls
 
 - Bus type selector (`Slack/PV/PQ`)
-- Global base MVA
+- Global base MVA editor
+- Generator/load/shunt editing
 - Solver settings (tolerance, max iterations, damping)
 - Solve / Reset / Export actions
 
@@ -278,16 +301,17 @@ The workspace should include a dedicated **single-line diagram** visualization
 rather than a plain topology list. The baseline implementation now renders:
 
 - Bus nodes (name + type label) using their editor coordinates
-- Branch segments between bus centers
+- Orthogonal branch polylines between bus centers
 - Selection highlighting for the currently selected bus/branch
 - Click interactions on both buses and branches that sync with the properties panel
+- Drag-to-reposition buses directly in the diagram
+- Basic result overlays through solved bus/branch data
 
 Planned follow-up upgrades:
 
-- Drag-to-reposition buses directly in the diagram (persisting `x`,`y`)
 - Device glyph overlays for generators/loads/shunts at each bus
 - Zoom/pan controls for larger multi-bus systems
-- Optional result overlays (voltage magnitude heatmap and branch flow labels)
+- Richer result overlays (voltage magnitude heatmap and branch flow labels)
 
 ### Validation UX
 
@@ -337,15 +361,15 @@ Pre-solve checks with blocking errors:
 
 ---
 
-## Concrete Implementation Plan (Stacked or Independent PR-Friendly)
+## Remaining Implementation Slices
 
-Below are bite-sized slices designed for clean review. They can be run as stacked PRs or independent PRs against `main`.
+The original PR plan is retained as a status-aware backlog. Completed slices should not be treated as future work.
 
 ### MVP Track
 
 #### PR 1 — Route shell + domain model contracts _(Completed March 31, 2026)_
 
-- ✅ Add `/load-flow` route with placeholder workspace layout
+- ✅ Add `/experimental/load-flow/` route with placeholder workspace layout
 - ✅ Introduce `model/types.ts`, defaults, and validation scaffolding
 - ✅ Add documentation for sign conventions and bus types
 
@@ -359,27 +383,29 @@ Below are bite-sized slices designed for clean review. They can be run as stacke
 
 **Acceptance:** users can create/edit buses and lines; state serializes correctly.
 
-#### PR 3 — Core solver skeleton
+#### PR 3 — Core solver skeleton _(Implemented baseline)_
 
-- Add case conversion (`graphToCase.ts`)
-- Add `Ybus` builder + mismatch + Newton-Raphson loop (no PV limit switching yet)
-- Add initial solver unit tests on small deterministic cases
+- ✅ Add case conversion (`graph/toLoadFlowCase.ts`)
+- ✅ Add `Ybus` assembly, mismatch calculation, Jacobian construction, and Newton-Raphson loop
+- ✅ Add initial solver unit tests on small deterministic cases
+- Remaining: split solver internals only if module size or review pressure justifies it.
 
 **Acceptance:** valid small systems converge and return voltages/angles.
 
-#### PR 4 — Full bus behavior + P/Q results
+#### PR 4 — Full bus behavior + P/Q results _(Partially implemented)_
 
-- Add Slack/PV/PQ equation handling end-to-end
-- Add PV `Q` limits and PV→PQ switching
-- Add result tables for bus/branch `P/Q`
+- ✅ Add Slack/PV/PQ equation handling end-to-end
+- ✅ Add bus P/Q injection outputs
+- ✅ Add branch-flow output data from the solver
+- Remaining: expose branch-flow results in the UI and finish PV `Q` limit switching behavior.
 
 **Acceptance:** solver handles mixed bus types with accurate `P/Q` outputs.
 
-#### PR 5 — Shunt devices (reactor, inductor, capacitor)
+#### PR 5 — Shunt devices (reactor, inductor, capacitor) _(Partially implemented)_
 
-- Add shunt device UI + model representation
-- Stamp shunts into case and solver
-- Add targeted unit tests for reactive behavior/sign conventions
+- ✅ Add model representation
+- ✅ Stamp shunts into the solver
+- Remaining: add shunt device UI and targeted tests for reactive behavior/sign conventions
 
 **Acceptance:** capacitor and reactor/inductor effects appear correctly in `Q` balances and voltages.
 

--- a/docs/playwright-testing-design.md
+++ b/docs/playwright-testing-design.md
@@ -108,6 +108,7 @@ Files:
 
 - `playwright/tests/visual/home-and-about.visual.spec.ts`
 - `playwright/tests/visual/blog.visual.spec.ts`
+- `playwright/tests/visual/experimental.visual.spec.ts`
 
 Current visual baselines are Linux snapshots generated in Docker and focus on top-of-page layout:
 
@@ -115,6 +116,7 @@ Current visual baselines are Linux snapshots generated in Docker and focus on to
 - about top fold
 - blog index top fold
 - blog post top fold
+- experiments hub top fold
 
 Current visual projects:
 

--- a/docs/typography-audit.md
+++ b/docs/typography-audit.md
@@ -3,11 +3,14 @@
 Date: 2026-03-04  
 Scope: `src/app/**` and `src/components/**` (excluding tests)
 
+Status: **audit history with current guardrails**. The original high-priority `ProseContent` issue has been addressed by an explicit `size` prop; keep this file as background for typography decisions and update it only when the typography system changes materially.
+
 ## Summary
 
-- Typography is mostly readable and consistent at a high level, but there is one systemic pitfall: `ProseContent` forces larger copy at `md` and up.
-- The design token utilities in `globals.css` are underused in favor of ad hoc Tailwind text sizes, which increases drift risk.
-- Agent documentation did not previously include typography-specific guardrails.
+- Typography is mostly readable and consistent at a high level.
+- `ProseContent` now defaults to base prose sizing and only applies larger desktop prose through `size="lg"`.
+- The design token utilities in `globals.css` are increasingly used, but ad hoc Tailwind text sizes still appear in feature surfaces and should be introduced deliberately.
+- Agent documentation now includes typography-specific guardrails.
 
 ## Method
 
@@ -16,6 +19,8 @@ Scope: `src/app/**` and `src/components/**` (excluding tests)
 3. Spot-check route-level components for breakpoint behavior.
 
 ## Baseline Metrics
+
+These metrics are from the original March 4, 2026 audit and are retained as historical context.
 
 - Files with typography classes: **17**
 - Unique typography tokens: **35**
@@ -37,38 +42,40 @@ Most frequent typography tokens:
 
 ### High
 
-1. Hidden prose upscaling in shared component
+1. Hidden prose upscaling in shared component (**resolved**)
    - File: `src/components/ProseContent.tsx`
-   - `ProseContent` includes `md:prose-lg` by default, which increases typography size at medium breakpoints regardless of local intent.
-   - This caused the now-page footer note to appear larger than expected when only `text-sm` was provided at call site.
-   - Example call site: `src/app/now/page.tsx`.
+   - `ProseContent` now exposes `size: "sm" | "base" | "lg"` and defaults to `"base"`.
+   - Use `size="lg"` when blog-style prose should scale to `md:prose-lg`.
+   - Use `size="sm"` for small notes/footers so both `prose-sm` and `md:prose-sm` apply.
 
 ### Medium
 
 1. Heavy reliance on ad hoc text classes for regular content
-   - Most `text-*` usage is ad hoc (`67/79`) rather than semantic token classes.
+   - The original audit found most `text-*` usage was ad hoc (`67/79`) rather than semantic token classes.
    - This makes typography harder to reason about and easier to regress during incremental edits.
 
 2. Shared typography tokens are partially unused
-   - `text-body-sm` and `text-body-lg` are defined in `src/app/globals.css` but not currently used by app/components source files.
-   - Signals either dead utilities or missing adoption guidance.
+   - Prefer existing semantic utilities before adding new one-off sizes:
+     `text-body-sm`, `text-body`, `text-body-lg`, `text-heading-sm`, `text-heading`, and the `text-hero-*` utilities.
 
 ### Low
 
-1. No route-level typography verification checklist in docs
-   - Without a documented breakpoint check, regressions like prose-size jumps are easy to miss in review.
+1. Route-level typography verification remains easy to skip
+   - Typography class changes should still be checked at mobile and `md+` breakpoints through local browser inspection or relevant Playwright coverage.
 
 ## Recommended Actions
 
-1. Treat `ProseContent` as opt-in for large desktop prose, not implicit.
-   - Add a `size` prop (`\"base\" | \"sm\" | \"lg\"`) or require explicit override when small text is intended.
+1. Keep `ProseContent` sizing explicit at call sites:
+   - default/base prose: omit `size`
+   - small notes: `size="sm"`
+   - article/body prose that should scale larger at desktop: `size="lg"`
 2. Standardize body-copy usage on semantic token classes first (`text-body`, `text-body-sm`, `text-body-lg`).
-3. Add a lightweight typography checklist to agent docs:
+3. Preserve the lightweight typography checklist in agent docs:
    - no `text-md` (invalid in Tailwind defaults)
    - be explicit with prose breakpoint behavior
    - verify mobile and `md+` before finalizing text-class changes
 
 ## Immediate Follow-up
 
-- Keep the now-page footer note small at all breakpoints by using `prose-sm md:prose-sm` on that `ProseContent` instance.
-- Consider a follow-up PR to introduce a typed `ProseContent` size API so local intent is encoded in props instead of class overrides.
+- Completed: the now-page footer note uses `ProseContent size="sm"`.
+- Completed: `ProseContent` has a typed size API so local intent is encoded in props instead of class overrides.


### PR DESCRIPTION
## Summary
- trim duplicated README runbooks and point to canonical docs for Playwright and Codespaces details
- expand the docs directory inventory into active runbooks, feature notes, and parked planning references
- refresh stale load-flow, typography, and Playwright documentation so it matches the current repo state

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn test:e2e`
- `yarn test:e2e:visual`