### PR TITLE
Remove unused exports and dead helpers

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreDependencies": ["http-server"],
+  "ignoreFiles": ["next-env.d.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/hast": "^3.0.4",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:coverage": "jest --coverage",
     "perf:lighthouse": "lhci autorun --config=.lighthouserc.json",
     "lint": "eslint . && prettier --check '{src,docs,playwright,scripts,.github}/**/*.{js,jsx,ts,tsx,css,md,json,yml,mjs}' '*.{js,mjs,ts,json,md,yml}'",
+    "lint:unused": "knip --reporter compact",
     "lint:fix": "eslint --fix . && prettier --write '{src,docs,playwright,scripts,.github}/**/*.{js,jsx,ts,tsx,css,md,json,yml,mjs}' '*.{js,mjs,ts,json,md,yml}'",
     "predeploy": "yarn build:prod",
     "deploy": "gh-pages -d out"
@@ -70,6 +71,7 @@
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "katex": "^0.16.45",
+    "knip": "^6.7.0",
     "postcss": "^8.5.10",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "perf:lighthouse": "lhci autorun --config=.lighthouserc.json",
-    "lint": "eslint . && prettier --check '{src,docs,playwright,scripts,.github}/**/*.{js,jsx,ts,tsx,css,md,json,yml,mjs}' '*.{js,mjs,ts,json,md,yml}'",
+    "lint": "eslint . && prettier --check '{src,docs,playwright,scripts,.github}/**/*.{js,jsx,ts,tsx,css,md,json,yml,mjs}' '*.{js,mjs,ts,json,md,yml}' && yarn lint:unused",
     "lint:unused": "knip --reporter compact",
     "lint:fix": "eslint --fix . && prettier --write '{src,docs,playwright,scripts,.github}/**/*.{js,jsx,ts,tsx,css,md,json,yml,mjs}' '*.{js,mjs,ts,json,md,yml}'",
     "predeploy": "yarn build:prod",

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 import { Surface } from "@/components/Surface";
 
-export interface CardProps {
+interface CardProps {
   children: ReactNode;
   className?: string;
 }

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 import { LinkText } from "@/components/LinkText";
 
-export interface ExternalLinkProps {
+interface ExternalLinkProps {
   href: string;
   children: ReactNode;
   className?: string;

--- a/src/components/JsonLdBreadcrumbs.tsx
+++ b/src/components/JsonLdBreadcrumbs.tsx
@@ -4,12 +4,12 @@ import { BreadcrumbList } from "schema-dts";
 
 import { toCanonical } from "@/lib/seo";
 
-export type JsonLdBreadcrumbItem = {
+type JsonLdBreadcrumbItem = {
   name: string;
   item: string;
 };
 
-export type JsonLdBreadcrumbsProps = {
+type JsonLdBreadcrumbsProps = {
   items: JsonLdBreadcrumbItem[];
 };
 

--- a/src/components/Subtitle.tsx
+++ b/src/components/Subtitle.tsx
@@ -1,4 +1,4 @@
-export type SubtitleProps = {
+type SubtitleProps = {
   title: string;
   id?: string;
 };

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,4 +1,4 @@
-export type TitleProps = {
+type TitleProps = {
   title: string;
   id?: string;
 };

--- a/src/constants/experiments.ts
+++ b/src/constants/experiments.ts
@@ -1,4 +1,4 @@
-export type ExperimentEntry = {
+type ExperimentEntry = {
   description: string;
   id: string;
   lastModified: string;

--- a/src/features/event-loop/types.ts
+++ b/src/features/event-loop/types.ts
@@ -1,11 +1,6 @@
 export type QueueKind = "sync" | "microtask" | "task";
 
-export type TimelineEventType =
-  | "run"
-  | "schedule"
-  | "complete"
-  | "idle"
-  | "tick";
+type TimelineEventType = "run" | "schedule" | "complete" | "idle" | "tick";
 
 export type Operation =
   | {

--- a/src/features/load-flow/model/types.ts
+++ b/src/features/load-flow/model/types.ts
@@ -1,6 +1,6 @@
 export type BusType = "SLACK" | "PV" | "PQ";
 
-export type ShuntDeviceKind = "REACTOR" | "INDUCTOR" | "CAPACITOR";
+type ShuntDeviceKind = "REACTOR" | "INDUCTOR" | "CAPACITOR";
 
 export interface Bus {
   id: string;

--- a/src/features/load-flow/model/validation.ts
+++ b/src/features/load-flow/model/validation.ts
@@ -1,6 +1,6 @@
 import { LoadFlowCase } from "@/features/load-flow/model/types";
 
-export interface LoadFlowValidationResult {
+interface LoadFlowValidationResult {
   errors: string[];
 }
 

--- a/src/features/load-flow/solver/algorithmSelection.ts
+++ b/src/features/load-flow/solver/algorithmSelection.ts
@@ -2,7 +2,7 @@ import { LoadFlowCase } from "@/features/load-flow/model/types";
 
 import { SolveOptions, SolverAlgorithm } from "./types";
 
-export interface AlgorithmSelectionDecision {
+interface AlgorithmSelectionDecision {
   selected: SolverAlgorithm;
   reason: string;
 }

--- a/src/features/load-flow/solver/complex.ts
+++ b/src/features/load-flow/solver/complex.ts
@@ -10,11 +10,6 @@ export const addComplex = (a: Complex, b: Complex): Complex => ({
   im: a.im + b.im,
 });
 
-export const subtractComplex = (a: Complex, b: Complex): Complex => ({
-  re: a.re - b.re,
-  im: a.im - b.im,
-});
-
 export const multiplyComplex = (a: Complex, b: Complex): Complex => ({
   re: a.re * b.re - a.im * b.im,
   im: a.re * b.im + a.im * b.re,

--- a/src/features/load-flow/solver/runLoadFlow.ts
+++ b/src/features/load-flow/solver/runLoadFlow.ts
@@ -3,12 +3,7 @@ import { validateLoadFlowCase } from "@/features/load-flow/model/validation";
 
 import { selectSolverAlgorithm } from "./algorithmSelection";
 import { solveWithNewtonRaphson } from "./newtonRaphsonSolver";
-import {
-  DEFAULT_SOLVE_OPTIONS,
-  LoadFlowEngine,
-  LoadFlowResult,
-  SolveOptions,
-} from "./types";
+import { DEFAULT_SOLVE_OPTIONS, LoadFlowResult, SolveOptions } from "./types";
 
 export const runLoadFlow = (
   loadFlowCase: LoadFlowCase,
@@ -69,8 +64,4 @@ export const runLoadFlow = (
       iterationMaxMismatchPu: [],
     },
   };
-};
-
-export const loadFlowEngine: LoadFlowEngine = {
-  solve: runLoadFlow,
 };

--- a/src/features/load-flow/solver/types.ts
+++ b/src/features/load-flow/solver/types.ts
@@ -1,5 +1,3 @@
-import { LoadFlowCase } from "@/features/load-flow/model/types";
-
 /**
  * Keep the public surface area intentionally narrow until the first
  * numerical kernel is production-ready.
@@ -42,7 +40,7 @@ export interface BranchFlowSolution {
   qLossMVar: number;
 }
 
-export interface LoadFlowDiagnostics {
+interface LoadFlowDiagnostics {
   converged: boolean;
   algorithm: SolverAlgorithm;
   initialization: InitializationMode;
@@ -56,13 +54,6 @@ export interface LoadFlowResult {
   diagnostics: LoadFlowDiagnostics;
   buses?: BusSolution[];
   branchFlows?: BranchFlowSolution[];
-}
-
-export interface LoadFlowEngine {
-  solve: (
-    loadFlowCase: LoadFlowCase,
-    options?: Partial<SolveOptions>
-  ) => LoadFlowResult;
 }
 
 export const DEFAULT_SOLVE_OPTIONS: SolveOptions = {

--- a/src/features/mandelbrot/gpu.ts
+++ b/src/features/mandelbrot/gpu.ts
@@ -186,12 +186,12 @@ type WebGpuRenderPassDescriptor = {
   }>;
 };
 
-export type WebGpuAvailability = {
+type WebGpuAvailability = {
   isAvailable: boolean;
   reason?: string;
 };
 
-export type WebGpuRenderResult = {
+type WebGpuRenderResult = {
   completed: boolean;
   rendered: boolean;
   fallbackReason?: string;

--- a/src/features/mandelbrot/renderer.ts
+++ b/src/features/mandelbrot/renderer.ts
@@ -23,7 +23,7 @@ import {
 const DECIMAL_ROWS_PER_CHUNK = 6;
 const NUMBER_ROWS_PER_CHUNK = 20;
 
-export type RenderExecutionResult = {
+type RenderExecutionResult = {
   completed: boolean;
   backend: RenderBackend;
   gpuFallbackReason?: string;
@@ -58,7 +58,7 @@ function nextFrame(): Promise<void> {
   });
 }
 
-export async function renderMandelbrot({
+async function renderMandelbrot({
   viewport,
   size,
   settings,

--- a/src/features/mandelbrot/types.ts
+++ b/src/features/mandelbrot/types.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js";
 
-export type PreciseDecimal = Decimal;
+type PreciseDecimal = Decimal;
 
 export type ComplexPoint = {
   real: PreciseDecimal;
@@ -51,7 +51,7 @@ export type EscapeResult = {
   smoothIteration: number;
 };
 
-export type RenderChunk = {
+type RenderChunk = {
   startRow: number;
   rowCount: number;
   pixels: Uint8ClampedArray;

--- a/src/features/mandelbrot/useMandelbrotRender.ts
+++ b/src/features/mandelbrot/useMandelbrotRender.ts
@@ -13,9 +13,9 @@ import {
   RenderBackend,
 } from "@/features/mandelbrot/types";
 
-export type RenderPhase = "idle" | "preview" | "refining" | "ready" | "error";
+type RenderPhase = "idle" | "preview" | "refining" | "ready" | "error";
 
-export type RenderState = {
+type RenderState = {
   phase: RenderPhase;
   progress: number;
   message: string;

--- a/src/features/mandelbrot/viewport.ts
+++ b/src/features/mandelbrot/viewport.ts
@@ -56,10 +56,7 @@ export function cloneViewport(viewport: PreciseViewport): PreciseViewport {
   };
 }
 
-export function viewportHeightForSize(
-  width: Decimal.Value,
-  size: PixelSize
-): Decimal {
+function viewportHeightForSize(width: Decimal.Value, size: PixelSize): Decimal {
   const preciseWidth = precise(width);
   configurePrecisionForWidth(preciseWidth);
 

--- a/src/features/optimizer-lab/sampling.ts
+++ b/src/features/optimizer-lab/sampling.ts
@@ -67,10 +67,7 @@ export function normalizePoint(
   };
 }
 
-export function denormalizePoint(
-  surface: SurfaceDefinition,
-  point: Vector2
-): Vector2 {
+function denormalizePoint(surface: SurfaceDefinition, point: Vector2): Vector2 {
   const xRange = surface.domain.xMax - surface.domain.xMin;
   const yRange = surface.domain.yMax - surface.domain.yMin;
 

--- a/src/features/optimizer-lab/simulation.ts
+++ b/src/features/optimizer-lab/simulation.ts
@@ -9,11 +9,7 @@ import {
   SurfaceDefinition,
   Vector2,
 } from "@/features/optimizer-lab/types";
-import {
-  magnitude,
-  maxAbsComponent,
-  ZERO_VECTOR,
-} from "@/features/optimizer-lab/vector";
+import { magnitude, maxAbsComponent } from "@/features/optimizer-lab/vector";
 
 const CONVERGENCE_GRADIENT_THRESHOLD = 0.035;
 const PLATEAU_GRADIENT_THRESHOLD = 0.08;
@@ -85,7 +81,7 @@ export function classifyRunStatus({
   return "optimizing";
 }
 
-export function createRunSnapshot(
+function createRunSnapshot(
   surface: SurfaceDefinition,
   config: RunConfig,
   startPoint: Vector2
@@ -186,24 +182,4 @@ export function hasAnyActiveRun(
     const matchingConfig = configs.find((config) => config.id === run.id);
     return matchingConfig?.enabled && run.status === "optimizing";
   });
-}
-
-export function createEmptyRunSnapshot(config: RunConfig): RunSnapshot {
-  return {
-    id: config.id,
-    label: config.label,
-    color: config.color,
-    enabled: config.enabled,
-    optimizerId: config.optimizerId,
-    step: 0,
-    position: ZERO_VECTOR,
-    gradient: ZERO_VECTOR,
-    gradientMagnitude: 0,
-    loss: 0,
-    initialLoss: 0,
-    status: "optimizing",
-    memory: createOptimizerMemory(),
-    trail: [ZERO_VECTOR],
-    recentLosses: [0],
-  };
 }

--- a/src/features/optimizer-lab/types.ts
+++ b/src/features/optimizer-lab/types.ts
@@ -26,7 +26,7 @@ export type SurfaceDefinition = {
   gradient: (point: Vector2) => Vector2;
 };
 
-export type OptimizerTuning = {
+type OptimizerTuning = {
   learningRate: number;
   momentum: number;
   beta1: number;

--- a/src/features/optimizer-lab/vector.ts
+++ b/src/features/optimizer-lab/vector.ts
@@ -33,7 +33,3 @@ export function magnitude(vector: Vector2): number {
 export function maxAbsComponent(vector: Vector2): number {
   return Math.max(Math.abs(vector.x), Math.abs(vector.y));
 }
-
-export function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
-}

--- a/src/features/pid-simulator/firstOrderPlant.ts
+++ b/src/features/pid-simulator/firstOrderPlant.ts
@@ -1,6 +1,6 @@
 import { PlantModel, PlantState } from "@/features/pid-simulator/types";
 
-export type FirstOrderPlantConfig = {
+type FirstOrderPlantConfig = {
   gain: number;
   timeConstantSeconds: number;
   initialOutput: number;

--- a/src/features/pid-simulator/pidController.ts
+++ b/src/features/pid-simulator/pidController.ts
@@ -1,13 +1,13 @@
 import { PidControllerConfig } from "@/features/pid-simulator/types";
 import { clamp } from "@/features/pid-simulator/utils";
 
-export type PidTerms = {
+type PidTerms = {
   proportional: number;
   integral: number;
   derivative: number;
 };
 
-export type PidStepResult = {
+type PidStepResult = {
   output: number;
   error: number;
   terms: PidTerms;

--- a/src/features/pid-simulator/presets.ts
+++ b/src/features/pid-simulator/presets.ts
@@ -1,6 +1,6 @@
 import { SimulatorPreset } from "@/features/pid-simulator/types";
 
-export const PID_SIMULATOR_DEFAULT_SETPOINT = 1;
+const PID_SIMULATOR_DEFAULT_SETPOINT = 1;
 
 export const PID_SIMULATOR_PRESETS: readonly SimulatorPreset[] = [
   {

--- a/src/features/pid-simulator/types.ts
+++ b/src/features/pid-simulator/types.ts
@@ -4,7 +4,7 @@ export type SimulatorPresetId =
   | "overdamped"
   | "oscillatory";
 
-export type PidGains = {
+type PidGains = {
   kp: number;
   ki: number;
   kd: number;

--- a/src/lib/coverVariants.ts
+++ b/src/lib/coverVariants.ts
@@ -4,7 +4,7 @@ import {
   getLargestImageVariant,
 } from "@/lib/imageVariantManifest";
 
-export type CoverVariant = "card" | "hero";
+type CoverVariant = "card" | "hero";
 
 export function getCoverVariantSourceSet(
   src: string | undefined,

--- a/src/lib/localImageMetadata.ts
+++ b/src/lib/localImageMetadata.ts
@@ -19,7 +19,7 @@ const staticImageProfiles = {
   },
 } satisfies Record<string, StaticImageProfile>;
 
-export type StaticImageProfileName = keyof typeof staticImageProfiles;
+type StaticImageProfileName = keyof typeof staticImageProfiles;
 
 function getRequiredVariant(
   sourcePath: string,

--- a/src/lib/seo/index.ts
+++ b/src/lib/seo/index.ts
@@ -13,5 +13,4 @@ export {
   buildWebPageSchema,
   buildWebsiteSchema,
 } from "./jsonld";
-export type { SeoImage, SeoInput } from "./types";
 export { toAbsoluteUrl, toCanonical } from "./url";

--- a/src/lib/seo/types.ts
+++ b/src/lib/seo/types.ts
@@ -1,4 +1,4 @@
-export type SeoImage = {
+type SeoImage = {
   alt?: string;
   height?: number;
   url: string;

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,13 +1,13 @@
 import { getAllPosts } from "@/lib/blogApi";
 
-export type TagEntry = {
+type TagEntry = {
   count: number;
   latestModified: string;
   name: string;
   slug: string;
 };
 
-export function toTagSlug(tag: string): string {
+function toTagSlug(tag: string): string {
   return tag
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,6 +532,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.9.2":
+  version: 1.9.2
+  resolution: "@emnapi/core@npm:1.9.2"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/5500393f953951bad0768fafaa9191f2d938956b20c6d6a79e5ab696a613a25ce6ad23422bc18e86e6ce8deb147619d8d0d7d413a69f84adc01a6633cc353cd9
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
@@ -549,6 +559,15 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.1.0"
     tslib: "npm:^2.4.0"
   checksum: 10c0/2c242f4b49779bac403e1cbcc98edacdb1c8ad36562408ba9a20663824669e930bc8493be46a2522d9dc946b8d96cd7073970bae914928c7671b5221c85b432e
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.9.2":
+  version: 1.9.2
+  resolution: "@emnapi/runtime@npm:1.9.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/61c3a59e0c36784558b8d58eb02bd04815aa5fb0dbfbaf84d1b3050a78aa0cc63ea129ae806bd1e48062bfeb7fc36eb0e5431740d62f64ea51bdf426404b8caa
   languageName: node
   linkType: hard
 
@@ -576,6 +595,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
   languageName: node
   linkType: hard
 
@@ -1461,6 +1489,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:16.2.4":
   version: 16.2.4
   resolution: "@next/env@npm:16.2.4"
@@ -1582,6 +1622,299 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/26e376d780f60ff16e874a0ac9bc3399186846baae0b6e1352286385ac134d900cc5dafaded77f38d77f86898fc923ae1cee9d7399f0275b1aa24878915d722b
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-android-arm-eabi@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-android-arm-eabi@npm:0.127.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-android-arm64@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-android-arm64@npm:0.127.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-darwin-arm64@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.127.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-darwin-x64@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-darwin-x64@npm:0.127.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-freebsd-x64@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-freebsd-x64@npm:0.127.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm-gnueabihf@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.127.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm-musleabihf@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-arm-musleabihf@npm:0.127.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm64-gnu@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.127.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm64-musl@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.127.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-ppc64-gnu@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-ppc64-gnu@npm:0.127.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-riscv64-gnu@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-riscv64-gnu@npm:0.127.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-riscv64-musl@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-riscv64-musl@npm:0.127.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-s390x-gnu@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-s390x-gnu@npm:0.127.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-x64-gnu@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.127.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-x64-musl@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.127.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-openharmony-arm64@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-openharmony-arm64@npm:0.127.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-wasm32-wasi@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-wasm32-wasi@npm:0.127.0"
+  dependencies:
+    "@emnapi/core": "npm:1.9.2"
+    "@emnapi/runtime": "npm:1.9.2"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-arm64-msvc@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.127.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-ia32-msvc@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-win32-ia32-msvc@npm:0.127.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-x64-msvc@npm:0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.127.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:^0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-project/types@npm:0.127.0"
+  checksum: 10c0/52c0947ac64a9ca119fe971f947e784a35ecd14a072fa3f542a58a5f6c42010b53f2bf92731e39b9899b83c990a9517bbd29d1e5a5b7b489e52616685c6a9278
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm-eabi@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.19.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-android-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.19.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.19.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-darwin-x64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.19.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-freebsd-x64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.19.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.19.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.19.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.19.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-linux-x64-musl@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.19.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-openharmony-arm64@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.19.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-wasm32-wasi@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.19.1"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^1.1.1"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1":
+  version: 11.19.1
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2655,6 +2988,7 @@ __metadata:
     jest: "npm:^30.3.0"
     jest-environment-jsdom: "npm:^30.3.0"
     katex: "npm:^0.16.45"
+    knip: "npm:^6.7.0"
     next: "npm:^16.2.4"
     postcss: "npm:^8.5.10"
     prettier: "npm:^3.8.3"
@@ -4402,6 +4736,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fd-package-json@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fd-package-json@npm:2.0.0"
+  dependencies:
+    walk-up-path: "npm:^4.0.0"
+  checksum: 10c0/a0a48745257bc09c939486608dad9f2ced238f0c64266222cc881618ed4c8f6aa0ccfe45a1e6d4f9ce828509e8d617cec60e2a114851bebb1ff4886dc5ed5112
+  languageName: node
+  linkType: hard
+
 "fd-slicer@npm:~1.1.0":
   version: 1.1.0
   resolution: "fd-slicer@npm:1.1.0"
@@ -4560,6 +4903,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"formatly@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "formatly@npm:0.3.0"
+  dependencies:
+    fd-package-json: "npm:^2.0.0"
+  bin:
+    formatly: bin/index.mjs
+  checksum: 10c0/ef9dbd3cdaee649e9604ea060d8d62d8131eb81117634336592ee2193fc7c98a3f1f1b5d09a045dbd36287ba88edf868ef179d39fbda2f34fbe2be70c42dd014
+  languageName: node
+  linkType: hard
+
 "forwarded@npm:0.2.0":
   version: 0.2.0
   resolution: "forwarded@npm:0.2.0"
@@ -4708,6 +5062,15 @@ __metadata:
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:4.14.0":
+  version: 4.14.0
+  resolution: "get-tsconfig@npm:4.14.0"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/abc2b9275468eb589079a0b7a95eb5107c14fdd0ca6dda1bff116fe774ea1f79975421dcb22a0c86b4f820fcc69a7655dddf9b6d6a8a2c06fcb59e19794c0724
   languageName: node
   linkType: hard
 
@@ -6006,7 +6369,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.6.1":
+"jiti@npm:^2.6.0, jiti@npm:^2.6.1":
   version: 2.6.1
   resolution: "jiti@npm:2.6.1"
   bin:
@@ -6175,6 +6538,31 @@ __metadata:
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
+  languageName: node
+  linkType: hard
+
+"knip@npm:^6.7.0":
+  version: 6.7.0
+  resolution: "knip@npm:6.7.0"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    formatly: "npm:^0.3.0"
+    get-tsconfig: "npm:4.14.0"
+    jiti: "npm:^2.6.0"
+    minimist: "npm:^1.2.8"
+    oxc-parser: "npm:^0.127.0"
+    oxc-resolver: "npm:^11.19.1"
+    picomatch: "npm:^4.0.4"
+    smol-toml: "npm:^1.6.1"
+    strip-json-comments: "npm:5.0.3"
+    tinyglobby: "npm:^0.2.16"
+    unbash: "npm:^3.0.0"
+    yaml: "npm:^2.8.2"
+    zod: "npm:^4.1.11"
+  bin:
+    knip: bin/knip.js
+    knip-bun: bin/knip-bun.js
+  checksum: 10c0/35c13edc66e48cb696c196d0acb4622954041b4b11393e897433cf493bf46c1a591d51ae10911252aebd6424a9ce255f4476dcd9e85b9214e927606669a769b0
   languageName: node
   linkType: hard
 
@@ -7049,7 +7437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.6":
+"minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -7492,6 +7880,145 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxc-parser@npm:^0.127.0":
+  version: 0.127.0
+  resolution: "oxc-parser@npm:0.127.0"
+  dependencies:
+    "@oxc-parser/binding-android-arm-eabi": "npm:0.127.0"
+    "@oxc-parser/binding-android-arm64": "npm:0.127.0"
+    "@oxc-parser/binding-darwin-arm64": "npm:0.127.0"
+    "@oxc-parser/binding-darwin-x64": "npm:0.127.0"
+    "@oxc-parser/binding-freebsd-x64": "npm:0.127.0"
+    "@oxc-parser/binding-linux-arm-gnueabihf": "npm:0.127.0"
+    "@oxc-parser/binding-linux-arm-musleabihf": "npm:0.127.0"
+    "@oxc-parser/binding-linux-arm64-gnu": "npm:0.127.0"
+    "@oxc-parser/binding-linux-arm64-musl": "npm:0.127.0"
+    "@oxc-parser/binding-linux-ppc64-gnu": "npm:0.127.0"
+    "@oxc-parser/binding-linux-riscv64-gnu": "npm:0.127.0"
+    "@oxc-parser/binding-linux-riscv64-musl": "npm:0.127.0"
+    "@oxc-parser/binding-linux-s390x-gnu": "npm:0.127.0"
+    "@oxc-parser/binding-linux-x64-gnu": "npm:0.127.0"
+    "@oxc-parser/binding-linux-x64-musl": "npm:0.127.0"
+    "@oxc-parser/binding-openharmony-arm64": "npm:0.127.0"
+    "@oxc-parser/binding-wasm32-wasi": "npm:0.127.0"
+    "@oxc-parser/binding-win32-arm64-msvc": "npm:0.127.0"
+    "@oxc-parser/binding-win32-ia32-msvc": "npm:0.127.0"
+    "@oxc-parser/binding-win32-x64-msvc": "npm:0.127.0"
+    "@oxc-project/types": "npm:^0.127.0"
+  dependenciesMeta:
+    "@oxc-parser/binding-android-arm-eabi":
+      optional: true
+    "@oxc-parser/binding-android-arm64":
+      optional: true
+    "@oxc-parser/binding-darwin-arm64":
+      optional: true
+    "@oxc-parser/binding-darwin-x64":
+      optional: true
+    "@oxc-parser/binding-freebsd-x64":
+      optional: true
+    "@oxc-parser/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-parser/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-parser/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-parser/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-parser/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-x64-musl":
+      optional: true
+    "@oxc-parser/binding-openharmony-arm64":
+      optional: true
+    "@oxc-parser/binding-wasm32-wasi":
+      optional: true
+    "@oxc-parser/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-parser/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-parser/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/9d109fb3a79c0862a36434cc01c8c0e8f6cf5f1efe9369e02d2183fd518479b10262cf092da2e7f8328befae446afa05ccf742ce12f8346d81429c8f2cdf1651
+  languageName: node
+  linkType: hard
+
+"oxc-resolver@npm:^11.19.1":
+  version: 11.19.1
+  resolution: "oxc-resolver@npm:11.19.1"
+  dependencies:
+    "@oxc-resolver/binding-android-arm-eabi": "npm:11.19.1"
+    "@oxc-resolver/binding-android-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-darwin-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-darwin-x64": "npm:11.19.1"
+    "@oxc-resolver/binding-freebsd-x64": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm-gnueabihf": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm-musleabihf": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-arm64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-ppc64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-riscv64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-riscv64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-s390x-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-x64-gnu": "npm:11.19.1"
+    "@oxc-resolver/binding-linux-x64-musl": "npm:11.19.1"
+    "@oxc-resolver/binding-openharmony-arm64": "npm:11.19.1"
+    "@oxc-resolver/binding-wasm32-wasi": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-arm64-msvc": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-ia32-msvc": "npm:11.19.1"
+    "@oxc-resolver/binding-win32-x64-msvc": "npm:11.19.1"
+  dependenciesMeta:
+    "@oxc-resolver/binding-android-arm-eabi":
+      optional: true
+    "@oxc-resolver/binding-android-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-arm64":
+      optional: true
+    "@oxc-resolver/binding-darwin-x64":
+      optional: true
+    "@oxc-resolver/binding-freebsd-x64":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-riscv64-musl":
+      optional: true
+    "@oxc-resolver/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-resolver/binding-linux-x64-musl":
+      optional: true
+    "@oxc-resolver/binding-openharmony-arm64":
+      optional: true
+    "@oxc-resolver/binding-wasm32-wasi":
+      optional: true
+    "@oxc-resolver/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-ia32-msvc":
+      optional: true
+    "@oxc-resolver/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/8ac4eaffa9c0bcbb9f4f4a2b43786457ec5a68684d8776cb78b5a15ce3d1a79d3e67262aa3c635f98a0c1cd6cd56a31fcb05bffb9a286100056e4ab06b928833
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -7686,7 +8213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:4.0.4":
+"picomatch@npm:4.0.4, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -8281,6 +8808,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
 "restore-cursor@npm:^2.0.0":
   version: 2.0.0
   resolution: "restore-cursor@npm:2.0.0"
@@ -8709,6 +9243,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"smol-toml@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "smol-toml@npm:1.6.1"
+  checksum: 10c0/511a78722f99c7616fdb46af708de3d7e81434b5a3d58061166da73f28bfc6cae4f0cd04683f60515b9c490cd10152fce72287c960b337419c0299cc1f0f2a22
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.5":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
@@ -8933,6 +9474,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-json-comments@npm:5.0.3":
+  version: 5.0.3
+  resolution: "strip-json-comments@npm:5.0.3"
+  checksum: 10c0/daaf20b29f69fb51112698f4a9a662490dbb78d5baf6127c75a0a83c2ac6c078a8c0f74b389ad5e0519d6fc359c4a57cb9971b1ae201aef62ce45a13247791e0
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -9137,6 +9685,16 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.16":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
   languageName: node
   linkType: hard
 
@@ -9352,6 +9910,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
+  languageName: node
+  linkType: hard
+
+"unbash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "unbash@npm:3.0.0"
+  checksum: 10c0/8d237237805c8d23a6a7ba9ba1dac612b79431f2458aaa7975c472eba9f429991e46417fd8cdb14c1ad88adffbc0b914d0556ad5978bc42bbd2fa9b0942a4f91
   languageName: node
   linkType: hard
 
@@ -9672,6 +10237,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"walk-up-path@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "walk-up-path@npm:4.0.0"
+  checksum: 10c0/fabe344f91387d1d41df230af962ef18bf703dd4178006d55cd6412caacd187b54440002d4d53a982d4f7f0455567dcffb6d3884533c8b2268928eca3ebd8a19
+  languageName: node
+  linkType: hard
+
 "walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
@@ -9971,6 +10543,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.8.2":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^13.1.2":
   version: 13.1.2
   resolution: "yargs-parser@npm:13.1.2"
@@ -10056,7 +10637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.3.6":
+"zod@npm:^4.1.11, zod@npm:^4.3.6":
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,6 +2636,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/react": "npm:^16.3.2"
+    "@types/hast": "npm:^3.0.4"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.12.2"
     "@types/react": "npm:^19.2.14"


### PR DESCRIPTION
## Summary
- remove high-confidence dead helpers surfaced by the unused-code audit
- demote file-local types and helpers that were exported only inside their own modules
- add @types/hast as a direct dev dependency for the markdown HAST type import

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- yarn test:e2e
- yarn test:e2e:visual

## Audit notes
- Knip still reports next-env.d.ts and http-server; both are retained as convention/string-use false positives.