### PR TITLE
Add blog cover alt text

### DIFF
--- a/content/posts/boring-blog-architecture.md
+++ b/content/posts/boring-blog-architecture.md
@@ -4,6 +4,7 @@ date: "2026-01-31"
 updated: "2026-02-14"
 excerpt: "How I added a fully static, markdown-based blog to my Next.js portfolio."
 coverImage: "/assets/blog/boring-blog-architecture/cover.webp"
+coverAlt: "Illustration of Alex working at a laptop under a desk lamp."
 tags:
   - "Next.js"
   - "Architecture"

--- a/content/posts/camping-indoors-in-san-francisco.md
+++ b/content/posts/camping-indoors-in-san-francisco.md
@@ -3,6 +3,7 @@ title: "Camping Indoors in San Francisco"
 date: "2026-04-27"
 excerpt: "My first week in San Francisco has mostly been logistics, empty rooms, cats, and the slow work of making enough space to focus."
 coverImage: "/assets/blog/camping-indoors-in-san-francisco/cover.webp"
+coverAlt: "Illustration of Alex sitting in an empty apartment with two cats, moving boxes, and a San Francisco view."
 tags:
   - "Reflection"
   - "Lifestyle"

--- a/content/posts/deep-learning-part-1-review.md
+++ b/content/posts/deep-learning-part-1-review.md
@@ -4,6 +4,7 @@ date: "2026-02-07"
 updated: "2026-02-14"
 excerpt: "A short review of Part I of Goodfellow, Bengio, and Courville's Deep Learning textbook, focused on the mathematical foundations."
 coverImage: "/assets/blog/deep-learning-part-1-review/cover.webp"
+coverAlt: "Illustration of Alex taking notes in front of a chalkboard filled with math and probability diagrams."
 tags:
   - "Deep Learning"
   - "Book Notes"

--- a/content/posts/dropout-as-implicit-bagging.md
+++ b/content/posts/dropout-as-implicit-bagging.md
@@ -3,6 +3,7 @@ title: "Dropout as Implicit Bagging in Deep Learning"
 date: "2026-03-07"
 excerpt: "A concrete way to understand dropout in deep learning: shared-parameter ensemble training that approximates bagging without training separate models."
 coverImage: "/assets/blog/dropout-as-implicit-bagging/cover.webp"
+coverAlt: "Illustration of Alex drawing glowing neural network diagrams at a desk."
 tags:
   - "Deep Learning"
   - "ML Theory"

--- a/content/posts/everyone-is-a-builder.md
+++ b/content/posts/everyone-is-a-builder.md
@@ -3,6 +3,7 @@ title: "More People Can Build Rough Tools Now"
 date: "2026-02-28"
 excerpt: "A conversation with colleagues made me think about what changes when the first version of a small tool gets cheaper."
 coverImage: "/assets/blog/everyone-is-a-builder/cover.webp"
+coverAlt: "Illustration of Alex and two colleagues talking over drinks with a city skyline and sketched buildings in the sky."
 tags:
   - "AI"
   - "Future of Work"

--- a/content/posts/from-coder-to-orchestrator.md
+++ b/content/posts/from-coder-to-orchestrator.md
@@ -4,6 +4,7 @@ date: "2026-02-03"
 updated: "2026-02-14"
 excerpt: "How my AI coding workflow moved from quick snippets to clearer briefs, agent review checkpoints, and build/lint/test verification."
 coverImage: "/assets/blog/from-coder-to-orchestrator/cover.webp"
+coverAlt: "Illustration of Alex conducting a room of robots working at screens with code and charts."
 tags:
   - "AI"
   - "Developer Workflow"

--- a/content/posts/ipad-air-m3-11-inch-first-impressions.md
+++ b/content/posts/ipad-air-m3-11-inch-first-impressions.md
@@ -3,6 +3,7 @@ title: "iPad Air M3 11-Inch for Note-Taking: First Impressions"
 date: "2026-03-05"
 excerpt: "First impressions of the 11-inch iPad Air M3 as a lightweight reading, annotation, and note-taking setup for a study-heavy workflow."
 coverImage: "/assets/blog/ipad-air-m3-11-inch-first-impressions/cover.webp"
+coverAlt: "Illustration of Alex beside a tablet note-taking setup at a desk."
 tags:
   - "Tech"
   - "Review"

--- a/content/posts/making-responsive-images-just-work.md
+++ b/content/posts/making-responsive-images-just-work.md
@@ -3,6 +3,7 @@ title: "Making Responsive Images Just Work"
 date: "2026-03-04"
 excerpt: "I replaced scattered responsive-image conventions with a manifest-driven workflow that made authoring simpler and failures easier to see."
 coverImage: "/assets/blog/making-responsive-images-just-work/cover.webp"
+coverAlt: "Illustration of Alex measuring framed landscape images labeled with responsive sizes."
 tags:
   - "Web Performance"
   - "Architecture"

--- a/content/posts/medium-and-meaning.md
+++ b/content/posts/medium-and-meaning.md
@@ -3,6 +3,7 @@ title: "Using AI Tools for Small Site Edits and Visual Ideas"
 date: "2026-02-22"
 excerpt: "Reflections on how Codex, Sora, and other AI tools change the texture of small site edits, exploratory visuals, and creative judgment."
 coverImage: "/assets/blog/medium-and-meaning/cover.webp"
+coverAlt: "Illustration of Alex holding a phone beside a train platform, laptop, and floating interface sketches."
 tags:
   - "AI"
   - "Creativity"

--- a/content/posts/small-interactive-tools-with-a-coding-agent.md
+++ b/content/posts/small-interactive-tools-with-a-coding-agent.md
@@ -3,6 +3,7 @@ title: "Relearning Through Small Interactive Tools"
 date: "2026-04-10"
 excerpt: "Using a coding agent to build small browser tools turned out to be a good way to revisit concepts I had not touched in a while."
 coverImage: "/assets/blog/small-interactive-tools-with-a-coding-agent/cover.png"
+coverAlt: "Illustration of Alex working across several screens showing small interactive tools and charts."
 tags:
   - "AI"
   - "Learning"

--- a/content/posts/structural-reasoning-about-deep-networks.md
+++ b/content/posts/structural-reasoning-about-deep-networks.md
@@ -4,6 +4,7 @@ date: "2026-02-15"
 updated: "2026-02-15"
 excerpt: "Chapter 6 sharpened how I think about architecture as a structural assumption, not just a tuning choice."
 coverImage: "/assets/blog/structural-reasoning-about-deep-networks/cover.webp"
+coverAlt: "Illustration of Alex studying neural network diagrams beside a lake."
 tags:
   - "Deep Learning"
   - "ML Theory"

--- a/src/app/blog/[slug]/__tests__/page.test.tsx
+++ b/src/app/blog/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+
+import Post from "../page";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+jest.mock("@/lib/markdownToHtml", () => ({
+  __esModule: true,
+  default: jest.fn(async () => "<p>Rendered body</p>"),
+}));
+
+jest.mock("@/lib/blogApi", () => ({
+  getPostBySlug: jest.fn((slug: string, fields?: string[]) => {
+    const post = {
+      slug,
+      title: "Cover Alt Hero",
+      date: "2026-01-01T00:00:00.000Z",
+      updated: undefined,
+      content: "Body",
+      coverImage: "/assets/blog/cover.webp",
+      coverAlt: "A laptop beside a notebook on a desk.",
+      excerpt: "A short summary.",
+      tags: [],
+    };
+
+    if (!fields) {
+      return post;
+    }
+
+    return Object.fromEntries(
+      fields.map((field) => {
+        const valuesByField: Record<string, unknown> = post;
+        return [field, valuesByField[field]];
+      })
+    );
+  }),
+  getAllPosts: jest.fn(() => []),
+  getRelatedPosts: jest.fn(() => []),
+  getSeriesNavigation: jest.fn(() => null),
+}));
+
+describe("Blog post page", () => {
+  it("uses custom cover alt text for the hero image", async () => {
+    const view = await Post({
+      params: Promise.resolve({ slug: "cover-alt-hero" }),
+    });
+
+    render(view);
+
+    expect(
+      screen.getByRole("img", {
+        name: "A laptop beside a notebook on a desk.",
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -111,6 +111,7 @@ export default async function Post({ params }: Props) {
     "slug",
     "content",
     "coverImage",
+    "coverAlt",
     "excerpt",
     "tags",
   ]);
@@ -216,7 +217,7 @@ export default async function Post({ params }: Props) {
             <CoverImage
               src={heroCoverImage || post.coverImage}
               srcSet={heroCoverSrcSet}
-              alt={`Cover for ${post.title}`}
+              alt={post.coverAlt || `Cover for ${post.title}`}
               variant="hero"
               sizes="(min-width: 1024px) 896px, 100vw"
               className="mb-6 sm:mx-0 md:mb-10"

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -48,6 +48,7 @@ export default function BlogIndex() {
     "date",
     "slug",
     "coverImage",
+    "coverAlt",
     "excerpt",
     "tags",
   ]);

--- a/src/app/blog/tags/[tag]/page.tsx
+++ b/src/app/blog/tags/[tag]/page.tsx
@@ -38,6 +38,7 @@ function getPostsForTag(tagName: string) {
     "date",
     "slug",
     "coverImage",
+    "coverAlt",
     "excerpt",
     "tags",
   ]).filter((post) => post.tags.includes(tagName));

--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -15,7 +15,7 @@ import { getTagPath } from "@/lib/tags";
 type BlogPostCardProps = {
   post: Pick<
     Post,
-    "slug" | "title" | "date" | "coverImage" | "excerpt" | "tags"
+    "slug" | "title" | "date" | "coverImage" | "coverAlt" | "excerpt" | "tags"
   >;
   coverPriority?: boolean;
   className?: string;
@@ -44,7 +44,7 @@ export function BlogPostCard({
           <CoverImage
             src={cardCoverImage || post.coverImage}
             srcSet={cardCoverSrcSet}
-            alt={`Cover for ${post.title}`}
+            alt={post.coverAlt || `Cover for ${post.title}`}
             variant="card"
             sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
             priority={coverPriority}

--- a/src/components/__tests__/BlogPostCard.test.tsx
+++ b/src/components/__tests__/BlogPostCard.test.tsx
@@ -25,6 +25,7 @@ describe("BlogPostCard", () => {
           title: "Test Post",
           date: "2026-01-01T00:00:00.000Z",
           coverImage: undefined,
+          coverAlt: undefined,
           excerpt: "A short summary",
           tags: ["ai"],
         }}
@@ -51,6 +52,7 @@ describe("BlogPostCard", () => {
           title: "Inline Code Post",
           date: "2026-01-01T00:00:00.000Z",
           coverImage: undefined,
+          coverAlt: undefined,
           excerpt: "Use `srcSet` variants to improve performance.",
           tags: [],
         }}
@@ -59,6 +61,28 @@ describe("BlogPostCard", () => {
 
     expect(
       screen.getByText("srcSet", { selector: "code" })
+    ).toBeInTheDocument();
+  });
+
+  it("uses custom cover alt text when a cover image is present", () => {
+    render(
+      <BlogPostCard
+        post={{
+          slug: "cover-alt-post",
+          title: "Cover Alt Post",
+          date: "2026-01-01T00:00:00.000Z",
+          coverImage: "/assets/blog/cover.webp",
+          coverAlt: "A laptop beside a notebook on a desk.",
+          excerpt: undefined,
+          tags: [],
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("img", {
+        name: "A laptop beside a notebook on a desk.",
+      })
     ).toBeInTheDocument();
   });
 });

--- a/src/lib/__tests__/blogApi.test.ts
+++ b/src/lib/__tests__/blogApi.test.ts
@@ -67,6 +67,18 @@ describe("blogApi front matter validation", () => {
     expect(post?.readingTimeMinutes).toBe(7);
   });
 
+  test("parses optional cover alt text", async () => {
+    const tempDir = setupTempPosts({
+      "cover-alt": `---\ntitle: "Cover Alt"\ndate: "2026-02-16"\ncoverImage: "/assets/blog/cover.webp"\ncoverAlt: "A desk with a laptop and notebook."\n---\nBody`,
+    });
+
+    const { getPostBySlug } = await loadBlogApiAtCwd(tempDir);
+
+    expect(getPostBySlug("cover-alt", ["coverAlt"])).toEqual({
+      coverAlt: "A desk with a laptop and notebook.",
+    });
+  });
+
   test("throws when front matter contains invalid types", async () => {
     const tempDir = setupTempPosts({
       "bad-types": `---\ntitle: "Hello"\ndate: "2026-02-16"\ntags: test\n---\nBody`,

--- a/src/lib/blogApi.ts
+++ b/src/lib/blogApi.ts
@@ -21,6 +21,7 @@ const POST_FIELDS = defineLiteralArray([
   "updated",
   "excerpt",
   "coverImage",
+  "coverAlt",
   "tags",
   "series",
   "seriesOrder",
@@ -43,6 +44,7 @@ export type Post = {
   updated?: string;
   excerpt?: string;
   coverImage?: string;
+  coverAlt?: string;
   tags: string[];
   series?: string;
   seriesOrder?: number;
@@ -58,6 +60,7 @@ const PostFrontMatterSchema = z
     updated: z.string().trim().min(1).optional(),
     excerpt: z.string().trim().min(1).optional(),
     coverImage: z.string().trim().min(1).optional(),
+    coverAlt: z.string().trim().min(1).optional(),
     tags: z.array(z.string().trim().min(1)).default([]),
     series: z.string().trim().min(1).optional(),
     seriesOrder: z.number().int().positive().optional(),
@@ -184,6 +187,7 @@ function parsePostBySlug(slug: string): Post | null {
       : undefined,
     excerpt: frontMatter.excerpt,
     coverImage: frontMatter.coverImage,
+    coverAlt: frontMatter.coverAlt,
     tags: frontMatter.tags,
     series: frontMatter.series,
     seriesOrder: frontMatter.seriesOrder,
@@ -256,7 +260,7 @@ function assertUniqueSeriesOrder(posts: readonly Post[]) {
 
 type RelatedPost = Pick<
   Post,
-  "slug" | "title" | "date" | "excerpt" | "coverImage" | "tags"
+  "slug" | "title" | "date" | "excerpt" | "coverImage" | "coverAlt" | "tags"
 >;
 
 type SeriesPost = Pick<Post, "slug" | "title" | "seriesOrder">;
@@ -501,6 +505,7 @@ export function getRelatedPosts(
     date: post.date,
     excerpt: post.excerpt,
     coverImage: post.coverImage,
+    coverAlt: post.coverAlt,
     tags: post.tags,
   }));
 }


### PR DESCRIPTION
## Summary
- add optional `coverAlt` frontmatter parsing and post field projection
- add concise cover alt text to every current post with a cover image
- use cover alt text for blog cards, tag archive cards, and post hero images with the existing title-based fallback preserved
- add focused tests for cover alt parsing and rendering

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- yarn test:e2e (passed on rerun after an initial code 129 interruption without a Playwright failure summary)
- yarn test:e2e:visual