### PR TITLE
Address SLD interaction feedback

### DIFF
--- a/src/app/experimental/load-flow/_components/SingleLineDiagram.tsx
+++ b/src/app/experimental/load-flow/_components/SingleLineDiagram.tsx
@@ -1,4 +1,4 @@
-import { PointerEvent, useEffect, useMemo, useRef, useState } from "react";
+import { PointerEvent, useCallback, useMemo, useRef, useState } from "react";
 
 import {
   BranchFlowSolution,
@@ -62,18 +62,37 @@ interface BranchLabelPoint {
   hasClearance: boolean;
 }
 
+interface ClientToSvgMatrix {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
 interface BusDragSession {
   busId: string;
-  startClientX: number;
-  startClientY: number;
-  startX: number;
-  startY: number;
-  svgUnitsPerClientPixelX: number;
-  svgUnitsPerClientPixelY: number;
+  pointerOffsetX: number;
+  pointerOffsetY: number;
+}
+
+interface SvgWheelListener {
+  node: SVGSVGElement;
+  handler: (event: WheelEvent) => void;
 }
 
 const getSegmentLength = (segment: BranchSegment) =>
   Math.hypot(segment.x2 - segment.x1, segment.y2 - segment.y1);
+
+const transformClientPoint = (
+  matrix: ClientToSvgMatrix,
+  clientX: number,
+  clientY: number
+) => ({
+  x: matrix.a * clientX + matrix.c * clientY + matrix.e,
+  y: matrix.b * clientX + matrix.d * clientY + matrix.f,
+});
 
 const branchLabelOverlapsBus = (
   point: { x: number; y: number },
@@ -216,63 +235,38 @@ export function SingleLineDiagram({
 }: SingleLineDiagramProps) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const dragSessionRef = useRef<BusDragSession | null>(null);
+  const svgWheelListenerRef = useRef<SvgWheelListener | null>(null);
   const [zoom, setZoom] = useState(1);
 
-  const handleBusPointerDown = (
-    event: PointerEvent<SVGGElement>,
-    busId: string
-  ) => {
-    const svg = svgRef.current;
-    const bus = busesById.get(busId);
-    const svgBounds = svg?.getBoundingClientRect();
+  const handleSvgRef = useCallback((node: SVGSVGElement | null) => {
+    const previousListener = svgWheelListenerRef.current;
+    if (previousListener) {
+      previousListener.node.removeEventListener(
+        "wheel",
+        previousListener.handler
+      );
+      svgWheelListenerRef.current = null;
+    }
 
-    if (
-      !svg ||
-      !bus ||
-      !svgBounds ||
-      svgBounds.width <= 0 ||
-      svgBounds.height <= 0
-    ) {
+    svgRef.current = node;
+    if (!node) {
       return;
     }
 
-    event.preventDefault();
-    dragSessionRef.current = {
-      busId,
-      startClientX: event.clientX,
-      startClientY: event.clientY,
-      startX: bus.x,
-      startY: bus.y,
-      svgUnitsPerClientPixelX: zoomedViewBoxWidth / svgBounds.width,
-      svgUnitsPerClientPixelY: zoomedViewBoxHeight / svgBounds.height,
+    const handleWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey) {
+        return;
+      }
+
+      event.preventDefault();
+      setZoom((previousZoom) =>
+        clampZoom(previousZoom + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP))
+      );
     };
-    onBusSelect(busId);
-    event.currentTarget.setPointerCapture(event.pointerId);
-  };
 
-  const handleBusPointerMove = (event: PointerEvent<SVGGElement>) => {
-    const dragSession = dragSessionRef.current;
-    if (!dragSession) {
-      return;
-    }
-
-    onBusMove(
-      dragSession.busId,
-      dragSession.startX +
-        (event.clientX - dragSession.startClientX) *
-          dragSession.svgUnitsPerClientPixelX,
-      dragSession.startY +
-        (event.clientY - dragSession.startClientY) *
-          dragSession.svgUnitsPerClientPixelY
-    );
-  };
-
-  const handleBusPointerUp = (event: PointerEvent<SVGGElement>) => {
-    dragSessionRef.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-  };
+    node.addEventListener("wheel", handleWheel, { passive: false });
+    svgWheelListenerRef.current = { node, handler: handleWheel };
+  }, []);
 
   const busesById = useMemo(
     () => new Map(buses.map((bus) => [bus.id, bus])),
@@ -316,29 +310,59 @@ export function SingleLineDiagram({
     setZoom((previousZoom) => clampZoom(previousZoom - ZOOM_STEP));
   };
 
-  useEffect(() => {
+  const handleBusPointerDown = (
+    event: PointerEvent<SVGGElement>,
+    busId: string
+  ) => {
     const svg = svgRef.current;
-    if (!svg) {
+    const bus = busesById.get(busId);
+    const clientToSvgMatrix = svg?.getScreenCTM()?.inverse();
+
+    if (!svg || !bus || !clientToSvgMatrix) {
       return;
     }
 
-    const handleWheel = (event: WheelEvent) => {
-      if (!event.ctrlKey) {
-        return;
-      }
-
-      event.preventDefault();
-      setZoom((previousZoom) =>
-        clampZoom(previousZoom + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP))
-      );
+    event.preventDefault();
+    const startPointer = transformClientPoint(
+      clientToSvgMatrix,
+      event.clientX,
+      event.clientY
+    );
+    dragSessionRef.current = {
+      busId,
+      pointerOffsetX: bus.x - startPointer.x,
+      pointerOffsetY: bus.y - startPointer.y,
     };
+    onBusSelect(busId);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
 
-    svg.addEventListener("wheel", handleWheel, { passive: false });
+  const handleBusPointerMove = (event: PointerEvent<SVGGElement>) => {
+    const dragSession = dragSessionRef.current;
+    const clientToSvgMatrix = svgRef.current?.getScreenCTM()?.inverse();
+    if (!dragSession || !clientToSvgMatrix) {
+      return;
+    }
 
-    return () => {
-      svg.removeEventListener("wheel", handleWheel);
-    };
-  }, []);
+    const nextPointer = transformClientPoint(
+      clientToSvgMatrix,
+      event.clientX,
+      event.clientY
+    );
+
+    onBusMove(
+      dragSession.busId,
+      nextPointer.x + dragSession.pointerOffsetX,
+      nextPointer.y + dragSession.pointerOffsetY
+    );
+  };
+
+  const handleBusPointerUp = (event: PointerEvent<SVGGElement>) => {
+    dragSessionRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
 
   const routedBranchesById = useMemo(() => {
     const routedById = new Map<string, RoutedBranch>();
@@ -431,7 +455,7 @@ export function SingleLineDiagram({
             </span>
           </div>
           <svg
-            ref={svgRef}
+            ref={handleSvgRef}
             viewBox={`${zoomedViewBoxX} ${zoomedViewBoxY} ${zoomedViewBoxWidth} ${zoomedViewBoxHeight}`}
             role="img"
             aria-label="Single line diagram"

--- a/src/app/experimental/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
+++ b/src/app/experimental/load-flow/_components/__tests__/SingleLineDiagram.test.tsx
@@ -112,6 +112,107 @@ describe("SingleLineDiagram", () => {
     expect(screen.getByText("140% (Ctrl + wheel)")).toBeInTheDocument();
   });
 
+  it("reattaches ctrl-wheel zoom after the SVG is recreated", () => {
+    const { container, rerender } = render(
+      <SingleLineDiagram
+        buses={[]}
+        branches={[]}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    expect(container.querySelector("svg")).toBeNull();
+
+    rerender(
+      <SingleLineDiagram
+        buses={horizontalBuses}
+        branches={[]}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    if (!svg) {
+      return;
+    }
+
+    fireEvent.wheel(svg, { ctrlKey: true, deltaY: -100 });
+    expect(screen.getByText("120% (Ctrl + wheel)")).toBeInTheDocument();
+  });
+
+  it("uses the SVG transform for bus drag deltas", () => {
+    const { container } = render(
+      <SingleLineDiagram
+        buses={horizontalBuses}
+        branches={[]}
+        selectedElementId={null}
+        selectedElementType={null}
+        onBusSelect={onBusSelect}
+        onBusMove={onBusMove}
+        onBranchSelect={onBranchSelect}
+      />
+    );
+
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    if (!svg) {
+      return;
+    }
+
+    Object.defineProperty(svg, "getScreenCTM", {
+      configurable: true,
+      value: () => ({
+        inverse: () => ({
+          a: 0.5,
+          b: 0,
+          c: 0,
+          d: 0.5,
+          e: -10,
+          f: -20,
+        }),
+      }),
+    });
+
+    const busGroup = screen.getByText("Bus A").closest("g");
+    expect(busGroup).not.toBeNull();
+    if (!busGroup) {
+      return;
+    }
+
+    busGroup.setPointerCapture = jest.fn();
+    busGroup.hasPointerCapture = jest.fn(() => true);
+    busGroup.releasePointerCapture = jest.fn();
+
+    const dispatchPointerEvent = (
+      type: string,
+      init: { clientX?: number; clientY?: number } = {}
+    ) => {
+      const event = new MouseEvent(type, {
+        bubbles: true,
+        clientX: init.clientX,
+        clientY: init.clientY,
+      });
+      Object.defineProperty(event, "pointerId", { value: 1 });
+      busGroup.dispatchEvent(event);
+    };
+
+    dispatchPointerEvent("pointerdown", { clientX: 300, clientY: 220 });
+    dispatchPointerEvent("pointermove", { clientX: 340, clientY: 260 });
+    dispatchPointerEvent("pointerup");
+
+    expect(onBusSelect).toHaveBeenCalledWith("bus-a");
+    expect(onBusMove).toHaveBeenCalledWith("bus-a", 120, 120);
+  });
+
   it("renders hop markers when two line segments cross", () => {
     const { container } = render(
       <SingleLineDiagram


### PR DESCRIPTION
## Summary
- reattach the SLD Ctrl-wheel listener whenever the SVG node is recreated
- convert pointer coordinates through the SVG screen transform for bus drags
- keep dragged buses under the pointer while the diagram viewBox recenters
- add regressions for SVG recreation zoom and transform-based drag math

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- yarn test src/app/experimental/load-flow/_components/__tests__/SingleLineDiagram.test.tsx --runInBand
- PLAYWRIGHT_BASE_URL=http://host.docker.internal:3000 yarn test:e2e
- PLAYWRIGHT_BASE_URL=http://host.docker.internal:3000 yarn test:e2e:visual
- Docker Playwright interaction check: Ctrl-wheel after SVG recreation reached 120% and Grid bus followed an 80x50 pointer drag with no console warnings

Follow-up for missed feedback on #275.