### PR TITLE
Add load-flow branch results table

### DIFF
--- a/src/app/experimental/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/experimental/load-flow/_components/LoadFlowWorkspace.tsx
@@ -41,6 +41,8 @@ const isBusType = (value: string): value is BusType =>
 const isBranchStatus = (value: string): value is BranchStatus =>
   BRANCH_STATUS_OPTIONS.some((status) => status === value);
 
+const formatBranchFlowValue = (value: number) => value.toFixed(2);
+
 export function LoadFlowWorkspace() {
   const defaultReferenceScenario = getReferenceScenarioById("ieee-14-bus");
   const [editorState, setEditorState] = useState(() =>
@@ -666,31 +668,135 @@ export function LoadFlowWorkspace() {
           {solveResult.diagnostics.message}
         </p>
         {solveResult.buses ? (
-          <div className="mt-3 overflow-auto">
-            <table className="min-w-full text-left text-xs text-gray-200">
-              <thead>
-                <tr>
-                  <th className="pr-3">Bus</th>
-                  <th className="pr-3">|V| (pu)</th>
-                  <th className="pr-3">θ (deg)</th>
-                  <th className="pr-3">P inj (pu)</th>
-                  <th>Q inj (pu)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {solveResult.buses.map((bus) => (
-                  <tr key={bus.busId}>
-                    <td className="pr-3">{bus.busId}</td>
-                    <td className="pr-3">
-                      {bus.voltageMagnitudePu.toFixed(4)}
-                    </td>
-                    <td className="pr-3">{bus.voltageAngleDeg.toFixed(3)}</td>
-                    <td className="pr-3">{bus.pInjectionPu.toFixed(4)}</td>
-                    <td>{bus.qInjectionPu.toFixed(4)}</td>
+          <div className="mt-4">
+            <h4 className="text-sm font-semibold text-gray-100">
+              Bus voltages and injections
+            </h4>
+            <div className="mt-3 overflow-auto rounded-md border border-gray-700">
+              <table className="min-w-full text-left text-xs text-gray-200">
+                <caption className="sr-only">
+                  Bus voltages and injections
+                </caption>
+                <thead className="bg-gray-950/70 text-gray-300">
+                  <tr>
+                    <th className="px-3 py-2">Bus</th>
+                    <th className="px-3 py-2">|V| (pu)</th>
+                    <th className="px-3 py-2">θ (deg)</th>
+                    <th className="px-3 py-2">P inj (pu)</th>
+                    <th className="px-3 py-2">Q inj (pu)</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-gray-800">
+                  {solveResult.buses.map((bus) => (
+                    <tr key={bus.busId}>
+                      <td className="px-3 py-2 font-medium text-white">
+                        {bus.busId}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {bus.voltageMagnitudePu.toFixed(4)}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {bus.voltageAngleDeg.toFixed(3)}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {bus.pInjectionPu.toFixed(4)}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {bus.qInjectionPu.toFixed(4)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
+        {solveResult.branchFlows?.length ? (
+          <div className="mt-5">
+            <h4 className="text-sm font-semibold text-gray-100">
+              Branch flows and losses
+            </h4>
+            <p className="mt-1 text-xs text-gray-400">
+              Positive direction follows each configured from-bus → to-bus path;
+              reverse columns show the solved receiving-end flow.
+            </p>
+            <div className="mt-3 overflow-auto rounded-md border border-gray-700">
+              <table className="min-w-full text-left text-xs text-gray-200">
+                <caption className="sr-only">Branch flows and losses</caption>
+                <thead className="text-gray-300">
+                  <tr>
+                    <th
+                      rowSpan={2}
+                      className="bg-gray-950/70 px-3 py-2 align-bottom"
+                    >
+                      Branch
+                    </th>
+                    <th
+                      rowSpan={2}
+                      className="bg-gray-950/70 px-3 py-2 align-bottom"
+                    >
+                      Path
+                    </th>
+                    <th
+                      colSpan={2}
+                      className="bg-gray-950/70 px-3 py-2 text-center"
+                    >
+                      From → To
+                    </th>
+                    <th
+                      colSpan={2}
+                      className="bg-gray-950/70 px-3 py-2 text-center"
+                    >
+                      To → From
+                    </th>
+                    <th
+                      colSpan={2}
+                      className="bg-gray-950/70 px-3 py-2 text-center"
+                    >
+                      Loss
+                    </th>
+                  </tr>
+                  <tr className="bg-gray-950/70 text-gray-300">
+                    <th className="px-3 py-2 text-right">MW</th>
+                    <th className="px-3 py-2 text-right">MVar</th>
+                    <th className="px-3 py-2 text-right">MW</th>
+                    <th className="px-3 py-2 text-right">MVar</th>
+                    <th className="px-3 py-2 text-right">MW</th>
+                    <th className="px-3 py-2 text-right">MVar</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-800">
+                  {solveResult.branchFlows.map((branchFlow) => (
+                    <tr key={branchFlow.branchId}>
+                      <td className="whitespace-nowrap px-3 py-2 font-medium text-white">
+                        {branchFlow.branchId}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-gray-300">
+                        {branchFlow.fromBusId} → {branchFlow.toBusId}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {formatBranchFlowValue(branchFlow.pFromToMW)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {formatBranchFlowValue(branchFlow.qFromToMVar)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {formatBranchFlowValue(branchFlow.pToFromMW)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {formatBranchFlowValue(branchFlow.qToFromMVar)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-emerald-100">
+                        {formatBranchFlowValue(branchFlow.pLossMW)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-emerald-100">
+                        {formatBranchFlowValue(branchFlow.qLossMVar)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         ) : null}
       </div>

--- a/src/app/experimental/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
+++ b/src/app/experimental/load-flow/_components/__tests__/LoadFlowWorkspace.test.tsx
@@ -1,6 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { getReferenceScenarioById } from "@/features/load-flow/solver/referenceScenarios";
+import { runLoadFlow } from "@/features/load-flow/solver/runLoadFlow";
 
 import { LoadFlowWorkspace } from "../LoadFlowWorkspace";
+
+const formatBranchFlowValue = (value: number) => value.toFixed(2);
 
 describe("LoadFlowWorkspace", () => {
   it("loads IEEE 14-Bus by default", () => {
@@ -23,6 +28,57 @@ describe("LoadFlowWorkspace", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Grid • SLACK • 230 kV/i)).toBeInTheDocument();
     expect(screen.getByText(/\"id\": \"load-1\"/i)).toBeInTheDocument();
+  });
+
+  it("shows branch MW, MVar, and loss results from the solver output", () => {
+    const scenario = getReferenceScenarioById("two-bus-radial");
+    expect(scenario).toBeDefined();
+
+    const branchFlow = runLoadFlow(scenario!.loadFlowCase).branchFlows?.[0];
+    expect(branchFlow).toBeDefined();
+
+    render(<LoadFlowWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: "2-Bus Radial" }));
+
+    const branchFlowTable = screen.getByRole("table", {
+      name: /branch flows and losses/i,
+    });
+    const branchFlowTableQueries = within(branchFlowTable);
+
+    expect(
+      branchFlowTableQueries.getByRole("columnheader", { name: "From → To" })
+    ).toBeInTheDocument();
+    expect(
+      branchFlowTableQueries.getByRole("columnheader", { name: "To → From" })
+    ).toBeInTheDocument();
+    expect(
+      branchFlowTableQueries.getByRole("columnheader", { name: "Loss" })
+    ).toBeInTheDocument();
+    expect(
+      branchFlowTableQueries.getAllByRole("columnheader", { name: "MW" })
+    ).toHaveLength(3);
+    expect(
+      branchFlowTableQueries.getAllByRole("columnheader", { name: "MVar" })
+    ).toHaveLength(3);
+    expect(
+      branchFlowTableQueries.getByText(
+        `${branchFlow!.fromBusId} → ${branchFlow!.toBusId}`
+      )
+    ).toBeInTheDocument();
+
+    [
+      branchFlow!.pFromToMW,
+      branchFlow!.qFromToMVar,
+      branchFlow!.pToFromMW,
+      branchFlow!.qToFromMVar,
+      branchFlow!.pLossMW,
+      branchFlow!.qLossMVar,
+    ].forEach((value) => {
+      expect(
+        branchFlowTableQueries.getAllByText(formatBranchFlowValue(value)).length
+      ).toBeGreaterThan(0);
+    });
   });
 
   it("keeps reference-bus setpoints when loading a scenario", () => {


### PR DESCRIPTION
## Summary
- add a readable branch flows and losses results table to the load-flow workspace
- group solver output by from-to flow, reverse flow, and MW/MVar losses
- cover the new branch-flow UI with component tests tied to solver output

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- yarn test:e2e
- yarn test:e2e:visual