### PR TITLE
Add Mandelbrot perturbation deep zoom

### DIFF
--- a/playwright/tests/smoke/mandelbrot.spec.ts
+++ b/playwright/tests/smoke/mandelbrot.spec.ts
@@ -1,7 +1,7 @@
 import { expect, gotoAndStabilize, test } from "../../fixtures/stableRendering";
 
 const deepZoomPath =
-  "/experimental/mandelbrot/?cx=-0.743643887037151&cy=0.13182590420533&w=1e-13&iter=2000&quality=1";
+  "/experimental/mandelbrot/?cx=-0.743643887045151&cy=0.13182590421333&w=1e-13&iter=2000&quality=1";
 
 test("Mandelbrot deep zoom renders a responsive precision preview", async ({
   page,
@@ -15,12 +15,55 @@ test("Mandelbrot deep zoom renders a responsive precision preview", async ({
     timeout: 20_000,
   });
   await expect(
-    page.getByText("Ready at 5% deep-zoom preview (100 iterations).")
+    page.getByText(
+      "Ready at 100% perturbation deep-zoom render (2000 iterations)."
+    )
   ).toBeVisible();
   await expect(page.getByText("Backend: CPU")).toBeVisible();
   await expect(page.getByTestId("mandelbrot-width")).toHaveText(
     "0.0000000000001"
   );
+  const sampledColorCount = await page
+    .getByLabel("Mandelbrot set rendering canvas")
+    .evaluate((canvas) => {
+      if (!(canvas instanceof HTMLCanvasElement)) {
+        return 0;
+      }
+
+      const context = canvas.getContext("2d");
+
+      if (!context || canvas.width === 0 || canvas.height === 0) {
+        return 0;
+      }
+
+      const colors = new Set<string>();
+      const sampleFractions = [0.2, 0.4, 0.6, 0.8];
+
+      for (const yFraction of sampleFractions) {
+        for (const xFraction of sampleFractions) {
+          const x = Math.min(
+            canvas.width - 1,
+            Math.max(0, Math.floor(canvas.width * xFraction))
+          );
+          const y = Math.min(
+            canvas.height - 1,
+            Math.max(0, Math.floor(canvas.height * yFraction))
+          );
+          const [red, green, blue, alpha] = context.getImageData(
+            x,
+            y,
+            1,
+            1
+          ).data;
+
+          colors.add(`${red},${green},${blue},${alpha}`);
+        }
+      }
+
+      return colors.size;
+    });
+
+  expect(sampledColorCount).toBeGreaterThan(1);
 
   const plotControls = page.getByText("Plot controls").locator("xpath=..");
   const zoomButton = page.getByRole("button", { name: "Zoom in" }).first();

--- a/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
+++ b/src/app/experimental/mandelbrot/_components/MandelbrotExplorer.tsx
@@ -603,6 +603,11 @@ export function MandelbrotExplorer() {
                 frames whenever the view changes.
               </li>
               <li>
+                Deep frames use a high-precision reference orbit with
+                perturbation deltas so tiny viewports can still render at the
+                selected quality.
+              </li>
+              <li>
                 Query parameters can seed the initial center, width, backend,
                 palette, quality, and iteration budget.
               </li>

--- a/src/features/mandelbrot/__tests__/mandelbrot.test.ts
+++ b/src/features/mandelbrot/__tests__/mandelbrot.test.ts
@@ -1,11 +1,15 @@
 import Decimal from "decimal.js";
 
 import {
+  createPerturbationReferenceOrbit,
   iterateMandelbrot,
   iterateMandelbrotNumber,
+  iterateMandelbrotPerturbation,
   shouldUseNumberIteration,
+  shouldUsePerturbationIteration,
 } from "@/features/mandelbrot/mandelbrot";
 import { normalizedEscapeValue } from "@/features/mandelbrot/palettes";
+import { configurePrecisionForWidth } from "@/features/mandelbrot/viewport";
 
 describe("mandelbrot escape-time logic", () => {
   it("keeps well-known interior points bounded", () => {
@@ -66,8 +70,69 @@ describe("mandelbrot escape-time logic", () => {
     );
   });
 
+  it("matches the decimal path for tiny perturbations around a reference orbit", () => {
+    const centerX = new Decimal("-0.75");
+    const centerY = new Decimal("0.1");
+    const width = new Decimal("1e-13");
+    const height = new Decimal("6.25e-14");
+    const size = { width: 9, height: 5 };
+    const maxIterations = 300;
+
+    configurePrecisionForWidth(width);
+
+    const orbit = createPerturbationReferenceOrbit(
+      centerX,
+      centerY,
+      maxIterations
+    );
+    const stepX = width.div(size.width);
+    const stepY = height.div(size.height);
+    const samplePixels = [
+      { x: 0, y: 0 },
+      { x: 4, y: 2 },
+      { x: 8, y: 4 },
+    ];
+
+    expect(orbit.usable).toBe(true);
+
+    for (const point of samplePixels) {
+      const deltaReal = width
+        .neg()
+        .div(2)
+        .add(stepX.mul(point.x + 0.5));
+      const deltaImaginary = height.div(2).sub(stepY.mul(point.y + 0.5));
+      const decimalResult = iterateMandelbrot(
+        centerX.add(deltaReal),
+        centerY.add(deltaImaginary),
+        maxIterations
+      );
+      const perturbationResult = iterateMandelbrotPerturbation(
+        deltaReal.toNumber(),
+        deltaImaginary.toNumber(),
+        orbit,
+        maxIterations
+      );
+
+      expect(perturbationResult.escaped).toBe(decimalResult.escaped);
+      expect(perturbationResult.iterations).toBe(decimalResult.iterations);
+
+      if (decimalResult.escaped) {
+        expect(perturbationResult.smoothIteration).toBeCloseTo(
+          decimalResult.smoothIteration,
+          8
+        );
+      }
+    }
+  });
+
   it("switches to the decimal escape path only once zoom depth is small enough", () => {
     expect(shouldUseNumberIteration(new Decimal("1e-6"))).toBe(true);
     expect(shouldUseNumberIteration(new Decimal("1e-15"))).toBe(false);
+  });
+
+  it("uses perturbation rendering for practical deep zoom widths", () => {
+    expect(shouldUsePerturbationIteration(new Decimal("1e-13"))).toBe(true);
+    expect(shouldUsePerturbationIteration(new Decimal("1e-80"))).toBe(true);
+    expect(shouldUsePerturbationIteration(new Decimal("1e-320"))).toBe(false);
   });
 });

--- a/src/features/mandelbrot/__tests__/renderPlan.test.ts
+++ b/src/features/mandelbrot/__tests__/renderPlan.test.ts
@@ -47,13 +47,45 @@ describe("createMandelbrotRenderPlan", () => {
     expect(plan.completionMessage).toBe("Ready at 100% render scale.");
   });
 
-  it("uses a capped deep-zoom preview once Decimal iteration is required", () => {
+  it("uses a full perturbation render once Decimal viewport precision is required", () => {
     const plan = createMandelbrotRenderPlan(
       createViewport("1e-13"),
       defaultSettings
     );
 
     expect(plan.passes).toHaveLength(1);
+    expect(plan.passes[0]).toEqual({
+      phase: "refining",
+      scale: 1,
+      settings: defaultSettings,
+      message: "Rendering perturbation deep-zoom frame...",
+    });
+    expect(plan.completionMessage).toBe(
+      "Ready at 100% perturbation deep-zoom render (2000 iterations)."
+    );
+  });
+
+  it("preserves lower user quality and iteration budgets for perturbation renders", () => {
+    const settings = {
+      ...defaultSettings,
+      maxIterations: 80,
+      resolutionScale: 0.5,
+    };
+    const plan = createMandelbrotRenderPlan(createViewport("1e-80"), settings);
+
+    expect(plan.passes[0]?.scale).toBe(0.5);
+    expect(plan.passes[0]?.settings.maxIterations).toBe(80);
+    expect(plan.completionMessage).toBe(
+      "Ready at 50% perturbation deep-zoom render (80 iterations)."
+    );
+  });
+
+  it("keeps a capped Decimal preview beyond perturbation's practical number range", () => {
+    const plan = createMandelbrotRenderPlan(
+      createViewport("1e-320"),
+      defaultSettings
+    );
+
     expect(plan.passes[0]).toEqual({
       phase: "refining",
       scale: 0.05,
@@ -65,21 +97,6 @@ describe("createMandelbrotRenderPlan", () => {
     });
     expect(plan.completionMessage).toBe(
       "Ready at 5% deep-zoom preview (100 iterations)."
-    );
-  });
-
-  it("does not raise a lower user iteration budget for deep zooms", () => {
-    const settings = {
-      ...defaultSettings,
-      maxIterations: 80,
-      resolutionScale: 0.5,
-    };
-    const plan = createMandelbrotRenderPlan(createViewport("1e-80"), settings);
-
-    expect(plan.passes[0]?.scale).toBe(0.05);
-    expect(plan.passes[0]?.settings.maxIterations).toBe(80);
-    expect(plan.completionMessage).toBe(
-      "Ready at 5% deep-zoom preview (80 iterations)."
     );
   });
 });

--- a/src/features/mandelbrot/mandelbrot.ts
+++ b/src/features/mandelbrot/mandelbrot.ts
@@ -5,7 +5,18 @@ import { EscapeResult } from "@/features/mandelbrot/types";
 const ESCAPE_RADIUS_SQUARED = new Decimal(4);
 const ESCAPE_RADIUS_SQUARED_NUMBER = 4;
 const NUMBER_RENDER_WIDTH_THRESHOLD = new Decimal("1e-12");
+const PERTURBATION_RENDER_WIDTH_FLOOR = new Decimal("1e-300");
 const LOG_2 = Math.log(2);
+
+type PerturbationOrbitPoint = {
+  real: number;
+  imaginary: number;
+};
+
+type PerturbationReferenceOrbit = {
+  points: PerturbationOrbitPoint[];
+  usable: boolean;
+};
 
 function smoothEscapeValue(
   iterations: number,
@@ -36,6 +47,17 @@ function smoothEscapeValueNumber(
   return (
     iterations + 1 - Math.log(Math.log(Math.sqrt(magnitudeSquared))) / LOG_2
   );
+}
+
+function escapedResultNumber(
+  iterations: number,
+  magnitudeSquared: number
+): EscapeResult {
+  return {
+    escaped: true,
+    iterations,
+    smoothIteration: smoothEscapeValueNumber(iterations, magnitudeSquared),
+  };
 }
 
 export function iterateMandelbrot(
@@ -93,14 +115,110 @@ export function iterateMandelbrotNumber(
     magnitudeSquared = zx * zx + zy * zy;
 
     if (magnitudeSquared > ESCAPE_RADIUS_SQUARED_NUMBER) {
+      return escapedResultNumber(iteration + 1, magnitudeSquared);
+    }
+  }
+
+  return {
+    escaped: false,
+    iterations: maxIterations,
+    smoothIteration: maxIterations,
+  };
+}
+
+export function createPerturbationReferenceOrbit(
+  cx: Decimal,
+  cy: Decimal,
+  maxIterations: number
+): PerturbationReferenceOrbit {
+  let zx = new Decimal(0);
+  let zy = new Decimal(0);
+  const points: PerturbationOrbitPoint[] = [{ real: 0, imaginary: 0 }];
+
+  for (let iteration = 0; iteration < maxIterations; iteration += 1) {
+    const zxSquared = zx.mul(zx);
+    const zySquared = zy.mul(zy);
+    const nextZy = zx.mul(zy).mul(2).add(cy);
+    const nextZx = zxSquared.sub(zySquared).add(cx);
+    const real = nextZx.toNumber();
+    const imaginary = nextZy.toNumber();
+
+    if (!Number.isFinite(real) || !Number.isFinite(imaginary)) {
       return {
-        escaped: true,
-        iterations: iteration + 1,
-        smoothIteration: smoothEscapeValueNumber(
-          iteration + 1,
-          magnitudeSquared
-        ),
+        points,
+        usable: false,
       };
+    }
+
+    zx = nextZx;
+    zy = nextZy;
+    points.push({ real, imaginary });
+
+    const magnitudeSquared = zx.mul(zx).add(zy.mul(zy));
+
+    if (magnitudeSquared.gt(ESCAPE_RADIUS_SQUARED)) {
+      return {
+        points,
+        usable: true,
+      };
+    }
+  }
+
+  return {
+    points,
+    usable: true,
+  };
+}
+
+export function iterateMandelbrotPerturbation(
+  deltaCx: number,
+  deltaCy: number,
+  referenceOrbit: PerturbationReferenceOrbit,
+  maxIterations: number
+): EscapeResult {
+  if (!referenceOrbit.usable || referenceOrbit.points.length < 2) {
+    return {
+      escaped: false,
+      iterations: maxIterations,
+      smoothIteration: maxIterations,
+    };
+  }
+
+  let deltaZx = 0;
+  let deltaZy = 0;
+  const iterationLimit = Math.min(
+    maxIterations,
+    referenceOrbit.points.length - 1
+  );
+
+  for (let iteration = 0; iteration < iterationLimit; iteration += 1) {
+    const referenceZ = referenceOrbit.points[iteration];
+    const referenceNextZ = referenceOrbit.points[iteration + 1];
+    const deltaZxSquared = deltaZx * deltaZx;
+    const deltaZySquared = deltaZy * deltaZy;
+    const nextDeltaZx =
+      2 * (referenceZ.real * deltaZx - referenceZ.imaginary * deltaZy) +
+      deltaZxSquared -
+      deltaZySquared +
+      deltaCx;
+    const nextDeltaZy =
+      2 * (referenceZ.real * deltaZy + referenceZ.imaginary * deltaZx) +
+      2 * deltaZx * deltaZy +
+      deltaCy;
+
+    deltaZx = nextDeltaZx;
+    deltaZy = nextDeltaZy;
+
+    const zx = referenceNextZ.real + deltaZx;
+    const zy = referenceNextZ.imaginary + deltaZy;
+    const magnitudeSquared = zx * zx + zy * zy;
+
+    if (!Number.isFinite(magnitudeSquared)) {
+      return escapedResultNumber(iteration + 1, Number.MAX_VALUE);
+    }
+
+    if (magnitudeSquared > ESCAPE_RADIUS_SQUARED_NUMBER) {
+      return escapedResultNumber(iteration + 1, magnitudeSquared);
     }
   }
 
@@ -113,4 +231,11 @@ export function iterateMandelbrotNumber(
 
 export function shouldUseNumberIteration(width: Decimal): boolean {
   return width.greaterThanOrEqualTo(NUMBER_RENDER_WIDTH_THRESHOLD);
+}
+
+export function shouldUsePerturbationIteration(width: Decimal): boolean {
+  return (
+    width.lessThan(NUMBER_RENDER_WIDTH_THRESHOLD) &&
+    width.greaterThanOrEqualTo(PERTURBATION_RENDER_WIDTH_FLOOR)
+  );
 }

--- a/src/features/mandelbrot/renderPlan.ts
+++ b/src/features/mandelbrot/renderPlan.ts
@@ -1,4 +1,7 @@
-import { shouldUseNumberIteration } from "@/features/mandelbrot/mandelbrot";
+import {
+  shouldUseNumberIteration,
+  shouldUsePerturbationIteration,
+} from "@/features/mandelbrot/mandelbrot";
 import {
   MandelbrotSettings,
   PreciseViewport,
@@ -25,6 +28,22 @@ export function createMandelbrotRenderPlan(
   viewport: PreciseViewport,
   settings: MandelbrotSettings
 ): MandelbrotRenderPlan {
+  if (shouldUsePerturbationIteration(viewport.width)) {
+    return {
+      passes: [
+        {
+          phase: "refining",
+          scale: settings.resolutionScale,
+          settings,
+          message: "Rendering perturbation deep-zoom frame...",
+        },
+      ],
+      completionMessage: `Ready at ${Math.round(
+        settings.resolutionScale * 100
+      )}% perturbation deep-zoom render (${settings.maxIterations} iterations).`,
+    };
+  }
+
   if (!shouldUseNumberIteration(viewport.width)) {
     const scale = Math.min(settings.resolutionScale, DEEP_ZOOM_PREVIEW_SCALE);
     const maxIterations = Math.min(

--- a/src/features/mandelbrot/renderer.ts
+++ b/src/features/mandelbrot/renderer.ts
@@ -4,9 +4,12 @@ import {
   renderMandelbrotWithWebGpu,
 } from "@/features/mandelbrot/gpu";
 import {
+  createPerturbationReferenceOrbit,
   iterateMandelbrot,
   iterateMandelbrotNumber,
+  iterateMandelbrotPerturbation,
   shouldUseNumberIteration,
+  shouldUsePerturbationIteration,
 } from "@/features/mandelbrot/mandelbrot";
 import { colorEscapeResult } from "@/features/mandelbrot/palettes";
 import {
@@ -71,9 +74,12 @@ async function renderMandelbrot({
   const safeWidth = Math.max(1, Math.round(size.width));
   const safeHeight = Math.max(1, Math.round(size.height));
   const useNumberIteration = shouldUseNumberIteration(viewport.width);
-  const rowsPerChunk = useNumberIteration
-    ? NUMBER_ROWS_PER_CHUNK
-    : DECIMAL_ROWS_PER_CHUNK;
+  const shouldUsePerturbation =
+    !useNumberIteration && shouldUsePerturbationIteration(viewport.width);
+  const rowsPerChunk =
+    useNumberIteration || shouldUsePerturbation
+      ? NUMBER_ROWS_PER_CHUNK
+      : DECIMAL_ROWS_PER_CHUNK;
   const left = viewport.centerX.sub(viewport.width.div(2));
   const top = viewport.centerY.add(viewport.height.div(2));
   const stepX = viewport.width.div(safeWidth);
@@ -82,6 +88,27 @@ async function renderMandelbrot({
   const topNumber = top.toNumber();
   const stepXNumber = stepX.toNumber();
   const stepYNumber = stepY.toNumber();
+  const deltaXStartNumber = viewport.width
+    .neg()
+    .div(2)
+    .add(stepX.div(2))
+    .toNumber();
+  const deltaYStartNumber = viewport.height.div(2).sub(stepY.div(2)).toNumber();
+  const usePerturbationIteration =
+    shouldUsePerturbation &&
+    Number.isFinite(deltaXStartNumber) &&
+    Number.isFinite(deltaYStartNumber) &&
+    Number.isFinite(stepXNumber) &&
+    Number.isFinite(stepYNumber) &&
+    stepXNumber > 0 &&
+    stepYNumber > 0;
+  const perturbationReferenceOrbit = usePerturbationIteration
+    ? createPerturbationReferenceOrbit(
+        viewport.centerX,
+        viewport.centerY,
+        settings.maxIterations
+      )
+    : null;
   let row = 0;
 
   while (row < safeHeight) {
@@ -104,13 +131,27 @@ async function renderMandelbrot({
           return false;
         }
 
-        const result = useNumberIteration
-          ? iterateMandelbrotNumber(
-              leftNumber + stepXNumber * (x + 0.5),
-              topNumber - stepYNumber * (y + 0.5),
-              settings.maxIterations
-            )
-          : renderDecimalPixel(viewport, size, x, y, settings.maxIterations);
+        const result =
+          usePerturbationIteration && perturbationReferenceOrbit?.usable
+            ? iterateMandelbrotPerturbation(
+                deltaXStartNumber + stepXNumber * x,
+                deltaYStartNumber - stepYNumber * y,
+                perturbationReferenceOrbit,
+                settings.maxIterations
+              )
+            : useNumberIteration
+              ? iterateMandelbrotNumber(
+                  leftNumber + stepXNumber * (x + 0.5),
+                  topNumber - stepYNumber * (y + 0.5),
+                  settings.maxIterations
+                )
+              : renderDecimalPixel(
+                  viewport,
+                  size,
+                  x,
+                  y,
+                  settings.maxIterations
+                );
         const [red, green, blue, alpha] = colorEscapeResult(
           result,
           settings.maxIterations,


### PR DESCRIPTION
## Summary
- add a perturbation renderer that uses a high-precision reference orbit plus number-space pixel deltas for practical deep zooms
- restore full selected render scale and iteration budget for perturbation-capable deep views while keeping the capped Decimal fallback below the number-delta floor
- strengthen Mandelbrot smoke coverage by asserting a visible deep structure canvas, not just readiness text

## Validation
- yarn lint
- yarn typecheck
- yarn test
- yarn build
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 yarn playwright:smoke:run playwright/tests/smoke/mandelbrot.spec.ts
- PLAYWRIGHT_BASE_URL=http://host.docker.internal:3000 yarn test:e2e
- PLAYWRIGHT_BASE_URL=http://host.docker.internal:3000 yarn test:e2e:visual

## Browser checks
- direct visible deep URL at w=1e-13 rendered full 100% / 2000-iteration perturbation structure in about 2.3s
- repeated zoom from that visible region reached 8.96e+15x without timeouts or console errors
- direct w=1e-80 rendered at 3.5e+80x in about 2.5s
- direct w=1e-300 rendered at 3.5e+300x in about 2.6s
- direct w=1e-320 used the capped 5% Decimal fallback in about 9.1s without freezing