### PR TITLE
Add corporate GitHub profile

### DIFF
--- a/playwright/tests/smoke/blog-and-contact.spec.ts
+++ b/playwright/tests/smoke/blog-and-contact.spec.ts
@@ -40,14 +40,15 @@ test("contact page shows the email CTA and social profile links", async ({
 
   await expect(page.getByText("alex [at] alexleung.ca")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Subscribe" })).toBeVisible();
-  await expect(main.getByRole("link", { name: "LinkedIn" })).toHaveAttribute(
-    "href",
-    "https://www.linkedin.com/in/aclyx"
-  );
-  await expect(main.getByRole("link", { name: "GitHub" })).toHaveAttribute(
-    "href",
-    "https://www.github.com/aclyx"
-  );
+  await expect(
+    main.getByRole("link", { name: "LinkedIn Profile", exact: true })
+  ).toHaveAttribute("href", "https://www.linkedin.com/in/aclyx");
+  await expect(
+    main.getByRole("link", { name: "GitHub Profile", exact: true })
+  ).toHaveAttribute("href", "https://www.github.com/aclyx");
+  await expect(
+    main.getByRole("link", { name: "Corporate GitHub Profile", exact: true })
+  ).toHaveAttribute("href", "https://github.com/aclyx-oai");
 });
 
 test("unknown routes render the exported not found page", async ({ page }) => {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,6 +24,7 @@ He is a licensed Professional Engineer (P.Eng.) through Professional Engineers O
 
 - [LinkedIn](https://www.linkedin.com/in/aclyx)
 - [GitHub](https://www.github.com/aclyx)
+- [Corporate GitHub](https://github.com/aclyx-oai)
 - [X/Twitter](https://www.x.com/aclyxpse)
 - [Bluesky](https://bsky.app/profile/alexleung.ca)
 - [Instagram](https://www.instagram.com/rootpanda)

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -127,6 +127,7 @@ describe("RootLayout", () => {
       expect(schema.sameAs.length).toBeGreaterThan(0);
       expect(schema.sameAs).toContain("https://www.linkedin.com/in/aclyx");
       expect(schema.sameAs).toContain("https://github.com/aclyx");
+      expect(schema.sameAs).toContain("https://github.com/aclyx-oai");
     });
   });
 });

--- a/src/app/contact/_components/__tests__/SocialMediaList.test.tsx
+++ b/src/app/contact/_components/__tests__/SocialMediaList.test.tsx
@@ -12,6 +12,9 @@ describe("SocialMediaList", () => {
     render(<SocialMediaList />);
     expect(screen.getByLabelText("LinkedIn Profile")).toBeInTheDocument();
     expect(screen.getByLabelText("GitHub Profile")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Corporate GitHub Profile")
+    ).toBeInTheDocument();
     expect(screen.getByLabelText("X (Twitter) Profile")).toBeInTheDocument();
     expect(screen.getByLabelText("Bluesky Profile")).toBeInTheDocument();
     expect(screen.getByLabelText("Instagram Profile")).toBeInTheDocument();
@@ -27,6 +30,10 @@ describe("SocialMediaList", () => {
       "href",
       "https://www.github.com/aclyx"
     );
+    expect(screen.getByLabelText("Corporate GitHub Profile")).toHaveAttribute(
+      "href",
+      "https://github.com/aclyx-oai"
+    );
   });
 
   it("opens links in new tab with security attributes", () => {
@@ -40,6 +47,7 @@ describe("SocialMediaList", () => {
     render(<SocialMediaList />);
     expect(screen.getByText("LinkedIn")).toBeInTheDocument();
     expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Corporate GitHub")).toBeInTheDocument();
     expect(screen.getByText("X (Twitter)")).toBeInTheDocument();
     expect(screen.getByText("Bluesky")).toBeInTheDocument();
     expect(screen.getByText("Instagram")).toBeInTheDocument();

--- a/src/constants/socialLinks.tsx
+++ b/src/constants/socialLinks.tsx
@@ -21,18 +21,24 @@ export const data = [
   },
   {
     id: 3,
+    icon: <FaGithub />,
+    url: "https://github.com/aclyx-oai",
+    label: "Corporate GitHub Profile",
+  },
+  {
+    id: 4,
     icon: <FaXTwitter />,
     url: "https://www.x.com/aclyxpse",
     label: "X (Twitter) Profile",
   },
   {
-    id: 4,
+    id: 5,
     icon: <FaBluesky />,
     url: "https://bsky.app/profile/alexleung.ca",
     label: "Bluesky Profile",
   },
   {
-    id: 5,
+    id: 6,
     icon: <FaInstagram />,
     url: "https://www.instagram.com/rootpanda",
     label: "Instagram Profile",

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -198,6 +198,7 @@ describe("seo jsonld builders", () => {
     });
     expect(person.knowsLanguage).toEqual(["en-CA"]);
     expect(person.sameAs).toContain("https://github.com/aclyx");
+    expect(person.sameAs).toContain("https://github.com/aclyx-oai");
     expect(person.hasOccupation).toMatchObject({
       "@type": "Occupation",
       name: "Software Engineer",
@@ -230,6 +231,7 @@ describe("seo jsonld builders", () => {
         "acl",
         "aclyxpse",
         "aclyx",
+        "aclyx-oai",
         "yattaro",
         "rootpanda",
       ])

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -32,6 +32,7 @@ const SITE_NAVIGATION_ELEMENT_TYPE: "SiteNavigationElement" =
 const SOCIAL_PROFILES = [
   "https://www.linkedin.com/in/aclyx",
   "https://github.com/aclyx",
+  "https://github.com/aclyx-oai",
   "https://www.x.com/aclyxpse",
   "https://bsky.app/profile/alexleung.ca",
   "https://www.instagram.com/rootpanda",
@@ -340,6 +341,7 @@ export function buildPersonSchema(input: {
       "acl",
       "aclyxpse",
       "aclyx",
+      "aclyx-oai",
       "yattaro",
       "rootpanda",
     ],


### PR DESCRIPTION
## Summary
- add the aclyx-oai corporate GitHub account to the shared social links
- include the corporate profile in JSON-LD identity metadata and llms.txt
- update unit and smoke coverage for the additional GitHub link

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- yarn test:e2e
- yarn test:e2e:visual

## Notes
- Verification was run from a clean PR worktree at /Users/aclyx/Development/alexleung-ca-corporate-github-pr. The original checkout still has unrelated local edits that are not part of this PR.