### PR TITLE
Search performance automation: Add engagement analytics instrumentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "deploy": "gh-pages -d out"
   },
   "dependencies": {
-    "@next/third-parties": "^16.2.4",
     "decimal.js": "^10.6.0",
     "feed": "^5.2.1",
     "next": "^16.2.6",

--- a/src/app/blog/[slug]/_components/BlogPostAnalytics.tsx
+++ b/src/app/blog/[slug]/_components/BlogPostAnalytics.tsx
@@ -40,6 +40,11 @@ export function BlogPostAnalytics({ slug, title }: BlogPostAnalyticsProps) {
   const firedEngagedReadRef = useRef(false);
 
   useEffect(() => {
+    maxScrollDepthRef.current = 0;
+    firedScrollDepthsRef.current = new Set<ScrollDepth>();
+    elapsedEnoughTimeRef.current = false;
+    firedEngagedReadRef.current = false;
+
     const article = document.querySelector<HTMLElement>("main article");
 
     if (!article) {

--- a/src/app/blog/[slug]/_components/BlogPostAnalytics.tsx
+++ b/src/app/blog/[slug]/_components/BlogPostAnalytics.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import {
+  trackArticleEngagedRead,
+  trackArticleScrollDepth,
+} from "@/lib/analytics";
+
+const ENGAGED_READ_SECONDS = 45;
+const SCROLL_DEPTH_THRESHOLDS: readonly ScrollDepth[] = [50, 90];
+
+type ScrollDepth = 50 | 90;
+
+type BlogPostAnalyticsProps = {
+  slug: string;
+  title: string;
+};
+
+function getArticleScrollDepth(article: HTMLElement) {
+  const rect = article.getBoundingClientRect();
+  const articleHeight = Math.max(article.scrollHeight, article.offsetHeight);
+
+  if (articleHeight <= 0) {
+    return 0;
+  }
+
+  const visibleBottom = Math.min(
+    articleHeight,
+    Math.max(0, window.innerHeight - rect.top)
+  );
+
+  return Math.min(100, Math.max(0, (visibleBottom / articleHeight) * 100));
+}
+
+export function BlogPostAnalytics({ slug, title }: BlogPostAnalyticsProps) {
+  const maxScrollDepthRef = useRef(0);
+  const firedScrollDepthsRef = useRef<Set<ScrollDepth>>(new Set());
+  const elapsedEnoughTimeRef = useRef(false);
+  const firedEngagedReadRef = useRef(false);
+
+  useEffect(() => {
+    const article = document.querySelector<HTMLElement>("main article");
+
+    if (!article) {
+      return;
+    }
+
+    const articleElement = article;
+
+    function maybeTrackEngagedRead() {
+      if (
+        firedEngagedReadRef.current ||
+        !elapsedEnoughTimeRef.current ||
+        maxScrollDepthRef.current < 50
+      ) {
+        return;
+      }
+
+      firedEngagedReadRef.current = true;
+      trackArticleEngagedRead({
+        minimumSeconds: ENGAGED_READ_SECONDS,
+        scrollDepth: Math.round(maxScrollDepthRef.current),
+        slug,
+        title,
+      });
+    }
+
+    function updateScrollDepth() {
+      const depth = getArticleScrollDepth(articleElement);
+      maxScrollDepthRef.current = Math.max(maxScrollDepthRef.current, depth);
+
+      for (const threshold of SCROLL_DEPTH_THRESHOLDS) {
+        if (
+          maxScrollDepthRef.current >= threshold &&
+          !firedScrollDepthsRef.current.has(threshold)
+        ) {
+          firedScrollDepthsRef.current.add(threshold);
+          trackArticleScrollDepth({
+            depth: threshold,
+            slug,
+            title,
+          });
+        }
+      }
+
+      maybeTrackEngagedRead();
+    }
+
+    const engagedReadTimer = window.setTimeout(() => {
+      elapsedEnoughTimeRef.current = true;
+      maybeTrackEngagedRead();
+    }, ENGAGED_READ_SECONDS * 1000);
+
+    updateScrollDepth();
+    window.addEventListener("scroll", updateScrollDepth, { passive: true });
+    window.addEventListener("resize", updateScrollDepth);
+
+    return () => {
+      window.clearTimeout(engagedReadTimer);
+      window.removeEventListener("scroll", updateScrollDepth);
+      window.removeEventListener("resize", updateScrollDepth);
+    };
+  }, [slug, title]);
+
+  return null;
+}

--- a/src/app/blog/[slug]/_components/__tests__/BlogPostAnalytics.test.tsx
+++ b/src/app/blog/[slug]/_components/__tests__/BlogPostAnalytics.test.tsx
@@ -1,0 +1,116 @@
+import { act, render } from "@testing-library/react";
+
+import { BlogPostAnalytics } from "../BlogPostAnalytics";
+
+const trackArticleEngagedRead = jest.fn();
+const trackArticleScrollDepth = jest.fn();
+
+jest.mock("@/lib/analytics", () => ({
+  trackArticleEngagedRead: (...args: unknown[]) =>
+    trackArticleEngagedRead(...args),
+  trackArticleScrollDepth: (...args: unknown[]) =>
+    trackArticleScrollDepth(...args),
+}));
+
+describe("BlogPostAnalytics", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    trackArticleEngagedRead.mockClear();
+    trackArticleScrollDepth.mockClear();
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 500,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("tracks article scroll thresholds once", () => {
+    const { container } = render(
+      <>
+        <main>
+          <article>Post body</article>
+        </main>
+        <BlogPostAnalytics slug="test-post" title="Test Post" />
+      </>
+    );
+    const article = container.querySelector("article");
+
+    expect(article).not.toBeNull();
+    Object.defineProperties(article!, {
+      offsetHeight: { configurable: true, value: 1000 },
+      scrollHeight: { configurable: true, value: 1000 },
+    });
+    article!.getBoundingClientRect = jest.fn(() => ({
+      bottom: 0,
+      height: 1000,
+      left: 0,
+      right: 0,
+      top: -100,
+      width: 0,
+      x: 0,
+      y: -100,
+      toJSON: () => ({}),
+    }));
+
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(trackArticleScrollDepth).toHaveBeenCalledTimes(1);
+    expect(trackArticleScrollDepth).toHaveBeenCalledWith({
+      depth: 50,
+      slug: "test-post",
+      title: "Test Post",
+    });
+  });
+
+  it("tracks engaged reads after enough time and scroll depth", () => {
+    const { container } = render(
+      <>
+        <main>
+          <article>Post body</article>
+        </main>
+        <BlogPostAnalytics slug="test-post" title="Test Post" />
+      </>
+    );
+    const article = container.querySelector("article");
+
+    expect(article).not.toBeNull();
+    Object.defineProperties(article!, {
+      offsetHeight: { configurable: true, value: 1000 },
+      scrollHeight: { configurable: true, value: 1000 },
+    });
+    article!.getBoundingClientRect = jest.fn(() => ({
+      bottom: 0,
+      height: 1000,
+      left: 0,
+      right: 0,
+      top: -100,
+      width: 0,
+      x: 0,
+      y: -100,
+      toJSON: () => ({}),
+    }));
+
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    act(() => {
+      jest.advanceTimersByTime(45_000);
+    });
+
+    expect(trackArticleEngagedRead).toHaveBeenCalledTimes(1);
+    expect(trackArticleEngagedRead).toHaveBeenCalledWith({
+      minimumSeconds: 45,
+      scrollDepth: 60,
+      slug: "test-post",
+      title: "Test Post",
+    });
+  });
+});

--- a/src/app/blog/[slug]/_components/__tests__/BlogPostAnalytics.test.tsx
+++ b/src/app/blog/[slug]/_components/__tests__/BlogPostAnalytics.test.tsx
@@ -70,6 +70,82 @@ describe("BlogPostAnalytics", () => {
     });
   });
 
+  it("resets scroll tracking when navigating between posts", () => {
+    const { container, rerender } = render(
+      <>
+        <main>
+          <article>Post body</article>
+        </main>
+        <BlogPostAnalytics slug="first-post" title="First Post" />
+      </>
+    );
+    const article = container.querySelector("article");
+
+    expect(article).not.toBeNull();
+    Object.defineProperties(article!, {
+      offsetHeight: { configurable: true, value: 1000 },
+      scrollHeight: { configurable: true, value: 1000 },
+    });
+    article!.getBoundingClientRect = jest.fn(() => ({
+      bottom: 0,
+      height: 1000,
+      left: 0,
+      right: 0,
+      top: -100,
+      width: 0,
+      x: 0,
+      y: -100,
+      toJSON: () => ({}),
+    }));
+
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(trackArticleScrollDepth).toHaveBeenCalledWith({
+      depth: 50,
+      slug: "first-post",
+      title: "First Post",
+    });
+
+    rerender(
+      <>
+        <main>
+          <article>Post body</article>
+        </main>
+        <BlogPostAnalytics slug="second-post" title="Second Post" />
+      </>
+    );
+    const nextArticle = container.querySelector("article");
+
+    expect(nextArticle).not.toBeNull();
+    Object.defineProperties(nextArticle!, {
+      offsetHeight: { configurable: true, value: 1000 },
+      scrollHeight: { configurable: true, value: 1000 },
+    });
+    nextArticle!.getBoundingClientRect = jest.fn(() => ({
+      bottom: 0,
+      height: 1000,
+      left: 0,
+      right: 0,
+      top: -100,
+      width: 0,
+      x: 0,
+      y: -100,
+      toJSON: () => ({}),
+    }));
+
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(trackArticleScrollDepth).toHaveBeenCalledWith({
+      depth: 50,
+      slug: "second-post",
+      title: "Second Post",
+    });
+  });
+
   it("tracks engaged reads after enough time and scroll depth", () => {
     const { container } = render(
       <>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -35,6 +35,8 @@ import {
 } from "@/lib/seo";
 import { getTagPath } from "@/lib/tags";
 
+import { BlogPostAnalytics } from "./_components/BlogPostAnalytics";
+
 export const dynamicParams = false;
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
@@ -158,6 +160,7 @@ export default async function Post({ params }: Props) {
           tags: post.tags,
         })}
       />
+      <BlogPostAnalytics slug={post.slug} title={post.title} />
       <PageShell title={post.title}>
         <ResponsiveContainer
           element="article"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,11 +4,11 @@ import { JsonLd } from "react-schemaorg";
 import type { Metadata, Viewport } from "next";
 import { Lato } from "next/font/google";
 
-import { GoogleAnalytics } from "@next/third-parties/google";
-
 import { AppBackground } from "@/components/AppBackground";
 import Footer from "@/components/Footer";
+import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 import Header from "@/components/Header";
+import { SiteLinkAnalytics } from "@/components/SiteLinkAnalytics";
 import { BASE_URL } from "@/constants";
 import {
   buildPersonSchema,
@@ -98,11 +98,14 @@ export default function RootLayout({ children }: PropsWithChildren) {
         <Header />
         <main className="flex grow flex-col">{children}</main>
         <Footer />
+        <SiteLinkAnalytics />
         <JsonLd item={buildPersonSchema({ description })} />
         <JsonLd item={buildWebsiteSchema({ description })} />
         <JsonLd item={buildSiteNavigationSchema()} />
+        {googleAnalyticsId ? (
+          <GoogleAnalytics measurementId={googleAnalyticsId} />
+        ) : null}
       </body>
-      {googleAnalyticsId ? <GoogleAnalytics gaId={googleAnalyticsId} /> : null}
     </html>
   );
 }

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+
+const GOOGLE_ANALYTICS_SCRIPT_ID = "google-analytics-gtag";
+const initializedMeasurementIds = new Set<string>();
+
+type GoogleAnalyticsProps = {
+  measurementId: string;
+};
+
+function ensureDataLayer() {
+  window.dataLayer = window.dataLayer ?? [];
+  window.gtag =
+    window.gtag ??
+    ((...args: unknown[]) => {
+      window.dataLayer?.push(args);
+    });
+}
+
+function loadGoogleAnalyticsScript(measurementId: string) {
+  if (document.getElementById(GOOGLE_ANALYTICS_SCRIPT_ID)) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.id = GOOGLE_ANALYTICS_SCRIPT_ID;
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(
+    measurementId
+  )}`;
+
+  document.head.appendChild(script);
+}
+
+export function GoogleAnalytics({ measurementId }: GoogleAnalyticsProps) {
+  useEffect(() => {
+    ensureDataLayer();
+    loadGoogleAnalyticsScript(measurementId);
+
+    if (!initializedMeasurementIds.has(measurementId)) {
+      window.gtag?.("js", new Date());
+      window.gtag?.("config", measurementId);
+      initializedMeasurementIds.add(measurementId);
+    }
+  }, [measurementId]);
+
+  return null;
+}

--- a/src/components/SiteLinkAnalytics.tsx
+++ b/src/components/SiteLinkAnalytics.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect } from "react";
+
+import {
+  trackExternalLinkClick,
+  trackInternalLinkClick,
+} from "@/lib/analytics";
+
+const MAX_LINK_TEXT_LENGTH = 120;
+
+function getLinkText(link: HTMLAnchorElement) {
+  return (
+    link.innerText ||
+    link.textContent ||
+    link.getAttribute("aria-label") ||
+    link.getAttribute("title") ||
+    link.href
+  )
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, MAX_LINK_TEXT_LENGTH);
+}
+
+export function SiteLinkAnalytics() {
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      const target = event.target;
+
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const link = target.closest<HTMLAnchorElement>("a[href]");
+
+      if (!link) {
+        return;
+      }
+
+      const rawHref = link.getAttribute("href");
+
+      if (!rawHref || rawHref.startsWith("#")) {
+        return;
+      }
+
+      const destination = new URL(link.href, window.location.href);
+      const currentPath = `${window.location.pathname}${window.location.search}`;
+      const params = {
+        current_path: currentPath,
+        link_text: getLinkText(link),
+        link_url: destination.href,
+      };
+
+      if (
+        destination.protocol === "http:" ||
+        destination.protocol === "https:"
+      ) {
+        if (destination.origin === window.location.origin) {
+          trackInternalLinkClick({
+            ...params,
+            destination_path: `${destination.pathname}${destination.search}`,
+          });
+          return;
+        }
+
+        trackExternalLinkClick({
+          ...params,
+          link_host: destination.host,
+        });
+        return;
+      }
+
+      trackExternalLinkClick({
+        ...params,
+        link_host: destination.protocol.replace(":", ""),
+      });
+    }
+
+    document.addEventListener("click", handleClick);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/__tests__/GoogleAnalytics.test.tsx
+++ b/src/components/__tests__/GoogleAnalytics.test.tsx
@@ -1,0 +1,38 @@
+import { render, waitFor } from "@testing-library/react";
+
+import { GoogleAnalytics } from "../GoogleAnalytics";
+
+describe("GoogleAnalytics", () => {
+  beforeEach(() => {
+    document.getElementById("google-analytics-gtag")?.remove();
+    delete window.dataLayer;
+    delete window.gtag;
+  });
+
+  afterEach(() => {
+    document.getElementById("google-analytics-gtag")?.remove();
+    delete window.dataLayer;
+    delete window.gtag;
+  });
+
+  it("creates the gtag queue and script", async () => {
+    render(<GoogleAnalytics measurementId="G-TEST123" />);
+
+    await waitFor(() => {
+      expect(document.getElementById("google-analytics-gtag")).not.toBeNull();
+    });
+
+    const script = document.getElementById("google-analytics-gtag");
+
+    if (!(script instanceof HTMLScriptElement)) {
+      throw new Error("Expected Google Analytics script to be present");
+    }
+
+    expect(script.async).toBe(true);
+    expect(script.src).toBe(
+      "https://www.googletagmanager.com/gtag/js?id=G-TEST123"
+    );
+    expect(window.dataLayer?.[0]).toEqual(["js", expect.any(Date)]);
+    expect(window.dataLayer?.[1]).toEqual(["config", "G-TEST123"]);
+  });
+});

--- a/src/components/__tests__/SiteLinkAnalytics.test.tsx
+++ b/src/components/__tests__/SiteLinkAnalytics.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { SiteLinkAnalytics } from "../SiteLinkAnalytics";
+
+const trackExternalLinkClick = jest.fn();
+const trackInternalLinkClick = jest.fn();
+
+jest.mock("@/lib/analytics", () => ({
+  trackExternalLinkClick: (...args: unknown[]) =>
+    trackExternalLinkClick(...args),
+  trackInternalLinkClick: (...args: unknown[]) =>
+    trackInternalLinkClick(...args),
+}));
+
+describe("SiteLinkAnalytics", () => {
+  beforeEach(() => {
+    trackExternalLinkClick.mockClear();
+    trackInternalLinkClick.mockClear();
+    window.history.pushState({}, "", "/blog/example/");
+  });
+
+  it("tracks delegated internal link clicks", () => {
+    render(
+      <>
+        <SiteLinkAnalytics />
+        <a href="/about/">About Alex</a>
+      </>
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "About Alex" }));
+
+    expect(trackInternalLinkClick).toHaveBeenCalledWith({
+      current_path: "/blog/example/",
+      destination_path: "/about/",
+      link_text: "About Alex",
+      link_url: "http://localhost/about/",
+    });
+    expect(trackExternalLinkClick).not.toHaveBeenCalled();
+  });
+
+  it("tracks delegated external link clicks", () => {
+    render(
+      <>
+        <SiteLinkAnalytics />
+        <a href="https://github.com/aclyx">GitHub</a>
+      </>
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "GitHub" }));
+
+    expect(trackExternalLinkClick).toHaveBeenCalledWith({
+      current_path: "/blog/example/",
+      link_host: "github.com",
+      link_text: "GitHub",
+      link_url: "https://github.com/aclyx",
+    });
+    expect(trackInternalLinkClick).not.toHaveBeenCalled();
+  });
+
+  it("ignores same-page hash links", () => {
+    render(
+      <>
+        <SiteLinkAnalytics />
+        <a href="#section">Jump</a>
+      </>
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Jump" }));
+
+    expect(trackExternalLinkClick).not.toHaveBeenCalled();
+    expect(trackInternalLinkClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,88 @@
+async function loadAnalytics({ enabled }: { enabled: boolean }) {
+  jest.resetModules();
+  process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = enabled ? "true" : "false";
+
+  return import("../analytics");
+}
+
+describe("analytics helpers", () => {
+  const originalAnalyticsEnv = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS;
+
+  beforeEach(() => {
+    delete window.dataLayer;
+    delete window.gtag;
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_ENABLE_ANALYTICS = originalAnalyticsEnv;
+  });
+
+  it("does not emit events when analytics are disabled", async () => {
+    window.gtag = jest.fn();
+    const { trackArticleEngagedRead } = await loadAnalytics({
+      enabled: false,
+    });
+
+    trackArticleEngagedRead({
+      minimumSeconds: 45,
+      scrollDepth: 60,
+      slug: "post",
+      title: "Post",
+    });
+
+    expect(window.gtag).not.toHaveBeenCalled();
+    expect(window.dataLayer).toBeUndefined();
+  });
+
+  it("emits article engagement events through gtag", async () => {
+    window.gtag = jest.fn();
+    const { trackArticleEngagedRead } = await loadAnalytics({
+      enabled: true,
+    });
+
+    trackArticleEngagedRead({
+      minimumSeconds: 45,
+      scrollDepth: 60,
+      slug: "post",
+      title: "Post",
+    });
+
+    expect(window.gtag).toHaveBeenCalledWith("event", "article_engaged_read", {
+      article_slug: "post",
+      article_title: "Post",
+      event_category: "engagement",
+      minimum_seconds: 45,
+      scroll_depth: 60,
+    });
+  });
+
+  it("falls back to dataLayer when gtag is not ready", async () => {
+    window.dataLayer = [];
+    const { trackExternalLinkClick } = await loadAnalytics({
+      enabled: true,
+    });
+
+    trackExternalLinkClick({
+      current_path: "/blog/post/",
+      link_host: "example.com",
+      link_text: "Example",
+      link_url: "https://example.com",
+    });
+
+    expect(window.dataLayer).toEqual([
+      [
+        "event",
+        "external_link_click",
+        {
+          current_path: "/blog/post/",
+          event_category: "navigation",
+          link_host: "example.com",
+          link_text: "Example",
+          link_type: "external",
+          link_url: "https://example.com",
+          outbound: true,
+        },
+      ],
+    ]);
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import { sendGAEvent } from "@next/third-parties/google";
-
 type AnalyticsParam = boolean | number | string;
 type AnalyticsParams = Record<string, AnalyticsParam | null | undefined>;
 
 const analyticsEnabled = process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === "true";
 const keyEventCategory = "key_event";
+const engagementCategory = "engagement";
+const navigationCategory = "navigation";
 
 function compactParams(
   params: AnalyticsParams
@@ -23,18 +23,39 @@ function compactParams(
 }
 
 function trackKeyEvent(eventName: string, params: AnalyticsParams = {}) {
-  if (!analyticsEnabled) {
+  trackEvent(eventName, keyEventCategory, params);
+}
+
+function trackEvent(
+  eventName: string,
+  eventCategory: string,
+  params: AnalyticsParams = {}
+) {
+  if (!analyticsEnabled || typeof window === "undefined") {
     return;
   }
 
-  sendGAEvent(
-    "event",
-    eventName,
-    compactParams({
-      event_category: keyEventCategory,
-      ...params,
-    })
-  );
+  const eventParams = compactParams({
+    event_category: eventCategory,
+    ...params,
+  });
+
+  if (typeof window.gtag === "function") {
+    window.gtag("event", eventName, eventParams);
+    return;
+  }
+
+  if (Array.isArray(window.dataLayer)) {
+    window.dataLayer.push(["event", eventName, eventParams]);
+  }
+}
+
+function getUrlHost(url: string) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return undefined;
+  }
 }
 
 export function trackContactLinkClick({
@@ -47,6 +68,7 @@ export function trackContactLinkClick({
   url: string;
 }) {
   trackKeyEvent("contact_link_click", {
+    link_host: getUrlHost(url),
     link_text: label,
     link_url: url,
     placement,
@@ -67,7 +89,76 @@ export function trackExperimentInteraction(
 
 export function trackNewsletterSubscribe(placement: string) {
   trackKeyEvent("newsletter_subscribe_submit", {
+    form_id: "follow_it_subscribe",
     method: "follow_it",
     placement,
+  });
+}
+
+type LinkClickParams = {
+  current_path: string;
+  link_text: string;
+  link_url: string;
+};
+
+export function trackInternalLinkClick({
+  destination_path,
+  ...params
+}: LinkClickParams & {
+  destination_path: string;
+}) {
+  trackEvent("internal_link_click", navigationCategory, {
+    ...params,
+    destination_path,
+    link_type: "internal",
+  });
+}
+
+export function trackExternalLinkClick({
+  link_host,
+  ...params
+}: LinkClickParams & {
+  link_host: string;
+}) {
+  trackEvent("external_link_click", navigationCategory, {
+    ...params,
+    link_host,
+    link_type: "external",
+    outbound: true,
+  });
+}
+
+export function trackArticleScrollDepth({
+  depth,
+  slug,
+  title,
+}: {
+  depth: 50 | 90;
+  slug: string;
+  title: string;
+}) {
+  trackEvent(`article_scroll_${depth}`, engagementCategory, {
+    article_slug: slug,
+    article_title: title,
+    scroll_depth: depth,
+  });
+}
+
+export function trackArticleEngagedRead({
+  minimumSeconds,
+  scrollDepth,
+  slug,
+  title,
+}: {
+  minimumSeconds: number;
+  scrollDepth: number;
+  slug: string;
+  title: string;
+}) {
+  trackEvent("article_engaged_read", engagementCategory, {
+    article_slug: slug,
+    article_title: title,
+    minimum_seconds: minimumSeconds,
+    scroll_depth: scrollDepth,
   });
 }

--- a/src/types/analytics.d.ts
+++ b/src/types/analytics.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,18 +1564,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/third-parties@npm:^16.2.4":
-  version: 16.2.4
-  resolution: "@next/third-parties@npm:16.2.4"
-  dependencies:
-    third-party-capital: "npm:1.0.20"
-  peerDependencies:
-    next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
-    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-  checksum: 10c0/acb055e17f121ffd543cedc8f0268c856544e54a160cfd2c7fb475dee5ad655a1303cf012126fb075a6bd72f93dd53f37615071de2953694adbe357c17e302a6
-  languageName: node
-  linkType: hard
-
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -2962,7 +2950,6 @@ __metadata:
   dependencies:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.7.1"
     "@lhci/cli": "npm:^0.15.1"
-    "@next/third-parties": "npm:^16.2.4"
     "@playwright/test": "npm:1.59.1"
     "@tailwindcss/postcss": "npm:^4.2.4"
     "@tailwindcss/typography": "npm:^0.5.19"
@@ -9647,13 +9634,6 @@ __metadata:
   dependencies:
     b4a: "npm:^1.6.4"
   checksum: 10c0/929938ed154fbadb660a7f3d1aca30b7e53649a731af7583168fcfba0c158046325d35d945926e2a512bb62d1a49a7818151c987ea38b48853f01e1615722fc5
-  languageName: node
-  linkType: hard
-
-"third-party-capital@npm:1.0.20":
-  version: 1.0.20
-  resolution: "third-party-capital@npm:1.0.20"
-  checksum: 10c0/7f45ff156ec9d7e2957a5b39061be22b780ffbd2d93c127252d908e2bff6cdd09f827a95909d457c8096e036f155006a38e355a06ee11cb6d63c7f4b150bbfb0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Data observations
- GSC and GA4 were enough for query/page and landing-page review, but GA4 did not expose article read depth or link-path behavior after search clicks.
- CTR diagnosis needs both search impressions/clicks and on-site engagement signals to separate content mismatch, weak internal paths, and low-quality visits.
- Existing site events covered contact/newsletter/experiments, but not article engagement, internal link clicks, external link clicks, or link host/destination details.

## Hypothesis
Adding stable read-depth and link-click events will make future search-performance reviews more actionable: pages with impressions but weak clicks can be compared against post-click engagement and onward navigation instead of relying on broad session aggregates.

## Confidence
High for instrumentation correctness; medium for downstream SEO impact because GA4 custom-event reporting and GSC comparisons need data propagation after deploy.

## Expected impact
Future reviews can segment organic landing pages by `article_scroll_50`, `article_scroll_90`, `article_engaged_read`, `internal_link_click`, `external_link_click`, `link_host`, and `destination_path`.

## Change summary
- replace the GA wrapper dependency with a small site-owned GA bootstrap that creates `dataLayer`, defines `gtag`, and loads the measurement script behind the existing analytics env gate
- add delegated internal/external link click tracking across the site
- add blog article 50%/90% scroll-depth and 45-second engaged-read events
- extend existing contact/newsletter events with link/form metadata and add focused unit coverage

## Validation
- `yarn install`
- `yarn test --runTestsByPath src/lib/__tests__/analytics.test.ts src/components/__tests__/GoogleAnalytics.test.tsx src/components/__tests__/SiteLinkAnalytics.test.tsx src/app/blog/[slug]/_components/__tests__/BlogPostAnalytics.test.tsx`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn build:prod`
- Headless system Chrome against the exported site confirmed `gtag`/`dataLayer` initialization plus `article_scroll_50`, `article_scroll_90`, `article_engaged_read`, `internal_link_click`, `external_link_click`, and existing `contact_link_click` events.
- `yarn test:e2e` passed on rerun; the first run hit a WebKit timeout after the expected Contact page was already rendered.
- `yarn test:e2e:visual`