### PR TITLE
Simplify utility code paths

### DIFF
--- a/src/features/optimizer-lab/simulation.ts
+++ b/src/features/optimizer-lab/simulation.ts
@@ -92,6 +92,7 @@ export function createRunSnapshot(
 ): RunSnapshot {
   const loss = surface.evaluate(startPoint);
   const gradient = surface.gradient(startPoint);
+  const gradientMagnitude = magnitude(gradient);
 
   return {
     id: config.id,
@@ -102,7 +103,7 @@ export function createRunSnapshot(
     step: 0,
     position: startPoint,
     gradient,
-    gradientMagnitude: magnitude(gradient),
+    gradientMagnitude,
     loss,
     initialLoss: loss,
     status: classifyRunStatus({
@@ -110,7 +111,7 @@ export function createRunSnapshot(
       position: startPoint,
       loss,
       initialLoss: loss,
-      gradientMagnitude: magnitude(gradient),
+      gradientMagnitude,
       recentLosses: [loss],
     }),
     memory: createOptimizerMemory(),

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -204,21 +204,7 @@ function getCachedPostBySlug(slug: string): Post | null {
 }
 
 function getCachedAllPosts(): Post[] {
-  if (!usePersistentCache) {
-    const posts = getPostSlugs()
-      .map((slug) => parsePostBySlug(slug))
-      .filter((post): post is Post => post !== null)
-      .sort(
-        (post1, post2) =>
-          new Date(post2.date).getTime() - new Date(post1.date).getTime()
-      );
-
-    assertUniqueSeriesOrder(posts);
-
-    return posts;
-  }
-
-  if (allPostsCache) {
+  if (usePersistentCache && allPostsCache) {
     return allPostsCache;
   }
 
@@ -232,9 +218,11 @@ function getCachedAllPosts(): Post[] {
 
   assertUniqueSeriesOrder(posts);
 
-  allPostsCache = posts;
+  if (usePersistentCache) {
+    allPostsCache = posts;
+  }
 
-  return allPostsCache;
+  return posts;
 }
 
 function assertUniqueSeriesOrder(posts: readonly Post[]) {

--- a/src/lib/imageVariantManifest.ts
+++ b/src/lib/imageVariantManifest.ts
@@ -70,12 +70,7 @@ export function getImageVariant(
   sourcePath: string | undefined,
   variantName: string
 ): VariantInfo | undefined {
-  const variants = getSourceVariants(sourcePath);
-  if (!variants) {
-    return undefined;
-  }
-
-  return variants[variantName];
+  return getSourceVariants(sourcePath)?.[variantName];
 }
 
 export function getImageVariantSourceSet(

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -2,23 +2,18 @@ import type { Metadata } from "next";
 
 import { toAbsoluteUrl, toCanonical } from "@/lib/seo/url";
 
-import type { SeoImage, SeoInput } from "./types";
+import type { SeoInput } from "./types";
 
 const SITE_NAME = "Alex Leung";
 const DEFAULT_LOCALE = "en_CA";
 
-function normalizeImages(images: SeoImage[] | undefined): SeoImage[] {
-  return (
-    images?.map((image) => ({
-      ...image,
-      url: toAbsoluteUrl(image.url),
-    })) ?? []
-  );
-}
-
 export function buildPageMetadata(input: SeoInput): Metadata {
   const canonicalUrl = toCanonical(input.path);
-  const normalizedImages = normalizeImages(input.images);
+  const normalizedImages =
+    input.images?.map((image) => ({
+      ...image,
+      url: toAbsoluteUrl(image.url),
+    })) ?? [];
   const hasImages = normalizedImages.length > 0;
   const twitterCard =
     input.twitterCard || (hasImages ? "summary_large_image" : "summary");

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -7,15 +7,11 @@ export type TagEntry = {
   slug: string;
 };
 
-function normalizeTagSlugPart(value: string): string {
-  return value
+export function toTagSlug(tag: string): string {
+  return tag
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-}
-
-export function toTagSlug(tag: string): string {
-  return normalizeTagSlugPart(tag);
 }
 
 export function getTagPath(tag: string): string {


### PR DESCRIPTION
## Summary
- collapse duplicated blog post loading branches while preserving persistent cache behavior
- inline one-use helpers for tag slugging, metadata image normalization, and image variant lookup
- reuse optimizer gradient magnitude during initial run setup

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- yarn test:e2e
- yarn test:e2e:visual