### PR TITLE
Fix experiment interaction issues

### DIFF
--- a/src/app/experimental/event-loop/_components/__tests__/EventLoopVisualizer.test.tsx
+++ b/src/app/experimental/event-loop/_components/__tests__/EventLoopVisualizer.test.tsx
@@ -14,6 +14,20 @@ describe("EventLoopVisualizer", () => {
     );
   });
 
+  it("labels completed stack frames without impossible next-op counts", () => {
+    render(<EventLoopVisualizer />);
+
+    const stepButton = screen.getByRole("button", { name: "Step forward" });
+    fireEvent.click(stepButton);
+    fireEvent.click(stepButton);
+    fireEvent.click(stepButton);
+
+    expect(
+      screen.getByText(/source: sync.*complete.*done/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/next op 2\/1/i)).not.toBeInTheDocument();
+  });
+
   it("resets the selected example state", () => {
     render(<EventLoopVisualizer />);
 

--- a/src/app/experimental/load-flow/_components/LoadFlowWorkspace.tsx
+++ b/src/app/experimental/load-flow/_components/LoadFlowWorkspace.tsx
@@ -31,7 +31,11 @@ const BRANCH_STATUS_OPTIONS: readonly BranchStatus[] = [
 ];
 
 const parseFiniteNumber = (value: string): number | null => {
-  const parsed = Number.parseFloat(value);
+  if (value.trim() === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 };
 

--- a/src/app/experimental/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/experimental/load-flow/_components/SingleLineDiagram.tsx
@@ -1,4 +1,4 @@
-import { PointerEvent, useMemo, useRef, useState, WheelEvent } from "react";
+import { PointerEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   BranchFlowSolution,
@@ -29,6 +29,16 @@ const MIN_ZOOM = 0.6;
 const MAX_ZOOM = 2.5;
 const ZOOM_STEP = 0.2;
 const LINE_HOP_RADIUS = 10;
+const MAX_ALWAYS_LABELED_BRANCHES = 20;
+const DETAILED_LABEL_ZOOM = 1.6;
+const MIN_BRANCH_LABEL_SEGMENT_LENGTH = 96;
+const BRANCH_LABEL_HALF_WIDTH = 42;
+const BRANCH_LABEL_TOP_OFFSET = 24;
+const BRANCH_LABEL_BOTTOM_OFFSET = 10;
+const BRANCH_LABEL_BUS_MARGIN = 0;
+
+const clampZoom = (nextZoom: number) =>
+  Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, nextZoom));
 
 interface BranchSegment {
   branchId: string;
@@ -44,6 +54,81 @@ interface RoutedBranch {
   points: Array<{ x: number; y: number }>;
   segments: BranchSegment[];
 }
+
+interface BranchLabelPoint {
+  x: number;
+  y: number;
+  segmentLength: number;
+  hasClearance: boolean;
+}
+
+interface BusDragSession {
+  busId: string;
+  startClientX: number;
+  startClientY: number;
+  startX: number;
+  startY: number;
+  svgUnitsPerClientPixelX: number;
+  svgUnitsPerClientPixelY: number;
+}
+
+const getSegmentLength = (segment: BranchSegment) =>
+  Math.hypot(segment.x2 - segment.x1, segment.y2 - segment.y1);
+
+const branchLabelOverlapsBus = (
+  point: { x: number; y: number },
+  bus: BusNode
+) => {
+  const labelBox = {
+    left: point.x - BRANCH_LABEL_HALF_WIDTH,
+    right: point.x + BRANCH_LABEL_HALF_WIDTH,
+    top: point.y - BRANCH_LABEL_TOP_OFFSET,
+    bottom: point.y + BRANCH_LABEL_BOTTOM_OFFSET,
+  };
+  const busBox = {
+    left: bus.x - BUS_HALF_WIDTH - BRANCH_LABEL_BUS_MARGIN,
+    right: bus.x + BUS_HALF_WIDTH + BRANCH_LABEL_BUS_MARGIN,
+    top: bus.y - BUS_HALF_HEIGHT - BRANCH_LABEL_BUS_MARGIN,
+    bottom: bus.y + BUS_HALF_HEIGHT + BRANCH_LABEL_BUS_MARGIN,
+  };
+
+  return !(
+    labelBox.right <= busBox.left ||
+    busBox.right <= labelBox.left ||
+    labelBox.bottom <= busBox.top ||
+    busBox.bottom <= labelBox.top
+  );
+};
+
+const toBranchLabelPoint = (segment: BranchSegment): BranchLabelPoint => ({
+  x: (segment.x1 + segment.x2) / 2,
+  y: (segment.y1 + segment.y2) / 2,
+  segmentLength: getSegmentLength(segment),
+  hasClearance: true,
+});
+
+const getBranchLabelPoint = (
+  branch: RoutedBranch,
+  buses: BusNode[]
+): BranchLabelPoint => {
+  const labelCandidates = branch.segments
+    .map(toBranchLabelPoint)
+    .sort((first, second) => second.segmentLength - first.segmentLength);
+
+  if (labelCandidates.length === 0) {
+    return {
+      ...(branch.points.at(-1) ?? { x: 0, y: 0 }),
+      segmentLength: 0,
+      hasClearance: false,
+    };
+  }
+
+  const clearCandidate = labelCandidates.find(
+    (candidate) => !buses.some((bus) => branchLabelOverlapsBus(candidate, bus))
+  );
+
+  return clearCandidate ?? { ...labelCandidates[0], hasClearance: false };
+};
 
 const getOrthogonalCrossingPoint = (
   firstSegment: BranchSegment,
@@ -130,56 +215,69 @@ export function SingleLineDiagram({
   branchFlowsById,
 }: SingleLineDiagramProps) {
   const svgRef = useRef<SVGSVGElement | null>(null);
-  const draggingBusIdRef = useRef<string | null>(null);
+  const dragSessionRef = useRef<BusDragSession | null>(null);
   const [zoom, setZoom] = useState(1);
 
-  const toSvgPoint = (clientX: number, clientY: number) => {
-    const svg = svgRef.current;
-    if (!svg) {
-      return null;
-    }
-
-    const point = svg.createSVGPoint();
-    point.x = clientX;
-    point.y = clientY;
-    const transform = svg.getScreenCTM();
-    if (!transform) {
-      return null;
-    }
-
-    return point.matrixTransform(transform.inverse());
-  };
-
   const handleBusPointerDown = (
-    event: PointerEvent<SVGRectElement>,
+    event: PointerEvent<SVGGElement>,
     busId: string
   ) => {
+    const svg = svgRef.current;
+    const bus = busesById.get(busId);
+    const svgBounds = svg?.getBoundingClientRect();
+
+    if (
+      !svg ||
+      !bus ||
+      !svgBounds ||
+      svgBounds.width <= 0 ||
+      svgBounds.height <= 0
+    ) {
+      return;
+    }
+
     event.preventDefault();
-    draggingBusIdRef.current = busId;
+    dragSessionRef.current = {
+      busId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startX: bus.x,
+      startY: bus.y,
+      svgUnitsPerClientPixelX: zoomedViewBoxWidth / svgBounds.width,
+      svgUnitsPerClientPixelY: zoomedViewBoxHeight / svgBounds.height,
+    };
     onBusSelect(busId);
     event.currentTarget.setPointerCapture(event.pointerId);
   };
 
-  const handleBusPointerMove = (event: PointerEvent<SVGRectElement>) => {
-    const draggingBusId = draggingBusIdRef.current;
-    if (!draggingBusId) {
+  const handleBusPointerMove = (event: PointerEvent<SVGGElement>) => {
+    const dragSession = dragSessionRef.current;
+    if (!dragSession) {
       return;
     }
 
-    const point = toSvgPoint(event.clientX, event.clientY);
-    if (!point) {
-      return;
+    onBusMove(
+      dragSession.busId,
+      dragSession.startX +
+        (event.clientX - dragSession.startClientX) *
+          dragSession.svgUnitsPerClientPixelX,
+      dragSession.startY +
+        (event.clientY - dragSession.startClientY) *
+          dragSession.svgUnitsPerClientPixelY
+    );
+  };
+
+  const handleBusPointerUp = (event: PointerEvent<SVGGElement>) => {
+    dragSessionRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
     }
-
-    onBusMove(draggingBusId, point.x, point.y);
   };
 
-  const handleBusPointerUp = (event: PointerEvent<SVGRectElement>) => {
-    draggingBusIdRef.current = null;
-    event.currentTarget.releasePointerCapture(event.pointerId);
-  };
-
-  const busesById = new Map(buses.map((bus) => [bus.id, bus]));
+  const busesById = useMemo(
+    () => new Map(buses.map((bus) => [bus.id, bus])),
+    [buses]
+  );
   const busCentersX = buses.map((bus) => bus.x);
   const busCentersY = buses.map((bus) => bus.y);
 
@@ -210,9 +308,6 @@ export function SingleLineDiagram({
   const zoomedViewBoxX = viewBoxCenterX - zoomedViewBoxWidth / 2;
   const zoomedViewBoxY = viewBoxCenterY - zoomedViewBoxHeight / 2;
 
-  const clampZoom = (nextZoom: number) =>
-    Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, nextZoom));
-
   const handleZoomIn = () => {
     setZoom((previousZoom) => clampZoom(previousZoom + ZOOM_STEP));
   };
@@ -221,16 +316,29 @@ export function SingleLineDiagram({
     setZoom((previousZoom) => clampZoom(previousZoom - ZOOM_STEP));
   };
 
-  const handleWheel = (event: WheelEvent<SVGSVGElement>) => {
-    if (!event.ctrlKey) {
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) {
       return;
     }
 
-    event.preventDefault();
-    setZoom((previousZoom) =>
-      clampZoom(previousZoom + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP))
-    );
-  };
+    const handleWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey) {
+        return;
+      }
+
+      event.preventDefault();
+      setZoom((previousZoom) =>
+        clampZoom(previousZoom + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP))
+      );
+    };
+
+    svg.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      svg.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
 
   const routedBranchesById = useMemo(() => {
     const routedById = new Map<string, RoutedBranch>();
@@ -328,7 +436,6 @@ export function SingleLineDiagram({
             role="img"
             aria-label="Single line diagram"
             className="h-[360px] min-w-[980px] w-full"
-            onWheel={handleWheel}
           >
             <rect
               x={viewBoxX}
@@ -350,12 +457,16 @@ export function SingleLineDiagram({
               if (!routedBranch) {
                 return null;
               }
-              const elbowPoint = routedBranch.points[1];
-              const fallbackLabelPoint =
-                routedBranch.points[routedBranch.points.length - 1];
+              const labelPoint = getBranchLabelPoint(routedBranch, buses);
               const isSelected =
                 selectedElementType === "BRANCH" &&
                 selectedElementId === branch.id;
+              const showBranchLabels =
+                labelPoint.hasClearance &&
+                labelPoint.segmentLength >= MIN_BRANCH_LABEL_SEGMENT_LENGTH &&
+                (branches.length <= MAX_ALWAYS_LABELED_BRANCHES ||
+                  zoom >= DETAILED_LABEL_ZOOM ||
+                  isSelected);
               const branchFlow = branchFlowsById?.get(branch.id);
               const activePowerFromTo = branchFlow?.pFromToMW;
               const flowDirectionSymbol =
@@ -370,32 +481,49 @@ export function SingleLineDiagram({
                   : Math.abs(activePowerFromTo).toFixed(2);
 
               return (
-                <g key={branch.id}>
+                <g
+                  key={branch.id}
+                  className="cursor-pointer"
+                  onClick={() => onBranchSelect(branch.id)}
+                >
                   <polyline
                     points={routedBranch.points
                       .map((point) => `${point.x},${point.y}`)
                       .join(" ")}
                     fill="none"
-                    className={`${lineClassName(isSelected)} cursor-pointer transition`}
-                    onClick={() => onBranchSelect(branch.id)}
+                    stroke="transparent"
+                    strokeWidth={16}
+                    vectorEffect="non-scaling-stroke"
+                    pointerEvents="stroke"
                   />
-                  <text
-                    x={elbowPoint?.x ?? fallbackLabelPoint?.x ?? 0}
-                    y={(elbowPoint?.y ?? fallbackLabelPoint?.y ?? 0) - 10}
-                    textAnchor="middle"
-                    className="fill-slate-300 text-[10px]"
-                  >
-                    {branch.id}
-                  </text>
-                  {flowMagnitudeMW ? (
-                    <text
-                      x={elbowPoint?.x ?? fallbackLabelPoint?.x ?? 0}
-                      y={(elbowPoint?.y ?? fallbackLabelPoint?.y ?? 0) + 4}
-                      textAnchor="middle"
-                      className="fill-emerald-200 text-[10px]"
-                    >
-                      {flowDirectionSymbol} {flowMagnitudeMW} MW
-                    </text>
+                  <polyline
+                    points={routedBranch.points
+                      .map((point) => `${point.x},${point.y}`)
+                      .join(" ")}
+                    fill="none"
+                    className={`${lineClassName(isSelected)} transition`}
+                  />
+                  {showBranchLabels ? (
+                    <>
+                      <text
+                        x={labelPoint.x}
+                        y={labelPoint.y - 10}
+                        textAnchor="middle"
+                        className="fill-slate-300 text-[10px]"
+                      >
+                        {branch.id}
+                      </text>
+                      {flowMagnitudeMW ? (
+                        <text
+                          x={labelPoint.x}
+                          y={labelPoint.y + 4}
+                          textAnchor="middle"
+                          className="fill-emerald-200 text-[10px]"
+                        >
+                          {flowDirectionSymbol} {flowMagnitudeMW} MW
+                        </text>
+                      ) : null}
+                    </>
                   ) : null}
                 </g>
               );
@@ -439,6 +567,12 @@ export function SingleLineDiagram({
                 <g
                   key={bus.id}
                   transform={`translate(${bus.x - BUS_HALF_WIDTH}, ${bus.y - BUS_HALF_HEIGHT})`}
+                  className="cursor-pointer"
+                  onClick={() => onBusSelect(bus.id)}
+                  onPointerDown={(event) => handleBusPointerDown(event, bus.id)}
+                  onPointerMove={handleBusPointerMove}
+                  onPointerUp={handleBusPointerUp}
+                  onPointerCancel={handleBusPointerUp}
                 >
                   <rect
                     x={0}
@@ -446,13 +580,7 @@ export function SingleLineDiagram({
                     rx={6}
                     width={BUS_WIDTH}
                     height={BUS_HEIGHT}
-                    className={`${busClassName(isSelected)} cursor-pointer stroke-2 transition`}
-                    onClick={() => onBusSelect(bus.id)}
-                    onPointerDown={(event) =>
-                      handleBusPointerDown(event, bus.id)
-                    }
-                    onPointerMove={handleBusPointerMove}
-                    onPointerUp={handleBusPointerUp}
+                    className={`${busClassName(isSelected)} stroke-2 transition`}
                   />
                   <text
                     x={BUS_HALF_WIDTH}

--- a/src/app/experimental/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
+++ b/src/app/experimental/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
@@ -32,6 +32,45 @@ const branches: LineEdge[] = [
 ];
 
 const reversedBranchOrder = [branches[1], branches[0]];
+const horizontalBuses: BusNode[] = [
+  { id: "bus-a", name: "Bus A", type: "SLACK", baseKV: 230, x: 100, y: 100 },
+  { id: "bus-b", name: "Bus B", type: "PQ", baseKV: 230, x: 300, y: 100 },
+];
+const horizontalBranches: LineEdge[] = [
+  {
+    id: "line-horizontal",
+    fromBusId: "bus-a",
+    toBusId: "bus-b",
+    r: 0.01,
+    x: 0.1,
+    bHalf: 0,
+    status: "IN_SERVICE",
+  },
+];
+const tightlySpacedVerticalBuses: BusNode[] = [
+  { id: "bus-a", name: "Bus A", type: "SLACK", baseKV: 230, x: 100, y: 100 },
+  { id: "bus-b", name: "Bus B", type: "PQ", baseKV: 230, x: 100, y: 170 },
+];
+const tightlySpacedVerticalBranches: LineEdge[] = [
+  {
+    id: "line-too-tight",
+    fromBusId: "bus-a",
+    toBusId: "bus-b",
+    r: 0.01,
+    x: 0.1,
+    bHalf: 0,
+    status: "IN_SERVICE",
+  },
+];
+const denseBranches: LineEdge[] = Array.from({ length: 21 }, (_, index) => ({
+  id: `dense-line-${index + 1}`,
+  fromBusId: "bus-a",
+  toBusId: "bus-b",
+  r: 0.01,
+  x: 0.1,
+  bHalf: 0,
+  status: "IN_SERVICE",
+}));
 
 describe("SingleLineDiagram", () => {
   const onBusSelect = jest.fn();
@@ -105,5 +144,96 @@ describe("SingleLineDiagram", () => {
 
     const hopPaths = container.querySelectorAll('path[d*="A 10 10"]');
     expect(hopPaths.length).toBeGreaterThan(0);
+  });
+
+  it("selects buses and branches when their labels are clicked", () => {
+    render(
+      <SingleLineDiagram
+        buses={buses}
+        branches={branches}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Bus 1"));
+    expect(onBusSelect).toHaveBeenCalledWith("bus-1");
+
+    fireEvent.click(screen.getByText("line-1"));
+    expect(onBranchSelect).toHaveBeenCalledWith("line-1");
+  });
+
+  it("places straight branch labels between endpoint buses", () => {
+    render(
+      <SingleLineDiagram
+        buses={horizontalBuses}
+        branches={horizontalBranches}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    const branchLabel = screen.getByText("line-horizontal");
+
+    expect(branchLabel).toHaveAttribute("x", "200");
+    expect(branchLabel).toHaveAttribute("y", "90");
+  });
+
+  it("suppresses branch labels that would overlap bus boxes", () => {
+    render(
+      <SingleLineDiagram
+        buses={tightlySpacedVerticalBuses}
+        branches={tightlySpacedVerticalBranches}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    expect(screen.queryByText("line-too-tight")).not.toBeInTheDocument();
+  });
+
+  it("suppresses unselected branch labels in dense diagrams", () => {
+    const { container } = render(
+      <SingleLineDiagram
+        buses={horizontalBuses}
+        branches={denseBranches}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    expect(screen.queryByText("dense-line-1")).not.toBeInTheDocument();
+    expect(
+      container.querySelectorAll('polyline[stroke="transparent"]')
+    ).toHaveLength(denseBranches.length);
+  });
+
+  it("shows a selected branch label in dense diagrams when it has room", () => {
+    render(
+      <SingleLineDiagram
+        buses={horizontalBuses}
+        branches={denseBranches}
+        selectedElementId="dense-line-1"
+        selectedElementType="BRANCH"
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    expect(screen.getByText("dense-line-1")).toBeInTheDocument();
+    expect(screen.queryByText("dense-line-2")).not.toBeInTheDocument();
   });
 });

--- a/src/app/experimental/pid-controller/__tests__/page.test.tsx
+++ b/src/app/experimental/pid-controller/__tests__/page.test.tsx
@@ -7,7 +7,10 @@ describe("PidControllerPage", () => {
     render(<PidControllerPage />);
 
     expect(
-      screen.getByRole("heading", { level: 1, name: "PID Controller" })
+      screen.getByRole("heading", {
+        level: 1,
+        name: "PID Controller Simulator",
+      })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {

--- a/src/app/experimental/pid-controller/page.tsx
+++ b/src/app/experimental/pid-controller/page.tsx
@@ -32,7 +32,7 @@ export default function PidControllerPage() {
   return (
     <>
       <JsonLdBreadcrumbs
-        items={buildExperimentBreadcrumbItems("PID Controller", path)}
+        items={buildExperimentBreadcrumbItems(experiment.pageTitle, path)}
       />
       <JsonLd<WebPage>
         item={buildWebPageSchema({
@@ -42,7 +42,7 @@ export default function PidControllerPage() {
         })}
       />
 
-      <PageShell title="PID Controller" titleId="pid-controller">
+      <PageShell title={experiment.pageTitle} titleId="pid-controller">
         <ResponsiveContainer element="section" className="space-y-6">
           <PidSimulatorWorkspace />
         </ResponsiveContainer>

--- a/src/features/event-loop/components/CallStackPanel.tsx
+++ b/src/features/event-loop/components/CallStackPanel.tsx
@@ -5,6 +5,14 @@ type CallStackPanelProps = {
   frames: Frame[];
 };
 
+function formatFrameProgress(frame: Frame): string {
+  if (!isFrameActive(frame)) {
+    return "complete";
+  }
+
+  return `next op ${frame.cursor + 1}/${frame.operations.length}`;
+}
+
 export function CallStackPanel({ frames }: CallStackPanelProps) {
   return (
     <section className="rounded-lg border border-gray-700 bg-gray-900/70 p-4">
@@ -31,8 +39,7 @@ export function CallStackPanel({ frames }: CallStackPanelProps) {
             >
               <p className="text-sm text-white">{frame.label}</p>
               <p className="text-xs text-gray-300">
-                source: {frame.source} • next op {frame.cursor + 1}/
-                {frame.operations.length} •{" "}
+                source: {frame.source} • {formatFrameProgress(frame)} •{" "}
                 {isFrameActive(frame) ? "active" : "done"}
               </p>
             </li>


### PR DESCRIPTION
## Summary
- improve the load-flow single-line diagram interaction model: stable bus dragging, clickable bus/branch labels, clearer branch label placement, dense-case label suppression, wider branch hit targets, and non-passive Ctrl-wheel zoom handling
- tighten load-flow numeric parsing so blank values and partial numeric strings are rejected consistently
- fix smaller experiment polish issues in the event-loop call stack progress label and PID controller page title/schema alignment

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn test:e2e`
- `docker compose run --rm -e PLAYWRIGHT_BASE_URL=http://host.docker.internal:3000 playwright-visual` against a local static `out/` server: 12 passed

## Notes
- The standard Docker and host visual wrappers timed out while waiting for Playwright's auto-started web server. I started the built static site explicitly and ran the same Docker visual project against it so the Linux snapshots were still validated.