### PR TITLE
Propagate CI to Playwright containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ x-playwright-base: &playwright-base
   init: true
   ipc: host
   environment:
+    CI: ${CI:-}
     TZ: UTC
     LANG: C.UTF-8
     HOME: /tmp/pw-home

--- a/docs/playwright-testing-design.md
+++ b/docs/playwright-testing-design.md
@@ -153,6 +153,8 @@ GitHub Actions runs Playwright through the same Compose services used locally:
 
 The post-deploy live job waits for `https://alexleung.ca/deploy-meta.json` to serve the current `GITHUB_SHA` before running `PLAYWRIGHT_BASE_URL=https://alexleung.ca` through the same Dockerized smoke service. This marker is emitted as part of `yarn build`, which prevents the live smoke suite from validating a stale Pages deployment that still returns `200` while the new revision is propagating.
 
+The Compose services pass the runner's `CI` environment value into the Playwright container, so `playwright.config.ts` applies CI-only guardrails such as `forbidOnly` and retries for transient browser failures. Local runs leave `CI` empty and keep the faster no-retry behavior.
+
 Relevant workflows:
 
 - `.github/workflows/pr-checks.yml`


### PR DESCRIPTION
## Summary
- pass the runner `CI` environment value into the Dockerized Playwright services
- document that CI-mode Playwright guardrails and retries now apply inside the containers

## Root Cause
The failing `Build and Deploy` run reached Playwright and failed the Chromium Mandelbrot deep-zoom smoke assertion without retrying. `playwright.config.ts` already enables retries and `forbidOnly` when `process.env.CI` is set, but `docker compose run` was not passing GitHub Actions' `CI=true` into the Playwright container.

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn test:e2e`
- `yarn test:e2e:visual`
- `env CI=true yarn test:e2e`
- `env CI=true yarn test:e2e:visual`