### PR TITLE
Improve SEO metadata previews

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # Alex Leung
 
-> Software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects. Licensed Professional Engineer (P.Eng.).
+> San Francisco-based software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects. Licensed Professional Engineer (P.Eng.).
 
 ## Background
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,10 +1,10 @@
 # Alex Leung
 
-> San Francisco-based software engineer writing notes on software systems, AI tools, and small experiments from his own projects. Licensed Professional Engineer (P.Eng.).
+> Software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects. Licensed Professional Engineer (P.Eng.).
 
 ## Background
 
-Alex Leung's software work has spanned embedded systems, distributed systems, and full-stack product engineering. He has worked across home electrification, AR/AI hardware, and consumer product engineering, and writes notes on software systems, AI tools, and small experiments.
+Alex Leung's software work has spanned embedded systems, distributed systems, and full-stack product engineering. He has worked across home electrification, AR/AI hardware, and consumer product engineering, and writes about software systems, AI-assisted coding, deep learning notes, and browser experiments.
 
 He holds a Master of Science in Electrical and Computer Engineering from Georgia Institute of Technology and a Bachelor of Applied Science in Electrical Engineering from the University of Waterloo.
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "id": "https://alexleung.ca/",
   "short_name": "Alex Leung",
   "name": "Alex Leung - Software Engineer and Occasional Writer",
-  "description": "Personal site of Alex Leung, a software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.",
+  "description": "Personal site of Alex Leung, a San Francisco-based software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.",
   "lang": "en",
   "icons": [
     {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "id": "https://alexleung.ca/",
   "short_name": "Alex Leung",
   "name": "Alex Leung - Software Engineer and Occasional Writer",
-  "description": "Personal site of Alex Leung, a San Francisco-based software engineer writing notes on software systems, AI tools, and small experiments from his own projects.",
+  "description": "Personal site of Alex Leung, a software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.",
   "lang": "en",
   "icons": [
     {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -45,6 +45,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     "title",
     "excerpt",
     "coverImage",
+    "coverAlt",
     "date",
     "updated",
     "tags",
@@ -68,6 +69,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       ? [
           {
             url: post.coverImage,
+            alt: post.coverAlt || `Cover for ${post.title}`,
+            width: 1200,
+            height: 630,
           },
         ]
       : undefined,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -22,6 +22,7 @@ import {
   getSeriesNavigation,
 } from "@/lib/blogApi";
 import {
+  getCoverVariant,
   getCoverVariantPath,
   getCoverVariantSourceSet,
 } from "@/lib/coverVariants";
@@ -59,22 +60,26 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const description =
     post.excerpt || `Read ${post.title} on Alex Leung's blog.`;
   const path = `/blog/${params_awaited.slug}`;
+  const metadataCoverImage = getCoverVariant(post.coverImage, "hero");
+  const metadataImage = post.coverImage
+    ? {
+        url: metadataCoverImage?.path || post.coverImage,
+        alt: post.coverAlt || `Cover for ${post.title}`,
+        ...(metadataCoverImage
+          ? {
+              width: metadataCoverImage.width,
+              height: metadataCoverImage.height,
+            }
+          : {}),
+      }
+    : undefined;
 
   const metadata = buildPageMetadata({
     title,
     description,
     path,
     type: "article",
-    images: post.coverImage
-      ? [
-          {
-            url: post.coverImage,
-            alt: post.coverAlt || `Cover for ${post.title}`,
-            width: 1200,
-            height: 630,
-          },
-        ]
-      : undefined,
+    images: metadataImage ? [metadataImage] : undefined,
   });
 
   return {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -15,6 +15,7 @@ import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { Tag } from "@/components/Tag";
 import { getAllPosts, getSeriesSummaries } from "@/lib/blogApi";
+import { getCoverVariant } from "@/lib/coverVariants";
 import {
   buildBlogCollectionPageSchema,
   buildBlogItemListSchema,
@@ -36,21 +37,25 @@ export function generateMetadata(): Metadata {
   const firstCoverPost = getAllPosts(["coverImage", "coverAlt", "title"]).find(
     (post) => post.coverImage
   );
+  const metadataCoverImage = getCoverVariant(firstCoverPost?.coverImage, "hero");
+  const metadataImage = firstCoverPost?.coverImage
+    ? {
+        url: metadataCoverImage?.path || firstCoverPost.coverImage,
+        alt: firstCoverPost.coverAlt || `Cover for ${firstCoverPost.title}`,
+        ...(metadataCoverImage
+          ? {
+              width: metadataCoverImage.width,
+              height: metadataCoverImage.height,
+            }
+          : {}),
+      }
+    : undefined;
 
   return buildPageMetadata({
     title,
     description,
     path,
-    images: firstCoverPost?.coverImage
-      ? [
-          {
-            url: firstCoverPost.coverImage,
-            alt: firstCoverPost.coverAlt || `Cover for ${firstCoverPost.title}`,
-            width: 1200,
-            height: 630,
-          },
-        ]
-      : undefined,
+    images: metadataImage ? [metadataImage] : undefined,
   });
 }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -19,7 +19,6 @@ import {
   buildBlogCollectionPageSchema,
   buildBlogItemListSchema,
   buildPageMetadata,
-  toAbsoluteUrl,
 } from "@/lib/seo";
 import {
   getAllTags,
@@ -30,21 +29,25 @@ import {
 
 const title = "Blog | Alex Leung";
 const description =
-  "Notes on software systems, AI tools, learning, and small experiments.";
+  "Notes on software systems, AI-assisted coding, deep learning, Next.js static sites, and small browser experiments.";
 const path = "/blog";
 
 export function generateMetadata(): Metadata {
-  const posts = getAllPosts(["coverImage"]);
-  const firstCoverImage = posts.find((post) => post.coverImage)?.coverImage;
+  const firstCoverPost = getAllPosts(["coverImage", "coverAlt", "title"]).find(
+    (post) => post.coverImage
+  );
 
   return buildPageMetadata({
     title,
     description,
     path,
-    images: firstCoverImage
+    images: firstCoverPost?.coverImage
       ? [
           {
-            url: toAbsoluteUrl(firstCoverImage),
+            url: firstCoverPost.coverImage,
+            alt: firstCoverPost.coverAlt || `Cover for ${firstCoverPost.title}`,
+            width: 1200,
+            height: 630,
           },
         ]
       : undefined,
@@ -79,7 +82,8 @@ export default function BlogIndex() {
             className="mx-auto max-w-5xl space-y-4 text-left md:text-center"
           >
             <p className="mx-auto max-w-2xl text-body text-gray-200">
-              Software systems, AI tools, books, and experiments.
+              Software systems, AI-assisted coding, deep learning, and browser
+              experiments.
             </p>
             <div className="space-y-3">
               <TopicRevealList topics={topics} />

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -37,7 +37,10 @@ export function generateMetadata(): Metadata {
   const firstCoverPost = getAllPosts(["coverImage", "coverAlt", "title"]).find(
     (post) => post.coverImage
   );
-  const metadataCoverImage = getCoverVariant(firstCoverPost?.coverImage, "hero");
+  const metadataCoverImage = getCoverVariant(
+    firstCoverPost?.coverImage,
+    "hero"
+  );
   const metadataImage = firstCoverPost?.coverImage
     ? {
         url: metadataCoverImage?.path || firstCoverPost.coverImage,
@@ -87,8 +90,7 @@ export default function BlogIndex() {
             className="mx-auto max-w-5xl space-y-4 text-left md:text-center"
           >
             <p className="mx-auto max-w-2xl text-body text-gray-200">
-              Software systems, AI-assisted coding, deep learning, and browser
-              experiments.
+              Software systems, AI tools, books, and experiments.
             </p>
             <div className="space-y-3">
               <TopicRevealList topics={topics} />

--- a/src/app/experimental/event-loop/page.tsx
+++ b/src/app/experimental/event-loop/page.tsx
@@ -7,27 +7,32 @@ import { WebPage } from "schema-dts";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { buildExperimentBreadcrumbItems } from "@/constants/experiments";
+import {
+  buildExperimentBreadcrumbItems,
+  getExperimentById,
+  getExperimentMetadataImage,
+} from "@/constants/experiments";
 import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
 
 import { EventLoopVisualizer } from "./_components/EventLoopVisualizer";
 
-const title = "Event Loop Visualizer | Alex Leung";
-const description =
-  "A small event loop visualizer for call stack, microtasks, tasks, timers, and execution order.";
-const path = "/experimental/event-loop/";
+const experiment = getExperimentById("event-loop");
+const title = experiment.title;
+const description = experiment.description;
+const path = experiment.path;
 
 export const metadata: Metadata = buildPageMetadata({
   title,
   description,
   path,
+  images: [getExperimentMetadataImage(experiment)],
 });
 
 export default function EventLoopPage() {
   return (
     <>
       <JsonLdBreadcrumbs
-        items={buildExperimentBreadcrumbItems("Event Loop Visualizer", path)}
+        items={buildExperimentBreadcrumbItems(experiment.pageTitle, path)}
       />
       <JsonLd<WebPage>
         item={buildWebPageSchema({
@@ -37,7 +42,7 @@ export default function EventLoopPage() {
         })}
       />
 
-      <PageShell title="Event Loop Visualizer" titleId="event-loop-visualizer">
+      <PageShell title={experiment.pageTitle} titleId="event-loop-visualizer">
         <ResponsiveContainer element="section" className="space-y-4">
           <div className="mx-auto max-w-4xl" data-testid="experiment-intro">
             <p className="text-body text-gray-300 md:text-center">

--- a/src/app/experimental/learning-dynamics/page.tsx
+++ b/src/app/experimental/learning-dynamics/page.tsx
@@ -8,25 +8,30 @@ import { LearningDynamicsLab } from "@/app/experimental/learning-dynamics/_compo
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { buildExperimentBreadcrumbItems } from "@/constants/experiments";
+import {
+  buildExperimentBreadcrumbItems,
+  getExperimentById,
+  getExperimentMetadataImage,
+} from "@/constants/experiments";
 import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
 
-const title = "Learning Dynamics Lab | Alex Leung";
-const description =
-  "A client-side optimizer visualizer for comparing SGD, Momentum, RMSProp, and Adam on simple 2D loss surfaces.";
-const path = "/experimental/learning-dynamics/";
+const experiment = getExperimentById("learning-dynamics");
+const title = experiment.title;
+const description = experiment.description;
+const path = experiment.path;
 
 export const metadata: Metadata = buildPageMetadata({
   title,
   description,
   path,
+  images: [getExperimentMetadataImage(experiment)],
 });
 
 export default function LearningDynamicsPage() {
   return (
     <>
       <JsonLdBreadcrumbs
-        items={buildExperimentBreadcrumbItems("Learning Dynamics Lab", path)}
+        items={buildExperimentBreadcrumbItems(experiment.pageTitle, path)}
       />
       <JsonLd<WebPage>
         item={buildWebPageSchema({
@@ -36,7 +41,7 @@ export default function LearningDynamicsPage() {
         })}
       />
 
-      <PageShell title="Learning Dynamics Lab" titleId="learning-dynamics">
+      <PageShell title={experiment.pageTitle} titleId="learning-dynamics">
         <ResponsiveContainer element="section" className="space-y-6">
           <div className="mx-auto max-w-4xl" data-testid="experiment-intro">
             <p className="text-body text-slate-300 md:text-center">

--- a/src/app/experimental/load-flow/page.tsx
+++ b/src/app/experimental/load-flow/page.tsx
@@ -7,27 +7,32 @@ import { WebPage } from "schema-dts";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { buildExperimentBreadcrumbItems } from "@/constants/experiments";
+import {
+  buildExperimentBreadcrumbItems,
+  getExperimentById,
+  getExperimentMetadataImage,
+} from "@/constants/experiments";
 import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
 
 import { LoadFlowWorkspace } from "./_components/LoadFlowWorkspace";
 
-const title = "Load Flow | Alex Leung";
-const description =
-  "A browser AC load flow workspace for editing one-line models and solving bus voltages and branch flows.";
-const path = "/experimental/load-flow/";
+const experiment = getExperimentById("load-flow");
+const title = experiment.title;
+const description = experiment.description;
+const path = experiment.path;
 
 export const metadata: Metadata = buildPageMetadata({
   title,
   description,
   path,
+  images: [getExperimentMetadataImage(experiment)],
 });
 
 export default function LoadFlowPage() {
   return (
     <>
       <JsonLdBreadcrumbs
-        items={buildExperimentBreadcrumbItems("Load Flow", path)}
+        items={buildExperimentBreadcrumbItems(experiment.pageTitle, path)}
       />
       <JsonLd<WebPage>
         item={buildWebPageSchema({
@@ -37,7 +42,7 @@ export default function LoadFlowPage() {
         })}
       />
 
-      <PageShell title="Load Flow" titleId="load-flow">
+      <PageShell title={experiment.pageTitle} titleId="load-flow">
         <ResponsiveContainer element="section" className="space-y-6">
           <p className="text-body text-gray-300">
             This workspace uses a Newton-Raphson AC load flow engine with

--- a/src/app/experimental/mandelbrot/page.tsx
+++ b/src/app/experimental/mandelbrot/page.tsx
@@ -6,27 +6,32 @@ import { WebPage } from "schema-dts";
 
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
-import { buildExperimentBreadcrumbItems } from "@/constants/experiments";
+import {
+  buildExperimentBreadcrumbItems,
+  getExperimentById,
+  getExperimentMetadataImage,
+} from "@/constants/experiments";
 import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
 
 import { MandelbrotExplorer } from "./_components/MandelbrotExplorer";
 
-const title = "Mandelbrot Explorer | Alex Leung";
-const description =
-  "An in-browser Mandelbrot explorer with arbitrary-precision viewport math, progressive rendering, and shareable zoom state.";
-const path = "/experimental/mandelbrot/";
+const experiment = getExperimentById("mandelbrot");
+const title = experiment.title;
+const description = experiment.description;
+const path = experiment.path;
 
 export const metadata: Metadata = buildPageMetadata({
   title,
   description,
   path,
+  images: [getExperimentMetadataImage(experiment)],
 });
 
 export default function MandelbrotPage() {
   return (
     <>
       <JsonLdBreadcrumbs
-        items={buildExperimentBreadcrumbItems("Mandelbrot Explorer", path)}
+        items={buildExperimentBreadcrumbItems(experiment.pageTitle, path)}
       />
       <JsonLd<WebPage>
         item={buildWebPageSchema({
@@ -36,7 +41,7 @@ export default function MandelbrotPage() {
         })}
       />
 
-      <PageShell title="Mandelbrot Explorer" titleId="mandelbrot-explorer">
+      <PageShell title={experiment.pageTitle} titleId="mandelbrot-explorer">
         <MandelbrotExplorer />
       </PageShell>
     </>

--- a/src/app/experimental/page.tsx
+++ b/src/app/experimental/page.tsx
@@ -9,13 +9,18 @@ import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
 import { Surface } from "@/components/Surface";
-import { EXPERIMENTS, EXPERIMENTS_HUB } from "@/constants/experiments";
+import {
+  EXPERIMENTS,
+  EXPERIMENTS_HUB,
+  getExperimentMetadataImage,
+} from "@/constants/experiments";
 import { buildCollectionPageSchema, buildPageMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = buildPageMetadata({
   title: EXPERIMENTS_HUB.title,
   description: EXPERIMENTS_HUB.description,
   path: EXPERIMENTS_HUB.path,
+  images: [getExperimentMetadataImage(EXPERIMENTS[0])],
 });
 
 export default function ExperimentsPage() {

--- a/src/app/experimental/pid-controller/page.tsx
+++ b/src/app/experimental/pid-controller/page.tsx
@@ -7,20 +7,25 @@ import { WebPage } from "schema-dts";
 import { JsonLdBreadcrumbs } from "@/components/JsonLdBreadcrumbs";
 import { PageShell } from "@/components/PageShell";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
-import { buildExperimentBreadcrumbItems } from "@/constants/experiments";
+import {
+  buildExperimentBreadcrumbItems,
+  getExperimentById,
+  getExperimentMetadataImage,
+} from "@/constants/experiments";
 import { buildPageMetadata, buildWebPageSchema } from "@/lib/seo";
 
 import { PidSimulatorWorkspace } from "./_components/PidSimulatorWorkspace";
 
-const title = "PID Controller Simulator | Alex Leung";
-const description =
-  "Fixed-step PID simulation for trying gains and seeing rise time, overshoot, oscillation, and settling behavior.";
-const path = "/experimental/pid-controller/";
+const experiment = getExperimentById("pid-controller");
+const title = experiment.title;
+const description = experiment.description;
+const path = experiment.path;
 
 export const metadata: Metadata = buildPageMetadata({
   title,
   description,
   path,
+  images: [getExperimentMetadataImage(experiment)],
 });
 
 export default function PidControllerPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ import "./globals.css";
 
 const title = "Alex Leung | Software Engineer and Occasional Writer";
 const description =
-  "Alex Leung writes about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.";
+  "Alex Leung is a San Francisco-based software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.";
 
 const lato = Lato({
   subsets: ["latin"],

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ import "./globals.css";
 
 const title = "Alex Leung | Software Engineer and Occasional Writer";
 const description =
-  "Alex Leung is a San Francisco-based software engineer writing notes on software systems, AI tools, and small experiments from his own projects.";
+  "Alex Leung writes about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.";
 
 const lato = Lato({
   subsets: ["latin"],

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import { buildHomePageSchema, buildPageMetadata } from "@/lib/seo";
 
 const title = "Alex Leung | Software Engineer and Occasional Writer";
 const description =
-  "Alex Leung writes about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.";
+  "Alex Leung is a San Francisco-based software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.";
 const path = "/";
 
 export const metadata: Metadata = buildPageMetadata({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import { buildHomePageSchema, buildPageMetadata } from "@/lib/seo";
 
 const title = "Alex Leung | Software Engineer and Occasional Writer";
 const description =
-  "Alex Leung is a San Francisco-based software engineer writing notes on software systems, AI tools, and small experiments from his own projects.";
+  "Alex Leung writes about software systems, AI-assisted coding, deep learning notes, and browser experiments from his own projects.";
 const path = "/";
 
 export const metadata: Metadata = buildPageMetadata({

--- a/src/constants/experiments.ts
+++ b/src/constants/experiments.ts
@@ -13,6 +13,8 @@ type ExperimentEntry = {
 };
 
 const EXPERIMENT_LAST_MODIFIED_ISO = "2026-04-20";
+const EXPERIMENT_THUMBNAIL_WIDTH = 960;
+const EXPERIMENT_THUMBNAIL_HEIGHT = 540;
 
 type ExperimentsHub = Pick<
   ExperimentEntry,
@@ -37,6 +39,25 @@ export function buildExperimentBreadcrumbItems(
     { name: EXPERIMENTS_HUB.pageTitle, item: EXPERIMENTS_HUB.path },
     { name: pageTitle, item: path },
   ];
+}
+
+export function getExperimentById(id: string): ExperimentEntry {
+  const experiment = EXPERIMENTS.find((entry) => entry.id === id);
+
+  if (!experiment) {
+    throw new Error(`Unknown experiment: ${id}`);
+  }
+
+  return experiment;
+}
+
+export function getExperimentMetadataImage(experiment: ExperimentEntry) {
+  return {
+    url: experiment.thumbnail.src,
+    alt: experiment.thumbnail.alt,
+    width: EXPERIMENT_THUMBNAIL_WIDTH,
+    height: EXPERIMENT_THUMBNAIL_HEIGHT,
+  };
 }
 
 export const EXPERIMENTS: readonly ExperimentEntry[] = [

--- a/src/lib/__tests__/coverVariants.test.ts
+++ b/src/lib/__tests__/coverVariants.test.ts
@@ -1,4 +1,5 @@
 import {
+  getCoverVariant,
   getCoverVariantPath,
   getCoverVariantSourceSet,
 } from "@/lib/coverVariants";
@@ -21,6 +22,16 @@ describe("coverVariants", () => {
         "hero"
       )
     ).toBe("/assets/blog/everyone-is-a-builder/cover-hero.webp");
+  });
+
+  test("returns selected variant metadata when generated asset exists", () => {
+    expect(
+      getCoverVariant("/assets/blog/everyone-is-a-builder/cover.webp", "hero")
+    ).toEqual({
+      path: "/assets/blog/everyone-is-a-builder/cover-hero.webp",
+      width: 1280,
+      height: 854,
+    });
   });
 
   test("returns responsive source set when multiple generated variants exist", () => {

--- a/src/lib/__tests__/feed.test.ts
+++ b/src/lib/__tests__/feed.test.ts
@@ -42,7 +42,7 @@ describe("buildRssFeedXml", () => {
       expect.objectContaining({
         title: "Alex Leung's Blog",
         description:
-          "Notes on software systems, AI tools, learning, and small experiments.",
+          "Notes on software systems, AI-assisted coding, deep learning, Next.js static sites, and small browser experiments.",
         id: "https://alexleung.ca/blog/",
         link: "https://alexleung.ca/blog/",
         image: "https://alexleung.ca/icon4.png",

--- a/src/lib/coverVariants.ts
+++ b/src/lib/coverVariants.ts
@@ -2,6 +2,7 @@ import {
   getCoverVariantProfile,
   getImageVariantSourceSet,
   getLargestImageVariant,
+  type VariantInfo,
 } from "@/lib/imageVariantManifest";
 
 type CoverVariant = "card" | "hero";
@@ -18,5 +19,12 @@ export function getCoverVariantPath(
   src: string | undefined,
   variant: CoverVariant
 ): string | undefined {
-  return getLargestImageVariant(src, getCoverVariantProfile(variant))?.path;
+  return getCoverVariant(src, variant)?.path;
+}
+
+export function getCoverVariant(
+  src: string | undefined,
+  variant: CoverVariant
+): VariantInfo | undefined {
+  return getLargestImageVariant(src, getCoverVariantProfile(variant));
 }

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -14,7 +14,7 @@ type FeedPost = {
 
 const FEED_TITLE = "Alex Leung's Blog";
 const FEED_DESCRIPTION =
-  "Notes on software systems, AI tools, learning, and small experiments.";
+  "Notes on software systems, AI-assisted coding, deep learning, Next.js static sites, and small browser experiments.";
 const FEED_IMAGE_URL = `${BASE_URL}/icon4.png`;
 
 export function buildRssFeedXml(posts: readonly FeedPost[]): string {

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -217,7 +217,7 @@ describe("seo jsonld builders", () => {
       addressCountry: "United States",
     });
     expect(person.disambiguatingDescription).toBe(
-      "Software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments."
+      "San Francisco-based software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments."
     );
     expect(person.knowsAbout).toEqual(
       expect.arrayContaining([

--- a/src/lib/seo/__tests__/jsonld.test.ts
+++ b/src/lib/seo/__tests__/jsonld.test.ts
@@ -217,7 +217,7 @@ describe("seo jsonld builders", () => {
       addressCountry: "United States",
     });
     expect(person.disambiguatingDescription).toBe(
-      "San Francisco-based software engineer writing notes on software systems, AI tools, and small experiments."
+      "Software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments."
     );
     expect(person.knowsAbout).toEqual(
       expect.arrayContaining([

--- a/src/lib/seo/__tests__/metadata.test.ts
+++ b/src/lib/seo/__tests__/metadata.test.ts
@@ -5,7 +5,6 @@ describe("buildPageMetadata", () => {
     const metadata = buildPageMetadata({
       title: "About Me | Alex Leung",
       description: "Learn more about Alex Leung.",
-      keywords: ["software engineer", "AI systems"],
       path: "/about",
     });
 
@@ -21,7 +20,6 @@ describe("buildPageMetadata", () => {
         },
       ],
     });
-    expect(metadata.keywords).toEqual(["software engineer", "AI systems"]);
     expect(openGraph?.url).toBe("https://alexleung.ca/about/");
 
     expect(openGraph).toMatchObject({ type: "website" });

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -368,7 +368,7 @@ export function buildPersonSchema(input: {
     worksFor: OPENAI_ORGANIZATION,
     description: input.description,
     disambiguatingDescription:
-      "Software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments.",
+      "San Francisco-based software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments.",
     knowsLanguage: ["en-CA"],
     sameAs: SOCIAL_PROFILES,
     address: {

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -368,7 +368,7 @@ export function buildPersonSchema(input: {
     worksFor: OPENAI_ORGANIZATION,
     description: input.description,
     disambiguatingDescription:
-      "San Francisco-based software engineer writing notes on software systems, AI tools, and small experiments.",
+      "Software engineer writing about software systems, AI-assisted coding, deep learning notes, and browser experiments.",
     knowsLanguage: ["en-CA"],
     sameAs: SOCIAL_PROFILES,
     address: {

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -22,7 +22,6 @@ export function buildPageMetadata(input: SeoInput): Metadata {
   return {
     title: input.title,
     description: input.description,
-    keywords: input.keywords,
     alternates: {
       canonical: canonicalUrl,
       types: {

--- a/src/lib/seo/types.ts
+++ b/src/lib/seo/types.ts
@@ -8,7 +8,6 @@ type SeoImage = {
 export type SeoInput = {
   description: string;
   images?: SeoImage[];
-  keywords?: string[];
   path: string;
   title: string;
   type?: "article" | "website";


### PR DESCRIPTION
## Summary
- add richer Open Graph and Twitter image metadata for blog posts and experiment pages
- tighten site, blog, feed, manifest, and JSON-LD descriptions around durable topics
- remove unused HTML meta keyword plumbing from the shared metadata helper

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- static browser check of /blog/ at 1280x900 and 390x844
- Playwright E2E/visual deferred to CI per request