### PR TITLE
Search performance automation: Clarify About page snippet

### DIFF
--- a/playwright/tests/smoke/navigation.spec.ts
+++ b/playwright/tests/smoke/navigation.spec.ts
@@ -65,7 +65,7 @@ test("primary navigation routes render expected page headings", async ({
   await gotoAndStabilize(page, "/");
 
   const routes = [
-    { label: "About", heading: "About" },
+    { label: "About", heading: "About Alex Leung" },
     { label: "Now", heading: "What I'm Doing Now" },
     { label: "Blog", heading: "Blog" },
     { label: "Experiments", heading: "Experiments" },

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -17,7 +17,7 @@ import { PreviousWork } from "./_components/PreviousWork";
 
 const title = "About Alex Leung | Software Engineer and Writer";
 const description =
-  "Alex Leung is a software engineer and writer in San Francisco with experience across embedded systems, distributed systems, product engineering, and AI product development.";
+  "Learn about Alex Leung's software engineering work at OpenAI, Google, Cash App, and Jetson, plus writing on AI product development and software systems.";
 const path = "/about";
 
 export const metadata: Metadata = buildPageMetadata({
@@ -56,7 +56,7 @@ export default function AboutPage() {
         })}
       />
 
-      <PageShell title="About" titleId="about">
+      <PageShell title="About Alex Leung" titleId="about">
         <div className="space-y-12 md:space-y-14">
           <Journey />
           <PreviousWork />

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -17,7 +17,7 @@ import { PreviousWork } from "./_components/PreviousWork";
 
 const title = "About Alex Leung | Software Engineer and Writer";
 const description =
-  "Learn about Alex Leung's software engineering work at OpenAI, Google, Cash App, and Jetson, plus writing on AI product development and software systems.";
+  "Learn about Alex Leung's software engineering work across AI products, embedded systems, infrastructure, and customer-facing systems, plus writing on software and deep learning.";
 const path = "/about";
 
 export const metadata: Metadata = buildPageMetadata({


### PR DESCRIPTION
## Summary
- make the About page H1 explicitly say `About Alex Leung`
- replace the About metadata description with a more concrete summary of work history and writing topics
- update the navigation smoke expectation for the intentional H1 change

## Data observations
- GSC Last 28 days baseline: `/about/` had 0 clicks, 360 impressions, 0% CTR, and average position 8.22 versus 1 click, 136 impressions, 0.74% CTR, and position 8.91 in the previous 28 days.
- `/about/` query drilldown is branded/name aligned rather than mismatched: `alex leung` had 0 clicks, 57 impressions, 0% CTR, and position 9.42; `alex software engineer` had 0 clicks, 1 impression, and position 7.
- The broader branded identity experiment is directionally positive for the homepage: `alex leung` overall moved to 5 clicks, 189 impressions, 2.65% CTR, and position 8.66 from 3 clicks, 108 impressions, 2.78% CTR, and position 12.64. Homepage split for that query moved to 5 clicks, 136 impressions, 3.68% CTR, and position 6.0 from 3 clicks, 86 impressions, 3.49% CTR, and position 8.53.
- GA4 Last 28 days showed measurement recovered: 23 active users, 158 events, and 18s average engagement. The organic Search Console report showed `/about/` at 0 clicks, 350 impressions, 0% CTR, position 8.31, and 0 active users.

## Experiment
- Experiment ID: `seo-2026-07-23-about-branded-ctr`
- Hypothesis: after the sitewide branded-title change improved homepage branded visibility, a clearer About-specific H1 and snippet should make the `/about/` result more understandable for branded/name and role searches where it is already near page one but getting no clicks.
- Confidence: medium. The query/page pattern is consistent and near-page-one, but volume is still small and some query detail is anonymized.
- Expected impact: low to medium CTR lift on `/about/`; no expected impact on homepage branded traffic.
- Primary metric: GSC `/about/` clicks and CTR for branded/name-aligned queries.
- Guardrails: homepage branded clicks/CTR, `/about/` average position, GA4 organic engagement for `/about/`, and Search Console indexing/enhancement health.
- Follow-up: take an early read after 14 complete post-deploy days and a decision read after 28 complete post-deploy days. Use a 90-day backup window if `/about/` query volume remains sparse.

## Validation
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn test:e2e`
- `yarn test:e2e:visual:update`
- `yarn test:e2e:visual`