### PR TITLE
[codex] Add regional LinkedIn sameAs URL

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -126,6 +126,7 @@ describe("RootLayout", () => {
       expect(schema.sameAs).toBeDefined();
       expect(schema.sameAs.length).toBeGreaterThan(0);
       expect(schema.sameAs).toContain("https://www.linkedin.com/in/aclyx");
+      expect(schema.sameAs).toContain("https://ca.linkedin.com/in/aclyx");
       expect(schema.sameAs).toContain("https://github.com/aclyx");
     });
   });

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -197,6 +197,8 @@ describe("seo jsonld builders", () => {
       name: "Professional Engineers Ontario",
     });
     expect(person.knowsLanguage).toEqual(["en-CA"]);
+    expect(person.sameAs).toContain("https://www.linkedin.com/in/aclyx");
+    expect(person.sameAs).toContain("https://ca.linkedin.com/in/aclyx");
     expect(person.sameAs).toContain("https://github.com/aclyx");
     expect(person.hasOccupation).toMatchObject({
       "@type": "Occupation",

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -31,6 +31,7 @@ const SITE_NAVIGATION_ELEMENT_TYPE: "SiteNavigationElement" =
   "SiteNavigationElement";
 const SOCIAL_PROFILES = [
   "https://www.linkedin.com/in/aclyx",
+  "https://ca.linkedin.com/in/aclyx",
   "https://github.com/aclyx",
   "https://www.x.com/aclyxpse",
   "https://bsky.app/profile/alexleung.ca",


### PR DESCRIPTION
## Summary
- add the indexed `ca.linkedin.com/in/aclyx` LinkedIn profile URL to the Person `sameAs` schema
- update JSON-LD/layout tests to assert both LinkedIn URL variants

## Why
Google is serving the public LinkedIn profile under the regional `ca.linkedin.com` hostname. Including both the existing `www.linkedin.com` URL and the indexed regional URL gives search engines a clearer identity graph without changing the visible social link.

## Validation
- `yarn test --runTestsByPath src/app/__tests__/layout.test.tsx src/lib/seo/__tests__/jsonld.test.ts`